### PR TITLE
All the tables use cursor pagination

### DIFF
--- a/src/components/Entry/DomainArchitectures/index.js
+++ b/src/components/Entry/DomainArchitectures/index.js
@@ -281,6 +281,8 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
             withPageSizeSelector={true}
             actualSize={payload.count}
             pagination={search}
+            nextAPICall={payload.next}
+            previousAPICall={payload.previous}
           />
         </div>
       </div>

--- a/src/components/Entry/EntryListFilters/EntryTypeFilter.js
+++ b/src/components/Entry/EntryListFilters/EntryTypeFilter.js
@@ -68,6 +68,7 @@ class EntryTypeFilter extends PureComponent /*:: <Props> */ {
   _handleSelection = ({ target: { value } }) => {
     const { page, type, ...search } = this.props.customLocation.search;
     if (!isAll(value)) search.type = value;
+    delete search.cursor;
     this.props.goToCustomLocation({ ...this.props.customLocation, search });
   };
 
@@ -137,7 +138,7 @@ const getUrlFor = createSelector(
   state => state.customLocation.search,
   ({ protocol, hostname, port, root }, description, search) => {
     // omit from search
-    const { type, search: _, ..._search } = search;
+    const { type, search: _, cursor: __, ..._search } = search;
     // add to search
     _search.group_by = 'type';
     // build URL

--- a/src/components/Entry/EntryListFilters/GOTermsFilter.js
+++ b/src/components/Entry/EntryListFilters/GOTermsFilter.js
@@ -158,11 +158,12 @@ const getUrlFor = createSelector(
   state => state.customLocation.search,
   ({ protocol, hostname, port, root }, description, search) => {
     // omit from search
-    // eslint-disable-next-line camelcase
     const {
+      // eslint-disable-next-line camelcase
       page_size,
       search: _,
       cursor: __,
+      // eslint-disable-next-line camelcase
       go_category,
       ..._search
     } = search;

--- a/src/components/Entry/EntryListFilters/GOTermsFilter.js
+++ b/src/components/Entry/EntryListFilters/GOTermsFilter.js
@@ -52,6 +52,7 @@ class GOTermsFilter extends PureComponent /*:: <Props> */ {
     const {
       page,
       go_category: _,
+      cursor: __,
       ...search
     } = this.props.customLocation.search;
     if (value !== 'All') search.go_category = value;
@@ -158,7 +159,13 @@ const getUrlFor = createSelector(
   ({ protocol, hostname, port, root }, description, search) => {
     // omit from search
     // eslint-disable-next-line camelcase
-    const { page_size, search: _, go_category, ..._search } = search;
+    const {
+      page_size,
+      search: _,
+      cursor: __,
+      go_category,
+      ..._search
+    } = search;
     // add to search
     _search.group_by = 'go_categories';
     // build URL

--- a/src/components/Entry/EntryListFilters/IntegratedFilter.js
+++ b/src/components/Entry/EntryListFilters/IntegratedFilter.js
@@ -25,6 +25,7 @@ const f = foundationPartial(style);
   goToCustomLocation: function,
   customLocation: {
     description: Object,
+    search: Object,
   }
 }; */
 
@@ -41,6 +42,7 @@ class IntegratedFilter extends PureComponent /*:: <Props, State> */ {
     goToCustomLocation: T.func.isRequired,
     customLocation: T.shape({
       description: T.object,
+      search: T.object,
     }).isRequired,
   };
 

--- a/src/components/Entry/EntryListFilters/IntegratedFilter.js
+++ b/src/components/Entry/EntryListFilters/IntegratedFilter.js
@@ -63,13 +63,18 @@ class IntegratedFilter extends PureComponent /*:: <Props, State> */ {
 
   _handleSelection = ({ target: { value } }) => {
     this.setState({ value });
-    const { goToCustomLocation, customLocation } = this.props;
+    const {
+      goToCustomLocation,
+      customLocation: { description, search: s, ...rest },
+    } = this.props;
+    const { cursor: _, ...search } = s;
     goToCustomLocation({
-      ...customLocation,
+      ...rest,
+      search,
       description: {
-        ...customLocation.description,
+        ...description,
         entry: {
-          ...customLocation.description.entry,
+          ...description.entry,
           integration: value === 'both' ? null : value,
         },
       },
@@ -121,7 +126,7 @@ const getUrlFor = createSelector(
     } = description;
     _description.entry = entry;
     // omit from search
-    const { search: _, ..._search } = search;
+    const { search: _, cursor: __, ..._search } = search;
     // add to search
     _search.interpro_status = null;
     // build URL

--- a/src/components/Entry/EntryListFilters/SignaturesFilter.js
+++ b/src/components/Entry/EntryListFilters/SignaturesFilter.js
@@ -53,6 +53,7 @@ class SignaturesFilter extends PureComponent /*:: <Props> */ {
     const {
       page,
       signature_in: _,
+      cursor: __,
       ...search
     } = this.props.customLocation.search;
     if (value !== 'All') search.signature_in = value;
@@ -124,7 +125,13 @@ const getUrlFor = createSelector(
   ({ protocol, hostname, port, root }, description, search) => {
     // omit from search
     // eslint-disable-next-line camelcase
-    const { signature_in, search: _, page_size, ..._search } = search;
+    const {
+      signature_in,
+      search: _,
+      cursor: __,
+      page_size,
+      ..._search
+    } = search;
     // add to search
     _search.group_by = 'member_databases';
     // build URL

--- a/src/components/Entry/EntryListFilters/SignaturesFilter.js
+++ b/src/components/Entry/EntryListFilters/SignaturesFilter.js
@@ -124,11 +124,12 @@ const getUrlFor = createSelector(
   state => state.customLocation.search,
   ({ protocol, hostname, port, root }, description, search) => {
     // omit from search
-    // eslint-disable-next-line camelcase
     const {
+      // eslint-disable-next-line camelcase
       signature_in,
       search: _,
       cursor: __,
+      // eslint-disable-next-line camelcase
       page_size,
       ..._search
     } = search;

--- a/src/components/Matches/index.js
+++ b/src/components/Matches/index.js
@@ -238,6 +238,8 @@ const Matches = (
     dbCounters,
     mainData,
     accessionSearch,
+    nextAPICall,
+    previousAPICall,
     ...props
   } /*: {
     matches: Array<Object>,
@@ -292,6 +294,8 @@ const Matches = (
       withTree={primary === 'taxonomy'}
       dbCounters={dbCounters}
       rowClassName={row => f({ exact: row.exact })}
+      nextAPICall={nextAPICall}
+      previousAPICall={previousAPICall}
     >
       <PageSizeSelector />
       <SearchBox loading={isStale} />

--- a/src/components/Matches/index.js
+++ b/src/components/Matches/index.js
@@ -238,6 +238,7 @@ const Matches = (
     dbCounters,
     mainData,
     accessionSearch,
+    currentAPICall,
     nextAPICall,
     previousAPICall,
     ...props
@@ -296,6 +297,7 @@ const Matches = (
       rowClassName={row => f({ exact: row.exact })}
       nextAPICall={nextAPICall}
       previousAPICall={previousAPICall}
+      currentAPICall={currentAPICall}
     >
       <PageSizeSelector />
       <SearchBox loading={isStale} />

--- a/src/components/Protein/ProteinListFilters/CurationFilter.js
+++ b/src/components/Protein/ProteinListFilters/CurationFilter.js
@@ -43,7 +43,7 @@ class CurationFilter extends PureComponent /*:: <Props> */ {
   };
 
   _handleSelection = ({ target: { value } }) => {
-    const { page, ...search } = this.props.customLocation.search;
+    const { page, cursor, ...search } = this.props.customLocation.search;
     this.props.goToCustomLocation({
       ...this.props.customLocation,
       description: {
@@ -118,7 +118,7 @@ const getUrl = createSelector(
     }
 
     // omit from search
-    const { search: _, ..._search } = search;
+    const { search: _, cursor: __, ..._search } = search;
     // add to search
     _search.group_by = 'source_database';
     // build URL

--- a/src/components/Protein/ProteinListFilters/FragmentFilter.js
+++ b/src/components/Protein/ProteinListFilters/FragmentFilter.js
@@ -42,7 +42,7 @@ class FragmentFilter extends PureComponent /*:: <Props> */ {
   };
 
   _handleSelection = ({ target: { value } }) => {
-    const { page, ...search } = this.props.customLocation.search;
+    const { page, cursor, ...search } = this.props.customLocation.search;
     const _search = { ...search, is_fragment: value };
     if (value === 'both') {
       delete _search.is_fragment;
@@ -120,7 +120,7 @@ const getUrl = createSelector(
     }
 
     // omit from search
-    const { search: _, ..._search } = search;
+    const { search: _, cursor: __, ..._search } = search;
     if ('is_fragment' in _search) delete _search.is_fragment;
     // add to search
     _search.group_by = 'is_fragment';

--- a/src/components/Protein/ProteinListFilters/MatchPresenceFilter.js
+++ b/src/components/Protein/ProteinListFilters/MatchPresenceFilter.js
@@ -49,8 +49,14 @@ class MatchPresenceFilter extends PureComponent /*:: <Props> */ {
 
   _handleSelection = ({ target: { value } }) => {
     const { goToCustomLocation, customLocation } = this.props;
-    const { page, match_presence: _, ...search } = customLocation.search;
-    if (labels.has(value)) search.match_presence = value;
+    const {
+      page,
+      match_presence: _,
+      cursor,
+      ...search
+    } = customLocation.search;
+    if (labels.has(value) && value.toLowerCase() !== 'both')
+      search.match_presence = value;
     goToCustomLocation({ ...customLocation, search });
   };
 
@@ -106,7 +112,7 @@ const getUrl = createSelector(
       protein: { db: 'UniProt' },
     };
     // omit from search
-    const { search: _, match_presence: __, ..._search } = search;
+    const { search: _, match_presence: __, cursor, ..._search } = search;
     // add to search
     _search.group_by = 'match_presence';
     // build URL

--- a/src/components/Protein/ProteinListFilters/TaxonomyFilter.js
+++ b/src/components/Protein/ProteinListFilters/TaxonomyFilter.js
@@ -45,7 +45,7 @@ class TaxonomyFilter extends PureComponent /*:: <Props> */ {
   };
 
   _handleSelection = ({ target: { value } }) => {
-    const { page, ...search } = this.props.customLocation.search;
+    const { page, cursor, ...search } = this.props.customLocation.search;
     this.props.goToCustomLocation({
       ...this.props.customLocation,
       description: {
@@ -116,7 +116,7 @@ const getUrlFor = createSelector(
   ({ protocol, hostname, port, root }, description, search) => {
     // omit from search
     // eslint-disable-next-line camelcase
-    const { tax_id, search: _, ..._search } = search;
+    const { tax_id, search: _, cursor: __, ..._search } = search;
     // add to search
     _search.group_by = 'tax_id';
     // build URL

--- a/src/components/Protein/Sequence/index.js
+++ b/src/components/Protein/Sequence/index.js
@@ -58,9 +58,8 @@ class Inner extends PureComponent /*:: <InnerProps> */ {
           processData={schemaProcessData}
         />
         {sequenceWords.map((e, i) => (
-          <>
+          <React.Fragment key={i}>
             <span
-              key={i}
               className={f('sequence_word')}
               style={{ zIndex: -i }}
               data-index={i}
@@ -68,7 +67,7 @@ class Inner extends PureComponent /*:: <InnerProps> */ {
               {e}
             </span>
             <div className={f('sequence_word_spacer')} />
-          </>
+          </React.Fragment>
         ))}
       </div>
     );

--- a/src/components/Related/DomainStructureOnProtein/index.js
+++ b/src/components/Related/DomainStructureOnProtein/index.js
@@ -110,7 +110,11 @@ const getUrlForInterPro = createSelector(
   state => state.settings.api,
   state => state.customLocation.description,
   state => state.customLocation.search,
-  ({ protocol, hostname, port, root }, description, search) => {
+  (
+    { protocol, hostname, port, root },
+    description,
+    { cursor: _, ...search },
+  ) => {
     const _description = {
       main: { key: 'entry' },
       structure: {

--- a/src/components/Related/index.js
+++ b/src/components/Related/index.js
@@ -376,7 +376,7 @@ const RelatedAdvancedQuery = loadData({
     getUrl: getReversedUrl,
     mapStateToProps: mapStateToPropsAdvancedQuery,
   })(({ data, secondaryData, ...props }) => {
-    const { payload, loading } = data;
+    const { payload, loading, url } = data;
     if (loading) return <Loading />;
     const _secondaryData =
       payload && payload.results
@@ -404,6 +404,7 @@ const RelatedAdvancedQuery = loadData({
         actualSize={c}
         nextAPICall={payload.next}
         previousAPICall={payload.previous}
+        currentAPICall={url}
         {...props}
       />
     );

--- a/src/components/Related/index.js
+++ b/src/components/Related/index.js
@@ -402,6 +402,8 @@ const RelatedAdvancedQuery = loadData({
       <RelatedAdvanced
         secondaryData={_secondaryData}
         actualSize={c}
+        nextAPICall={payload.next}
+        previousAPICall={payload.previous}
         {...props}
       />
     );

--- a/src/components/Structure/StructureListFilters/ExperimentTypeFilter.js
+++ b/src/components/Structure/StructureListFilters/ExperimentTypeFilter.js
@@ -45,6 +45,7 @@ class ExperimentTypeFilter extends PureComponent /*:: <Props> */ {
   _handleSelection = ({ target: { value } }) => {
     const {
       page,
+      cursor,
       experiment_type: _,
       ...search
     } = this.props.customLocation.search;
@@ -106,7 +107,7 @@ const getUrlFor = createSelector(
   ({ protocol, hostname, port, root }, description, search) => {
     // omit from search
     // eslint-disable-next-line camelcase
-    const { experiment_type, search: _, ..._search } = search;
+    const { experiment_type, search: _, cursor, ..._search } = search;
     // add to search
     _search.group_by = 'experiment_type';
     // build URL

--- a/src/components/Structure/StructureListFilters/ResolutionFilter/index.js
+++ b/src/components/Structure/StructureListFilters/ResolutionFilter/index.js
@@ -75,7 +75,9 @@ export class ResolutionFilter extends PureComponent /*:: <Props, State> */ {
   _updateLocation = debounce(fromMount => {
     const { min, max } = this.state;
     const { goToCustomLocation, customLocation } = this.props;
-    const { page, resolution: _, ...search } = { ...customLocation.search };
+    const { page, cursor, resolution: _, ...search } = {
+      ...customLocation.search,
+    };
     if (fromMount && page) search.page = page;
     if (min !== MIN || max !== MAX) search.resolution = `${min}-${max}`;
     if (
@@ -87,7 +89,12 @@ export class ResolutionFilter extends PureComponent /*:: <Props, State> */ {
   }, DEBOUNCE_RATE);
 
   _handleSelection = ({ target: { value } }) => {
-    const { page, resolution: _, ...search } = this.props.customLocation.search;
+    const {
+      page,
+      cursor,
+      resolution: _,
+      ...search
+    } = this.props.customLocation.search;
     if (value !== 'All') {
       search.resolution = `${this.state.min}-${this.state.max}`;
     }

--- a/src/components/Table/Footer/index.js
+++ b/src/components/Table/Footer/index.js
@@ -27,10 +27,11 @@ const scrollToTop = () => {
 };
 /*:: type Props = {
   className?: string,
-  value?: number,
+  value?: number | string,
   noLink?: boolean,
   children?: number| string,
-  duration?: number
+  duration?: number,
+  attributeName?: string,
 }; */
 class PaginationItem extends PureComponent /*:: <Props> */ {
   static propTypes = {
@@ -234,12 +235,20 @@ const NumberedPaginationLinks = ({ pagination, actualSize }) => {
     </>
   );
 };
+NumberedPaginationLinks.propTypes = {
+  actualSize: T.number,
+  pagination: T.object.isRequired,
+};
 
 const CursorPaginationItem = ({ cursor, label }) => (
   <PaginationItem value={cursor || '_'} noLink={!cursor} attributeName="cursor">
     {label}
   </PaginationItem>
 );
+CursorPaginationItem.propTypes = {
+  cursor: T.string,
+  label: T.string,
+};
 
 const CursorPaginationLinks = ({ next, previous }) => (
   <>
@@ -247,6 +256,11 @@ const CursorPaginationLinks = ({ next, previous }) => (
     <CursorPaginationItem cursor={next} label="Next" />
   </>
 );
+CursorPaginationLinks.propTypes = {
+  next: T.string,
+  previous: T.string,
+};
+
 const Footer = (
   {
     withPageSizeSelector,
@@ -255,7 +269,7 @@ const Footer = (
     notFound,
     nextAPICall,
     previousAPICall,
-  } /*: {withPageSizeSelector: boolean, actualSize: number, pagination: Object, notFound: boolean} */,
+  } /*: {withPageSizeSelector: boolean, actualSize: number, pagination: Object, notFound: boolean, nextAPICall: string, previousAPICall: string } */,
 ) => {
   if (notFound) return null;
 
@@ -297,6 +311,8 @@ Footer.propTypes = {
   actualSize: T.number,
   pagination: T.object.isRequired,
   notFound: T.bool,
+  nextAPICall: T.string,
+  previousAPICall: T.string,
 };
 
 export default Footer;

--- a/src/components/Table/PageSizeSelector/index.js
+++ b/src/components/Table/PageSizeSelector/index.js
@@ -40,12 +40,12 @@ class PageSizeSelector extends PureComponent /*:: <Props, State> */ {
 
   _handleChange = event => {
     this.setState({ pageSize: event.target.value });
+    const { cursor, page, ...search } = this.props.customLocation.search;
     this.props.goToCustomLocation({
       ...this.props.customLocation,
       search: {
-        ...this.props.customLocation.search,
+        ...search,
         page_size: +event.target.value,
-        page: 1,
       },
     });
   };

--- a/src/components/Table/SearchBox/index.js
+++ b/src/components/Table/SearchBox/index.js
@@ -54,7 +54,7 @@ export class SearchBox extends PureComponent /*:: <Props, State> */ {
   ) => this.setState({ localSearch: search }, this.routerPush);
 
   routerPush = () => {
-    const { page, search, ...rest } = this.props.customLocation.search;
+    const { page, search, cursor, ...rest } = this.props.customLocation.search;
     if (this.state.localSearch) rest.search = this.state.localSearch;
     this.props.goToCustomLocation({
       ...this.props.customLocation,

--- a/src/components/Table/TotalNb/index.js
+++ b/src/components/Table/TotalNb/index.js
@@ -51,8 +51,10 @@ const SelectorSpoof = ({ children } /*: { children: function } */) =>
 SelectorSpoof.propTypes = {
   children: T.func.isRequired,
 };
+
 const url2page = new Map();
 
+// eslint-disable-next-line complexity
 export const TotalNb = (
   {
     className,
@@ -66,9 +68,22 @@ export const TotalNb = (
     currentAPICall,
     nextAPICall,
     previousAPICall,
-  } /*: {className?: string, data: Array<Object>, actualSize?: number, pagination: Object, notFound?: boolean, description: Object, contentType?: string, databases?: Object, dbCounters?: Object} */,
+  } /*: {
+    className?: string,
+    data: Array<Object>,
+    actualSize?: number,
+    pagination: Object,
+    notFound?: boolean,
+    description: Object,
+    contentType?: string,
+    databases?: Object,
+    dbCounters?: Object,
+    currentAPICall?: ?string,
+    nextAPICall?: ?string,
+    previousAPICall?: ?string,
+  } */,
 ) => {
-  let page =
+  const page =
     (currentAPICall && url2page.get(toCanonicalURL(currentAPICall))) ||
     parseInt(pagination.page || 1, 10);
   const pageSize = parseInt(
@@ -77,7 +92,6 @@ export const TotalNb = (
   );
 
   if (currentAPICall && !pagination.page) {
-    // url2page.set(currentAPICall, page);
     if (nextAPICall) url2page.set(toCanonicalURL(nextAPICall), page + 1);
     if (previousAPICall)
       url2page.set(toCanonicalURL(previousAPICall), page - 1);
@@ -147,6 +161,9 @@ TotalNb.propTypes = {
   contentType: T.string,
   databases: T.object,
   dbCounters: T.object,
+  currentAPICall: T.string,
+  nextAPICall: T.string,
+  previousAPICall: T.string,
 };
 
 const mapStateToProps = createSelector(

--- a/src/components/Table/TotalNb/index.js
+++ b/src/components/Table/TotalNb/index.js
@@ -15,6 +15,7 @@ import config from 'config';
 import { toPlural } from 'utils/pages';
 
 import styles from './style.css';
+import { toCanonicalURL } from 'utils/url';
 
 const s = cn.bind(styles);
 
@@ -50,6 +51,7 @@ const SelectorSpoof = ({ children } /*: { children: function } */) =>
 SelectorSpoof.propTypes = {
   children: T.func.isRequired,
 };
+const url2page = new Map();
 
 export const TotalNb = (
   {
@@ -61,13 +63,25 @@ export const TotalNb = (
     contentType,
     databases,
     dbCounters,
+    currentAPICall,
+    nextAPICall,
+    previousAPICall,
   } /*: {className?: string, data: Array<Object>, actualSize?: number, pagination: Object, notFound?: boolean, description: Object, contentType?: string, databases?: Object, dbCounters?: Object} */,
 ) => {
-  const page = parseInt(pagination.page || 1, 10);
+  let page =
+    (currentAPICall && url2page.get(toCanonicalURL(currentAPICall))) ||
+    parseInt(pagination.page || 1, 10);
   const pageSize = parseInt(
     pagination.page_size || config.pagination.pageSize,
     10,
   );
+
+  if (currentAPICall && !pagination.page) {
+    // url2page.set(currentAPICall, page);
+    if (nextAPICall) url2page.set(toCanonicalURL(nextAPICall), page + 1);
+    if (previousAPICall)
+      url2page.set(toCanonicalURL(previousAPICall), page - 1);
+  }
 
   const index = (page - 1) * pageSize + 1;
 

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -175,8 +175,6 @@ export default class Table extends PureComponent /*:: <Props> */ {
                       className={f('icon-view', 'table-view')}
                       activeClass={f('active')}
                       aria-label="view your results as a table"
-                      onMouseOver={TableView.preload}
-                      onFocus={TableView.preload}
                       data-testid="view-table-button"
                     />
                   </Tooltip>
@@ -191,8 +189,6 @@ export default class Table extends PureComponent /*:: <Props> */ {
                           activeClass={f('active')}
                           aria-disabled={card ? 'false' : 'true'}
                           aria-label="view your results in a grid"
-                          onMouseOver={GridView.preload}
-                          onFocus={GridView.preload}
                           data-testid="view-grid-button"
                         />
                       </Tooltip>
@@ -208,8 +204,6 @@ export default class Table extends PureComponent /*:: <Props> */ {
                         activeClass={f('active')}
                         aria-disabled={withTree ? 'false' : 'true'}
                         aria-label="view your results as a tree"
-                        onMouseOver={TreeView.preload}
-                        onFocus={TreeView.preload}
                         data-testid="view-tree-button"
                       />
                     </Tooltip>

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -45,6 +45,8 @@ const f = foundationPartial(ebiGlobalStyles, fonts, styles);
   withTree: boolean,
   withGrid: boolean,
   rowClassName?: any,
+  nextAPICall?: ?string,
+  previousAPICall?: ?string,
 } */
 
 const TableView = loadable({
@@ -99,6 +101,8 @@ export default class Table extends PureComponent /*:: <Props> */ {
     status: T.number,
     actualSize: T.number,
     query: T.object,
+    nextAPICall: T.string,
+    previousAPICall: T.string,
     title: T.string,
     notFound: T.bool,
     contentType: T.string,

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -118,6 +118,8 @@ export default class Table extends PureComponent /*:: <Props> */ {
       status,
       actualSize,
       query,
+      nextAPICall,
+      previousAPICall,
       title,
       notFound,
       contentType,
@@ -259,6 +261,8 @@ export default class Table extends PureComponent /*:: <Props> */ {
                 withPageSizeSelector={withPageSizeSelector}
                 actualSize={actualSize}
                 pagination={_query}
+                nextAPICall={nextAPICall}
+                previousAPICall={previousAPICall}
               />
             </div>
           </div>

--- a/src/higherOrder/loadData/dataPropTypes.js
+++ b/src/higherOrder/loadData/dataPropTypes.js
@@ -30,7 +30,7 @@ export const interProScanPropType = T.shape({
 });
 
 export const dataPropType = T.shape({
-  loading: T.bool.isRequired,
+  loading: T.bool,
   payload: T.oneOfType([
     metadataPropType,
     resultsPropType,

--- a/src/higherOrder/loadData/defaults/index.js
+++ b/src/higherOrder/loadData/defaults/index.js
@@ -84,7 +84,10 @@ export const getUrl = createSelector(
               break;
           }
         }
-        return cleanUpMultipleSlashes(
+        const cursor = _search.cursor;
+        if (cursor) _search.cursor = undefined;
+
+        const urlTmp = cleanUpMultipleSlashes(
           format({
             protocol,
             hostname,
@@ -93,6 +96,12 @@ export const getUrl = createSelector(
             query: _search,
           }),
         );
+        // Cursors can have symbols that shouldn't be escaped
+        if (cursor) {
+          const sep = urlTmp.indexOf('?') === -1 ? '?' : '&';
+          return `${urlTmp}${sep}cursor=${cursor}`;
+        }
+        return urlTmp;
       },
     ),
 );

--- a/src/higherOrder/loadData/defaults/index.js
+++ b/src/higherOrder/loadData/defaults/index.js
@@ -85,7 +85,7 @@ export const getUrl = createSelector(
           }
         }
         const cursor = _search.cursor;
-        if (cursor) _search.cursor = undefined;
+        if (cursor) delete _search.cursor;
 
         const urlTmp = cleanUpMultipleSlashes(
           format({

--- a/src/pages/About/index.js
+++ b/src/pages/About/index.js
@@ -88,11 +88,7 @@ class About extends PureComponent /*:: <{}> */ {
         />
         <div className={f('columns', 'margin-bottom-large')}>
           <ul className={f('tabs', 'menu-style')}>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={AboutInterPro.preload}
-              onFocus={AboutInterPro.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['about', 'interpro'] } }}
                 activeClass={f('is-active', 'is-active-tab')}
@@ -100,11 +96,7 @@ class About extends PureComponent /*:: <{}> */ {
                 InterPro
               </Link>
             </li>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={InterProScan.preload}
-              onFocus={InterProScan.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['about', 'interproscan'] } }}
                 activeClass={f('is-active', 'is-active-tab')}
@@ -112,11 +104,7 @@ class About extends PureComponent /*:: <{}> */ {
                 InterProScan
               </Link>
             </li>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={Consortium.preload}
-              onFocus={Consortium.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['about', 'consortium'] } }}
                 activeClass={f('is-active', 'is-active-tab')}
@@ -124,11 +112,7 @@ class About extends PureComponent /*:: <{}> */ {
                 The InterPro Consortium
               </Link>
             </li>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={Citation.preload}
-              onFocus={Citation.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['about', 'citation'] } }}
                 activeClass={f('is-active', 'is-active-tab')}
@@ -136,11 +120,7 @@ class About extends PureComponent /*:: <{}> */ {
                 How to cite
               </Link>
             </li>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={Funding.preload}
-              onFocus={Funding.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['about', 'funding'] } }}
                 activeClass={f('is-active', 'is-active-tab')}
@@ -148,11 +128,7 @@ class About extends PureComponent /*:: <{}> */ {
                 Funding
               </Link>
             </li>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={Privacy.preload}
-              onFocus={Privacy.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['about', 'privacy'] } }}
                 activeClass={f('is-active', 'is-active-tab')}

--- a/src/pages/Entry/index.js
+++ b/src/pages/Entry/index.js
@@ -492,6 +492,8 @@ class List extends PureComponent /*:: <Props> */ {
             notFound={notFound}
             withGrid={!!includeGrid}
             databases={databases}
+            nextAPICall={_payload.next}
+            previousAPICall={_payload.previous}
           >
             <Exporter>
               <ul>

--- a/src/pages/Entry/index.js
+++ b/src/pages/Entry/index.js
@@ -494,6 +494,7 @@ class List extends PureComponent /*:: <Props> */ {
             databases={databases}
             nextAPICall={_payload.next}
             previousAPICall={_payload.previous}
+            currentAPICall={data.url}
           >
             <Exporter>
               <ul>

--- a/src/pages/Help/index.js
+++ b/src/pages/Help/index.js
@@ -100,11 +100,7 @@ export default class Help extends PureComponent /*:: <{}> */ {
         />
         <div className={f('columns', 'margin-bottom-large')}>
           <ul className={f('tabs', 'menu-style')}>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={Tutorial.preload}
-              onFocus={Tutorial.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['help', 'tutorial'] } }}
                 activeClass={f('is-active', 'is-active-tab')}
@@ -112,11 +108,7 @@ export default class Help extends PureComponent /*:: <{}> */ {
                 Tutorials &amp; training
               </Link>
             </li>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={Faqs.preload}
-              onFocus={Faqs.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['help', 'faqs'] } }}
                 activeClass={f('is-active', 'is-active-tab')}
@@ -124,11 +116,7 @@ export default class Help extends PureComponent /*:: <{}> */ {
                 FAQs
               </Link>
             </li>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={Documentation.preload}
-              onFocus={Documentation.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{ description: { other: ['help', 'documentation'] } }}
                 activeClass={f('is-active', 'is-active-tab')}

--- a/src/pages/Jobs/index.js
+++ b/src/pages/Jobs/index.js
@@ -140,11 +140,7 @@ class Wrapper extends PureComponent /*:: <Props> */ {
             processData={schemaProcessDataWebPage}
           />
           <ul className={f('tabs', 'menu-style')}>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={IPScanStatus.preload}
-              onFocus={IPScanStatus.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{
                   description: {
@@ -163,11 +159,7 @@ class Wrapper extends PureComponent /*:: <Props> */ {
                 Your InterProScan searches
               </Link>
             </li>
-            <li
-              className={f('tabs-title')}
-              onMouseOver={DownloadSummary.preload}
-              onFocus={DownloadSummary.preload}
-            >
+            <li className={f('tabs-title')}>
               <Link
                 to={{
                   description: {

--- a/src/pages/Protein/index.js
+++ b/src/pages/Protein/index.js
@@ -319,6 +319,7 @@ class List extends PureComponent /*:: <ListProps> */ {
             databases={databases}
             nextAPICall={_payload.next}
             previousAPICall={_payload.previous}
+            currentAPICall={url}
           >
             <Exporter>
               <ul>

--- a/src/pages/Protein/index.js
+++ b/src/pages/Protein/index.js
@@ -315,6 +315,8 @@ class List extends PureComponent /*:: <ListProps> */ {
             query={search}
             notFound={notFound}
             databases={databases}
+            nextAPICall={_payload.next}
+            previousAPICall={_payload.previous}
           >
             <Exporter>
               <ul>

--- a/src/pages/Protein/index.js
+++ b/src/pages/Protein/index.js
@@ -282,6 +282,8 @@ class List extends PureComponent /*:: <ListProps> */ {
       _payload = {
         results: [],
         count: 0,
+        next: null,
+        previous: null,
       };
     }
     const urlHasParameter = url && url.includes('?');

--- a/src/pages/Proteome/index.js
+++ b/src/pages/Proteome/index.js
@@ -360,6 +360,7 @@ class List extends PureComponent /*:: <Props> */ {
             databases={databases}
             nextAPICall={_payload.next}
             previousAPICall={_payload.previous}
+            currentAPICall={url}
           >
             <Exporter>
               <ul>

--- a/src/pages/Proteome/index.js
+++ b/src/pages/Proteome/index.js
@@ -261,7 +261,7 @@ const ProteomeCard = (
   </>
 );
 ProteomeCard.propTypes = {
-  data: dataPropType.object,
+  data: dataPropType,
   search: T.string,
   entryDB: T.string,
 };

--- a/src/pages/Proteome/index.js
+++ b/src/pages/Proteome/index.js
@@ -323,6 +323,8 @@ class List extends PureComponent /*:: <Props> */ {
       _payload = {
         results: [],
         count: 0,
+        next: null,
+        previous: null,
       };
     }
     const urlHasParameter = url && url.includes('?');

--- a/src/pages/Proteome/index.js
+++ b/src/pages/Proteome/index.js
@@ -356,6 +356,8 @@ class List extends PureComponent /*:: <Props> */ {
             query={search}
             notFound={notFound}
             databases={databases}
+            nextAPICall={_payload.next}
+            previousAPICall={_payload.previous}
           >
             <Exporter>
               <ul>

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -54,19 +54,12 @@ const TextSearchAndResults = () => (
     <SearchResults />
   </Wrapper>
 );
-TextSearchAndResults.preload = () => {
-  SearchByText.preload();
-  SearchResults.preload();
-};
 
 const WrappedIPScanSearch = () => (
   <Wrapper topic="InterProScan">
     <IPScanSearch />
   </Wrapper>
 );
-WrappedIPScanSearch.preload = () => {
-  IPScanSearch.preload();
-};
 
 const WrappedIDASearch = () => (
   <Wrapper topic="IDA">
@@ -137,11 +130,7 @@ const Wrapper = (
       <div className={f('columns', 'margin-bottom-large')}>
         <h3>Search InterPro</h3>
         <ul className={f('tabs', 'main-style', 'margin-top-large')}>
-          <li
-            className={f('tabs-title')}
-            onMouseOver={WrappedIPScanSearch.preload}
-            onFocus={WrappedIPScanSearch.preload}
-          >
+          <li className={f('tabs-title')}>
             <Link
               to={{
                 description: {
@@ -154,11 +143,7 @@ const Wrapper = (
               by sequence
             </Link>
           </li>
-          <li
-            className={f('tabs-title')}
-            onMouseOver={TextSearchAndResults.preload}
-            onFocus={TextSearchAndResults.preload}
-          >
+          <li className={f('tabs-title')}>
             <Link
               to={{
                 description: {
@@ -175,11 +160,7 @@ const Wrapper = (
               by text
             </Link>
           </li>
-          <li
-            className={f('tabs-title')}
-            onMouseOver={WrappedIPScanSearch.preload}
-            onFocus={WrappedIPScanSearch.preload}
-          >
+          <li className={f('tabs-title')}>
             <Link
               to={{
                 description: {

--- a/src/pages/Set/index.js
+++ b/src/pages/Set/index.js
@@ -261,7 +261,7 @@ const SetCard = (
     <SummaryCounterSet
       entryDB={entryDB}
       metadata={data.metadata}
-      counters={data.extra_fields.counters}
+      counters={(data && data.extra_fields && data.extra_fields.counters) || {}}
     />
 
     <div className={f('card-footer')}>

--- a/src/pages/Set/index.js
+++ b/src/pages/Set/index.js
@@ -369,6 +369,8 @@ class List extends PureComponent /*:: <ListProps> */ {
             query={search}
             notFound={notFound}
             databases={databases}
+            nextAPICall={_payload.next}
+            previousAPICall={_payload.previous}
           >
             <Exporter>
               <ul>

--- a/src/pages/Set/index.js
+++ b/src/pages/Set/index.js
@@ -336,6 +336,8 @@ class List extends PureComponent /*:: <ListProps> */ {
       _payload = {
         results: [],
         count: 0,
+        next: null,
+        previous: null,
       };
     }
     const urlHasParameter = url && url.includes('?');

--- a/src/pages/Set/index.js
+++ b/src/pages/Set/index.js
@@ -373,6 +373,7 @@ class List extends PureComponent /*:: <ListProps> */ {
             databases={databases}
             nextAPICall={_payload.next}
             previousAPICall={_payload.previous}
+            currentAPICall={url}
           >
             <Exporter>
               <ul>

--- a/src/pages/Structure/index.js
+++ b/src/pages/Structure/index.js
@@ -465,6 +465,8 @@ const List = (
           notFound={notFound}
           withGrid={!!includeGrid}
           databases={databases}
+          nextAPICall={_payload.next}
+          previousAPICall={_payload.previous}
         >
           <Exporter>
             <ul>

--- a/src/pages/Structure/index.js
+++ b/src/pages/Structure/index.js
@@ -467,6 +467,7 @@ const List = (
           databases={databases}
           nextAPICall={_payload.next}
           previousAPICall={_payload.previous}
+          currentAPICall={url}
         >
           <Exporter>
             <ul>

--- a/src/pages/Taxonomy/index.js
+++ b/src/pages/Taxonomy/index.js
@@ -473,6 +473,8 @@ class List extends PureComponent /*:: <Props> */ {
             withTree={true}
             withGrid={true}
             databases={databases}
+            nextAPICall={_payload.next}
+            previousAPICall={_payload.previous}
           >
             <Exporter>
               <ul>

--- a/src/pages/Taxonomy/index.js
+++ b/src/pages/Taxonomy/index.js
@@ -477,6 +477,7 @@ class List extends PureComponent /*:: <Props> */ {
             databases={databases}
             nextAPICall={_payload.next}
             previousAPICall={_payload.previous}
+            currentAPICall={url}
           >
             <Exporter>
               <ul>

--- a/src/pages/Taxonomy/index.js
+++ b/src/pages/Taxonomy/index.js
@@ -409,6 +409,8 @@ class List extends PureComponent /*:: <Props> */ {
       _payload = {
         results: [],
         count: 0,
+        next: null,
+        previous: null,
       };
     }
     const results = [...(_payload.results || [])];

--- a/src/subPages/SetAlignments/index.js
+++ b/src/subPages/SetAlignments/index.js
@@ -99,6 +99,9 @@ class SetAlignmentsSubPage extends PureComponent /*:: <Props, {}> */ {
           actualSize={data.payload.count}
           dataTable={data.payload.results}
           query={search}
+          nextAPICall={data.payload.next}
+          previousAPICall={data.payload.previous}
+          currentAPICall={data.url}
         >
           <Column
             dataKey="accession"

--- a/src/subPages/SimilarProteins/index.js
+++ b/src/subPages/SimilarProteins/index.js
@@ -143,6 +143,7 @@ dataIDA: {
   loading: boolean,
   isStale: boolean,
   payload: Object,
+  url: string,
 },
 dataBase: {
   payload: Object,

--- a/src/subPages/SimilarProteins/index.js
+++ b/src/subPages/SimilarProteins/index.js
@@ -130,7 +130,7 @@ const SimilarProteins = (
         metadata: { ida_accession: ida },
       },
     },
-    dataIDA: { loading, payload, isStale },
+    dataIDA: { loading, payload, isStale, url },
     dataBase,
     search,
     state,
@@ -163,6 +163,7 @@ state: Object,
         actualSize={payload.count}
         query={search}
         isStale={isStale}
+        currentAPICall={url}
         nextAPICall={payload.next}
         previousAPICall={payload.previous}
         notFound={payload.results.length === 0}

--- a/src/subPages/SimilarProteins/index.js
+++ b/src/subPages/SimilarProteins/index.js
@@ -20,6 +20,7 @@ import File from 'components/File';
 import { format } from 'url';
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
 import loadData from 'higherOrder/loadData';
+
 import {
   IDAProtVista,
   TextIDA,
@@ -33,7 +34,8 @@ const SimilarProteinsHeaderWithData = (
   {
     accession,
     data: { payload, loading },
-  } /*: {accession: string, data: {payload: Object, loading: boolean}} */,
+    databases,
+  } /*: {accession: string, data: {payload: Object, loading: boolean}, databases:Object} */,
 ) => {
   if (loading || !payload) return <Loading />;
   const idaObj = ida2json(payload.ida);
@@ -44,7 +46,11 @@ const SimilarProteinsHeaderWithData = (
         the protein with accession <b>{accession}</b>.
       </header>
       <TextIDA accessions={idaObj.accessions} />
-      <IDAProtVista matches={idaObj.domains} length={FAKE_PROTEIN_LENGTH} />
+      <IDAProtVista
+        matches={idaObj.domains}
+        length={FAKE_PROTEIN_LENGTH}
+        databases={databases}
+      />
       <br />
     </div>
   );
@@ -52,6 +58,7 @@ const SimilarProteinsHeaderWithData = (
 SimilarProteinsHeaderWithData.propTypes = {
   accession: T.string,
   data: dataPropType,
+  databases: T.object,
 };
 
 const getUrlForIDA = createSelector(
@@ -124,6 +131,7 @@ const SimilarProteins = (
       },
     },
     dataIDA: { loading, payload, isStale },
+    dataBase,
     search,
     state,
   } /*: {
@@ -136,6 +144,9 @@ dataIDA: {
   isStale: boolean,
   payload: Object,
 },
+dataBase: {
+  payload: Object,
+},
 search: Object,
 state: Object,
 }*/,
@@ -145,12 +156,15 @@ state: Object,
     <div className={f('row', 'column')}>
       <SimilarProteinsHeader
         accession={state.customLocation.description.protein.accession}
+        databases={(dataBase.payload && dataBase.payload.databases) || {}}
       />
       <Table
         dataTable={payload.results}
         actualSize={payload.count}
         query={search}
         isStale={isStale}
+        nextAPICall={payload.next}
+        previousAPICall={payload.previous}
         notFound={payload.results.length === 0}
       >
         <PageSizeSelector />
@@ -254,6 +268,7 @@ state: Object,
 SimilarProteins.propTypes = {
   data: dataPropType.isRequired,
   dataIDA: dataPropType.isRequired,
+  dataBase: dataPropType,
   search: T.object.isRequired,
   state: T.object.isRequired,
 };

--- a/src/utils/url/index.js
+++ b/src/utils/url/index.js
@@ -1,4 +1,6 @@
 // @flow
+
+import { parse } from 'url';
 const FINAL_SLASH = /\/*$/;
 
 export const removeLastSlash = (str /*: string*/) =>
@@ -30,3 +32,12 @@ export const buildAnchorLink = (
   pathname /*: string */,
   anchor /*: string */ = '',
 ) => `${pathname}#${anchor}`;
+
+export const getCursor = url => {
+  if (!url) return null;
+  const ulrObj = parse(url);
+  for (const attr of ulrObj.query.split('&')) {
+    if (attr.toLowerCase().startsWith('cursor=')) return attr.split('=')[1];
+  }
+  return null;
+};

--- a/src/utils/url/index.js
+++ b/src/utils/url/index.js
@@ -33,7 +33,7 @@ export const buildAnchorLink = (
   anchor /*: string */ = '',
 ) => `${pathname}#${anchor}`;
 
-export const getCursor = url => {
+export const getCursor = (url /*: string */) => {
   if (!url) return null;
   const ulrObj = parse(url);
   for (const attr of ulrObj.query.split('&')) {

--- a/src/utils/url/index.js
+++ b/src/utils/url/index.js
@@ -41,3 +41,12 @@ export const getCursor = (url /*: string */) => {
   }
   return null;
 };
+
+export const toCanonicalURL = (url /*: string */) => {
+  const [path, attr] = url.split('?');
+  if (!attr) return path;
+  return `${path}?${attr
+    .split('&')
+    .sort()
+    .join('&')}`;
+};

--- a/src/utils/url/test.js
+++ b/src/utils/url/test.js
@@ -1,5 +1,5 @@
 // @flow
-import { removeLastSlash, buildLink, buildAnchorLink } from '.';
+import { removeLastSlash, buildLink, buildAnchorLink, toCanonicalURL } from '.';
 
 describe('url utils', () => {
   describe('removeLastSlash', () => {
@@ -25,6 +25,16 @@ describe('url utils', () => {
     });
   });
 
+  describe('toCanonicalURL', () => {
+    test('shold return the same URL even if the order is different', () => {
+      expect(toCanonicalURL('http://example.com?a=1&b=2&c')).toEqual(
+        toCanonicalURL('http://example.com?a=1&c&b=2'),
+      );
+      expect(toCanonicalURL('http://example.com?a=1&b=2&c')).toEqual(
+        toCanonicalURL('http://example.com?c&a=1&b=2'),
+      );
+    });
+  });
   describe('buildAnchorLink', () => {
     test('should build a valid anchor link href', () => {
       expect(buildAnchorLink('/some/url/')).toBe('/some/url/#');


### PR DESCRIPTION
With the changes in the API for cursor pagination to support proper pagination of aggregations several client changes were required:
1. the pagination in the footer only has Next and Previous buttons, the page numbers were removed.
2. the links to next, previous are based on the next, previous values in the api response, so if that's not there it will use normal pagination, like when paginating ebisearch or genome3d data
3. The range numbers in the MemberDBSelector component (e.g. 21-40 entries...) are calculated in the component, assuming the first time it got there it was on page 1... this works except in the case of sharing a link of a further page.
4. Filters in the browser reset the cursor