### PR TITLE
Reordering ida

### DIFF
--- a/src/actions/creators/index.js
+++ b/src/actions/creators/index.js
@@ -51,6 +51,10 @@ export const toggleSideNav = () => ({
   type: types.TOGGLE_SIDE_NAV,
 });
 
+export const toggleAccessionDBForIDA = () => ({
+  type: types.TOGGLE_ACCESSION_DB_FOR_IDA,
+});
+
 export const openSideNav = () => ({
   type: types.TOGGLE_SIDE_NAV,
   status: 'open',

--- a/src/actions/types/index.js
+++ b/src/actions/types/index.js
@@ -38,6 +38,7 @@ export const TOGGLE_EMBL_MAP_NAV = 'TOGGLE_EMBL_MAP_NAV';
 export const CLOSE_EVERYTHING = 'CLOSE_EVERYTHING';
 export const STUCK = 'STUCK';
 export const UNSTUCK = 'UNSTUCK';
+export const TOGGLE_ACCESSION_DB_FOR_IDA = 'TOGGLE_ACCESSION_DB_FOR_IDA';
 
 // toast messages
 export const ADD_TOAST = 'ADD_TOAST';

--- a/src/components/Entry/DomainArchitectures/IDAResults.js
+++ b/src/components/Entry/DomainArchitectures/IDAResults.js
@@ -5,6 +5,8 @@ import T from 'prop-types';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 
+import { toggleAccessionDBForIDA } from 'actions/creators';
+
 import { format } from 'url';
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
 import loadData from 'higherOrder/loadData';
@@ -17,7 +19,12 @@ const mapStateToProps = createSelector(
     state.customLocation.description[state.customLocation.description.main.key]
       .accession,
   state => state.customLocation.search,
-  (mainAccession, search) => ({ mainAccession, search }),
+  state => state.ui.idaAccessionDB,
+  (mainAccession, search, idaAccessionDB) => ({
+    mainAccession,
+    search,
+    idaAccessionDB,
+  }),
 );
 
 const getUrlForIDASearch = createSelector(
@@ -59,6 +66,7 @@ const IDAResults = (
     loadData({
       getUrl: getUrlForIDASearch,
       mapStateToProps,
+      mapDispatchToProps: { toggleAccessionDBForIDA },
     })(DomainArchitecturesWithData),
   );
   return <Results highlight={entries} />;

--- a/src/components/Entry/DomainArchitectures/__snapshots__/test.js.snap
+++ b/src/components/Entry/DomainArchitectures/__snapshots__/test.js.snap
@@ -42,7 +42,7 @@ exports[`<DomainArchitecturesWithData /> should render 1`] = `
                 aria-hidden="true"
                 className="switch-active"
               >
-                PFam
+                Pfam
               </span>
               <span
                 aria-hidden="true"

--- a/src/components/Entry/DomainArchitectures/__snapshots__/test.js.snap
+++ b/src/components/Entry/DomainArchitectures/__snapshots__/test.js.snap
@@ -7,19 +7,54 @@ exports[`<DomainArchitecturesWithData /> should render 1`] = `
   <div
     className="columns"
   >
-    <h4>
-      511
-       domain architectures found.
-      <Tooltip
-        title="Toogle between domain architectures based on Pfam and InterPro entries"
+    <React.Fragment>
+      <h4>
+        511
+         domain architectures found.
+      </h4>
+      <div
+        className="accession-selector-panel"
       >
-        <button
-          className="icon icon-common"
-          data-icon=""
-          onClick={[Function]}
-        />
-      </Tooltip>
-    </h4>
+        <Tooltip
+          title="Toogle between domain architectures based on Pfam and InterPro entries"
+        >
+          <div
+            className="switch large"
+          >
+            <input
+              checked={true}
+              className="switch-input"
+              id="accessionDB-input"
+              name="accessionDB"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <label
+              className="switch-paddle accession-selector"
+              htmlFor="accessionDB-input"
+            >
+              <span
+                className="show-for-sr"
+              >
+                Use accessions from:
+              </span>
+              <span
+                aria-hidden="true"
+                className="switch-active"
+              >
+                PFam
+              </span>
+              <span
+                aria-hidden="true"
+                className="switch-inactive"
+              >
+                InterPro
+              </span>
+            </label>
+          </div>
+        </Tooltip>
+      </div>
+    </React.Fragment>
     <div
       className="margin-bottom-large"
     >

--- a/src/components/Entry/DomainArchitectures/index.js
+++ b/src/components/Entry/DomainArchitectures/index.js
@@ -229,9 +229,6 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
     toggleAccessionDBForIDA: T.func,
   };
 
-  constructor(props) {
-    super(props);
-  }
   toggleDomainEntry = () => {
     this.props.toggleAccessionDBForIDA();
   };

--- a/src/components/Entry/DomainArchitectures/index.js
+++ b/src/components/Entry/DomainArchitectures/index.js
@@ -4,6 +4,8 @@ import T from 'prop-types';
 import { createSelector } from 'reselect';
 import { format } from 'url';
 
+import { toggleAccessionDBForIDA } from 'actions/creators';
+
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
 import Link from 'components/generic/Link';
 import Loading from 'components/SimpleCommonComponents/Loading';
@@ -212,6 +214,8 @@ export class IDAProtVista extends ProtVistaMatches {
   mainAccession: string,
   search: Object,
   highlight: Array<string>,
+  idaAccessionDB: string,
+  toggleAccessionDBForIDA: function,
 }
 */
 class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitecturesWithDataProps> */ {
@@ -221,19 +225,15 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
     search: T.object,
     dataDB: T.object.isRequired,
     highlight: T.arrayOf(T.string),
+    idaAccessionDB: T.string,
+    toggleAccessionDBForIDA: T.func,
   };
 
   constructor(props) {
     super(props);
-
-    this.state = {
-      entry: 'pfam',
-    };
   }
   toggleDomainEntry = () => {
-    // TODO: change to put the value in the redux state
-    if (this.state.entry === 'pfam') this.setState({ entry: 'interpro' });
-    else this.setState({ entry: 'pfam' });
+    this.props.toggleAccessionDBForIDA();
   };
 
   render() {
@@ -243,6 +243,7 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
       search,
       dataDB,
       highlight = [],
+      idaAccessionDB,
     } = this.props;
     if (loading || dataDB.loading) return <Loading />;
 
@@ -264,7 +265,7 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
                   <div className={f('switch', 'large')}>
                     <input
                       type="checkbox"
-                      checked={this.state.entry === 'pfam'}
+                      checked={idaAccessionDB === 'pfam'}
                       className={f('switch-input')}
                       name="accessionDB"
                       id="accessionDB-input"
@@ -290,7 +291,7 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
             </>
           )}
           {(payload.results || []).map(obj => {
-            const idaObj = ida2json(obj.ida, this.state.entry);
+            const idaObj = ida2json(obj.ida, idaAccessionDB);
             return (
               <div key={obj.ida_id} className={f('margin-bottom-large')}>
                 <SchemaOrgData data={obj} processData={schemaProcessData} />
@@ -363,7 +364,12 @@ const mapStateToProps = createSelector(
     state.customLocation.description[state.customLocation.description.main.key]
       .accession,
   state => state.customLocation.search,
-  (mainAccession, search) => ({ mainAccession, search }),
+  state => state.ui.idaAccessionDB,
+  (mainAccession, search, idaAccessionDB) => ({
+    mainAccession,
+    search,
+    idaAccessionDB,
+  }),
 );
 
 export const DomainArchitecturesWithData = _DomainArchitecturesWithData;
@@ -374,5 +380,6 @@ export default loadData({
   loadData({
     getUrl: getUrlFor,
     mapStateToProps,
+    mapDispatchToProps: { toggleAccessionDBForIDA },
   })(DomainArchitecturesWithData),
 );

--- a/src/components/Entry/DomainArchitectures/index.js
+++ b/src/components/Entry/DomainArchitectures/index.js
@@ -138,12 +138,6 @@ export class IDAProtVista extends ProtVistaMatches {
         {
           name: domain.accession,
           source_database: sourceDatabase,
-          // color: !isIPR
-          //   ? getTrackColor(
-          //       { accession: domain.accession },
-          //       EntryColorMode.ACCESSION,
-          //     )
-          //   : '#888888',
           color: getTrackColor(
             { accession: domain.accession },
             EntryColorMode.ACCESSION,
@@ -237,6 +231,7 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
     };
   }
   toggleDomainEntry = () => {
+    // TODO: change to put the value in the redux state
     if (this.state.entry === 'pfam') this.setState({ entry: 'interpro' });
     else this.setState({ entry: 'pfam' });
   };
@@ -262,24 +257,37 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
               There are no Domain architectures for the current selection.
             </div>
           ) : (
-            <h4>
-              {payload.count} domain architectures found.
-              <Tooltip title="Toogle between domain architectures based on Pfam and InterPro entries">
-                {this.state.entry === 'pfam' ? (
-                  <button
-                    className={f('icon', 'icon-common')}
-                    data-icon="&#xf204;"
-                    onClick={this.toggleDomainEntry}
-                  />
-                ) : (
-                  <button
-                    className={f('icon', 'icon-common')}
-                    data-icon="&#xf205;"
-                    onClick={this.toggleDomainEntry}
-                  />
-                )}
-              </Tooltip>
-            </h4>
+            <>
+              <h4>{payload.count} domain architectures found.</h4>
+              <div className={f('accession-selector-panel')}>
+                <Tooltip title="Toogle between domain architectures based on Pfam and InterPro entries">
+                  <div className={f('switch', 'large')}>
+                    <input
+                      type="checkbox"
+                      checked={this.state.entry === 'pfam'}
+                      className={f('switch-input')}
+                      name="accessionDB"
+                      id="accessionDB-input"
+                      onChange={this.toggleDomainEntry}
+                    />
+                    <label
+                      className={f('switch-paddle', 'accession-selector')}
+                      htmlFor="accessionDB-input"
+                    >
+                      <span className={f('show-for-sr')}>
+                        Use accessions from:
+                      </span>
+                      <span className={f('switch-active')} aria-hidden="true">
+                        PFam
+                      </span>
+                      <span className={f('switch-inactive')} aria-hidden="true">
+                        InterPro
+                      </span>
+                    </label>
+                  </div>
+                </Tooltip>
+              </div>
+            </>
           )}
           {(payload.results || []).map(obj => {
             const idaObj = ida2json(obj.ida, this.state.entry);

--- a/src/components/Entry/DomainArchitectures/index.js
+++ b/src/components/Entry/DomainArchitectures/index.js
@@ -279,7 +279,7 @@ class _DomainArchitecturesWithData extends PureComponent /*:: <DomainArchitectur
                         Use accessions from:
                       </span>
                       <span className={f('switch-active')} aria-hidden="true">
-                        PFam
+                        Pfam
                       </span>
                       <span className={f('switch-inactive')} aria-hidden="true">
                         InterPro

--- a/src/components/Entry/DomainArchitectures/style.css
+++ b/src/components/Entry/DomainArchitectures/style.css
@@ -25,3 +25,17 @@
 .highlight svg {
   filter: drop-shadow(0 0 4px yellow);
 }
+
+.accession-selector-panel {
+  display: flex;
+  align-items: end;
+  justify-content: flex-end;
+
+  & .switch label.switch-paddle.accession-selector {
+    width: 8em;
+  }
+
+  & .switch input:checked ~ label.switch-paddle.accession-selector::after {
+    left: 5.75rem;
+  }
+}

--- a/src/components/Entry/DomainArchitectures/test.js
+++ b/src/components/Entry/DomainArchitectures/test.js
@@ -49,6 +49,7 @@ describe('<DomainArchitecturesWithData />', () => {
         }}
         mainAccession={'IPR000001'}
         search={{}}
+        idaAccessionDB="pfam"
       />,
     );
     expect(renderer.getRenderOutput()).toMatchSnapshot();

--- a/src/components/SearchByIDA/IdaEntry.js
+++ b/src/components/SearchByIDA/IdaEntry.js
@@ -64,7 +64,12 @@ class IdaEntry extends PureComponent /*:: <Props, State> */ {
   };
   state = {
     options: {},
+    draggable: false,
   };
+  constructor(props) {
+    super(props);
+    this.container = React.createRef();
+  }
   componentDidMount() {
     if (this.props.entry) this._handleOnChange(null, this.props.entry);
   }
@@ -91,16 +96,50 @@ class IdaEntry extends PureComponent /*:: <Props, State> */ {
     }
     this.setState({ options });
   };
+  _handleStartDragging = event => {
+    this.currentWidth = this.container.current.offsetWidth;
+    this.startPos = event.pageX;
+  };
+  _handleEndDragging = event => {
+    // if (this.startPos -event.pageX > this.currentWidth/2){
 
+    // }
+    //   console.log("move -1");
+    // if (event.pageX - this.startPos > this.currentWidth){
+    let delta = Math.floor((event.pageX - this.startPos) / this.currentWidth);
+    if (delta < 0) delta++;
+    this.props.handleMoveMarker('', 0);
+    console.log(`move ${delta}`);
+    // }
+    this.currentWidth = null;
+    this.startPos = null;
+  };
+  _handleDragging = event => {
+    let delta = Math.floor((event.pageX - this.startPos) / this.currentWidth);
+    if (delta < 0) delta++;
+    this.props.handleMoveMarker(this.props.entry, delta);
+    // if (this.startPos -event.pageX > this.currentWidth/2)
+    //   console.log("move -1");
+    // if (this.startPos -event.pageX > this.currentWidth/2)
+    //   console.log("move +1");
+  };
   render() {
     const {
       entry,
       changeEntryHandler,
       removeEntryHandler,
       position,
+      draggable = false,
     } = this.props;
     return (
-      <div className={f('ida-entry')}>
+      <div
+        className={f('ida-entry')}
+        draggable={this.state.draggable}
+        onDragStart={this._handleStartDragging}
+        onDragEnd={this._handleEndDragging}
+        onDragCapture={this._handleDragging}
+        ref={this.container}
+      >
         <Autocomplete
           inputProps={{ id: 'entries-autocomplete' }}
           getItemValue={item => item.accession}
@@ -141,8 +180,18 @@ class IdaEntry extends PureComponent /*:: <Props, State> */ {
             </>
           )}
         />
-
-        <button onClick={removeEntryHandler}>✖</button>
+        {draggable && (
+          <button
+            className={f('drag', { nodata: !this?.state?.options[entry] })}
+            onMouseEnter={() => this.setState({ draggable: true })}
+            onMouseLeave={() => this.setState({ draggable: false })}
+          >
+            |||
+          </button>
+        )}
+        <button className={f('close')} onClick={removeEntryHandler}>
+          ✖
+        </button>
       </div>
     );
   }

--- a/src/components/SearchByIDA/IdaEntry.js
+++ b/src/components/SearchByIDA/IdaEntry.js
@@ -96,32 +96,27 @@ class IdaEntry extends PureComponent /*:: <Props, State> */ {
     }
     this.setState({ options });
   };
+  _getDeltaFromDragging = event => {
+    let delta = Math.floor((event.pageX - this.startPos) / this.currentWidth);
+    if (delta <= 0) delta++;
+    return delta;
+  };
   _handleStartDragging = event => {
     this.currentWidth = this.container.current.offsetWidth;
     this.startPos = event.pageX;
   };
+  _handleDragging = event => {
+    this.props.handleMoveMarker(this._getDeltaFromDragging(event));
+  };
   _handleEndDragging = event => {
-    // if (this.startPos -event.pageX > this.currentWidth/2){
-
-    // }
-    //   console.log("move -1");
-    // if (event.pageX - this.startPos > this.currentWidth){
-    let delta = Math.floor((event.pageX - this.startPos) / this.currentWidth);
-    if (delta < 0) delta++;
-    this.props.handleMoveMarker('', 0);
-    console.log(`move ${delta}`);
-    // }
+    let delta = this._getDeltaFromDragging(event);
+    this.props.handleMoveMarker(null);
+    if (delta > 0) delta--;
+    if (delta !== 0) {
+      this.props.handleMoveEntry(delta);
+    }
     this.currentWidth = null;
     this.startPos = null;
-  };
-  _handleDragging = event => {
-    let delta = Math.floor((event.pageX - this.startPos) / this.currentWidth);
-    if (delta < 0) delta++;
-    this.props.handleMoveMarker(this.props.entry, delta);
-    // if (this.startPos -event.pageX > this.currentWidth/2)
-    //   console.log("move -1");
-    // if (this.startPos -event.pageX > this.currentWidth/2)
-    //   console.log("move +1");
   };
   render() {
     const {

--- a/src/components/SearchByIDA/IdaEntry.js
+++ b/src/components/SearchByIDA/IdaEntry.js
@@ -38,8 +38,11 @@ const getUrlForAutocomplete = (
 /*:: type Props = {
   entry: string,
   position: number,
+  draggable: boolean,
   changeEntryHandler: function,
   removeEntryHandler: function,
+  handleMoveMarker: function,
+  handleMoveEntry: function,
   api: {
     protocol: string,
     hostname: string,
@@ -49,27 +52,36 @@ const getUrlForAutocomplete = (
 }; */
 /*:: type State = {
   options: {},
+  draggable: boolean,
 }; */
 /*:: type DataType = {
   ok: bool,
   payload: Object,
 }; */
 class IdaEntry extends PureComponent /*:: <Props, State> */ {
+  /*:: container: { current: null | React$ElementRef<'div'> }; */
+  /*:: startPos: number; */
+  /*:: currentWidth: number; */
   static propTypes = {
     entry: T.string,
     changeEntryHandler: T.func,
     removeEntryHandler: T.func,
+    handleMoveMarker: T.func,
+    handleMoveEntry: T.func,
     api: T.object,
     position: T.number,
-  };
-  state = {
-    options: {},
-    draggable: false,
+    draggable: T.bool,
   };
   constructor(props) {
     super(props);
     this.container = React.createRef();
+    this.startPos = 0;
+    this.currentWidth = 1;
   }
+  state = {
+    options: {},
+    draggable: false,
+  };
   componentDidMount() {
     if (this.props.entry) this._handleOnChange(null, this.props.entry);
   }
@@ -97,12 +109,14 @@ class IdaEntry extends PureComponent /*:: <Props, State> */ {
     this.setState({ options });
   };
   _getDeltaFromDragging = event => {
-    let delta = Math.floor((event.pageX - this.startPos) / this.currentWidth);
+    let delta = Math.floor(
+      (event.pageX - (this.startPos || 0)) / this.currentWidth,
+    );
     if (delta <= 0) delta++;
     return delta;
   };
   _handleStartDragging = event => {
-    this.currentWidth = this.container.current.offsetWidth;
+    this.currentWidth = this.container?.current?.offsetWidth || 1;
     this.startPos = event.pageX;
   };
   _handleDragging = event => {
@@ -115,8 +129,8 @@ class IdaEntry extends PureComponent /*:: <Props, State> */ {
     if (delta !== 0) {
       this.props.handleMoveEntry(delta);
     }
-    this.currentWidth = null;
-    this.startPos = null;
+    this.currentWidth = 1;
+    this.startPos = 0;
   };
   render() {
     const {

--- a/src/components/SearchByIDA/IdaEntry.js
+++ b/src/components/SearchByIDA/IdaEntry.js
@@ -10,6 +10,8 @@ import getFetch from 'higherOrder/loadData/getFetch';
 import { format } from 'url';
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
 
+import { getTrackColor, EntryColorMode } from 'utils/entry-color';
+
 import { foundationPartial } from 'styles/foundation';
 import local from './style.css';
 
@@ -136,6 +138,14 @@ class IdaEntry extends PureComponent /*:: <Props, State> */ {
       draggable = false,
       options = {},
     } = this.props;
+    const style = options[this.props.entry]
+      ? {
+          background: getTrackColor(
+            { accession: this.props.entry, source_database: '' },
+            EntryColorMode.ACCESSION,
+          ),
+        }
+      : {};
     return (
       <div
         className={f('ida-entry')}
@@ -144,6 +154,7 @@ class IdaEntry extends PureComponent /*:: <Props, State> */ {
         onDragEnd={this._handleEndDragging}
         onDragCapture={this._handleDragging}
         ref={this.container}
+        style={style}
       >
         <Autocomplete
           inputProps={{ id: 'entries-autocomplete' }}

--- a/src/components/SearchByIDA/__snapshots__/test.js.snap
+++ b/src/components/SearchByIDA/__snapshots__/test.js.snap
@@ -37,6 +37,8 @@ exports[`<SearchByIDA /> should render 1`] = `
               isOrdered={false}
               markerAfterEntry={null}
               markerBeforeEntry={null}
+              mergeResults={[Function]}
+              options={Object {}}
               removeEntryHandler={[Function]}
               removeIgnoreHandler={[Function]}
             />

--- a/src/components/SearchByIDA/__snapshots__/test.js.snap
+++ b/src/components/SearchByIDA/__snapshots__/test.js.snap
@@ -35,6 +35,7 @@ exports[`<SearchByIDA /> should render 1`] = `
               handleMoveMarker={[Function]}
               ignoreList={Array []}
               isOrdered={false}
+              markerAfterEntry={null}
               markerBeforeEntry={null}
               removeEntryHandler={[Function]}
               removeIgnoreHandler={[Function]}

--- a/src/components/SearchByIDA/__snapshots__/test.js.snap
+++ b/src/components/SearchByIDA/__snapshots__/test.js.snap
@@ -31,8 +31,11 @@ exports[`<SearchByIDA /> should render 1`] = `
               changeEntryHandler={[Function]}
               changeIgnoreHandler={[Function]}
               entryList={Array []}
+              handleMoveEntry={[Function]}
+              handleMoveMarker={[Function]}
               ignoreList={Array []}
               isOrdered={false}
+              markerBeforeEntry={null}
               removeEntryHandler={[Function]}
               removeIgnoreHandler={[Function]}
             />

--- a/src/components/SearchByIDA/__snapshots__/test.js.snap
+++ b/src/components/SearchByIDA/__snapshots__/test.js.snap
@@ -74,18 +74,40 @@ exports[`<SearchByIDA /> should render 1`] = `
                 Add Domain to exclude
               </span>
             </button>
-            <label
-              htmlFor="ordered"
+            <div
+              className="switch tiny"
             >
-              <input
-                checked={false}
-                id="ordered"
-                onChange={[Function]}
-                type="checkbox"
-              />
-               
-              Order sensitivity
-            </label>
+              <label
+                htmlFor="ordered"
+              >
+                <input
+                  checked={false}
+                  className="switch-input"
+                  id="ordered"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                 
+                Order of domain matters:
+                 
+                <span
+                  className="switch-paddle"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="switch-active"
+                  >
+                    Yes
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    className="switch-inactive"
+                  >
+                    No
+                  </span>
+                </span>
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/SearchByIDA/index.js
+++ b/src/components/SearchByIDA/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Fragment } from 'react';
 import T from 'prop-types';
 
 import { connect } from 'react-redux';
@@ -30,6 +30,7 @@ const PanelIDA = (
     changeIgnoreHandler,
     removeIgnoreHandler,
     markerBeforeEntry = null,
+    markerAfterEntry = null,
     handleMoveMarker,
     handleMoveEntry,
   } /*: {
@@ -41,6 +42,7 @@ const PanelIDA = (
   changeIgnoreHandler: function,
   removeIgnoreHandler: function,
   markerBeforeEntry: ?string,
+  markerAfterEntry: ?string,
   handleMoveMarker: function,
   handleMoveEntry: function,
   } */,
@@ -52,9 +54,9 @@ const PanelIDA = (
         <ul className={f('ida-list', { ordered: isOrdered })}>
           {entryList &&
             entryList.map((e, i) => (
-              <>
+              <Fragment key={i}>
                 {markerBeforeEntry === e && <div>|</div>}
-                <li key={i}>
+                <li>
                   <IdaEntry
                     position={i}
                     entry={e}
@@ -66,7 +68,8 @@ const PanelIDA = (
                     changeEntryHandler={name => changeEntryHandler(i, name)}
                   />
                 </li>
-              </>
+                {markerAfterEntry === e && <div>|</div>}
+              </Fragment>
             ))}
         </ul>
       </div>
@@ -100,6 +103,7 @@ PanelIDA.propTypes = {
   changeIgnoreHandler: T.func,
   goToCustomLocation: T.func,
   markerBeforeEntry: T.string,
+  markerAfterEntry: T.string,
   handleMoveMarker: T.func,
   handleMoveEntry: T.func,
 };
@@ -110,6 +114,7 @@ PanelIDA.propTypes = {
 }; */
 /*:: type State = {
   markerBeforeEntry: ?string,
+  markerAfterEntry: ?string,
 }; */
 
 /*:: type SearchProps = {
@@ -127,6 +132,7 @@ export class SearchByIDA extends PureComponent /*:: <Props, State> */ {
   };
   state = {
     markerBeforeEntry: null,
+    markerAfterEntry: null,
   };
   _handleSubmit = ({ entries, order, ignore }) => {
     const search /*: SearchProps */ = {
@@ -146,11 +152,21 @@ export class SearchByIDA extends PureComponent /*:: <Props, State> */ {
   };
   _handleMoveMarker = entries => pos => delta => {
     if (delta === null) {
-      this.setState({ markerBeforeEntry: null });
+      this.setState({ markerBeforeEntry: null, markerAfterEntry: null });
       return;
     }
-    const newPos = Math.max(0, Math.min(entries.length - 1, pos + delta));
-    this.setState({ markerBeforeEntry: entries[newPos] });
+    const newPos = Math.max(0, Math.min(entries.length, pos + delta));
+    if (newPos === entries.length) {
+      this.setState({
+        markerBeforeEntry: null,
+        markerAfterEntry: entries[newPos - 1],
+      });
+    } else {
+      this.setState({
+        markerBeforeEntry: entries[newPos],
+        markerAfterEntry: null,
+      });
+    }
   };
   _handleMoveEntry = (currentEntries, ignore) => pos => delta => {
     const newPos = Math.max(
@@ -207,6 +223,7 @@ export class SearchByIDA extends PureComponent /*:: <Props, State> */ {
                     ignoreList={ignore}
                     isOrdered={order}
                     markerBeforeEntry={this.state.markerBeforeEntry}
+                    markerAfterEntry={this.state.markerAfterEntry}
                     handleMoveMarker={this._handleMoveMarker(entries)}
                     handleMoveEntry={this._handleMoveEntry(entries, ignore)}
                     removeEntryHandler={n =>

--- a/src/components/SearchByIDA/index.js
+++ b/src/components/SearchByIDA/index.js
@@ -92,6 +92,8 @@ const PanelIDA = (
                 active={true}
                 removeEntryHandler={() => removeIgnoreHandler(i)}
                 changeEntryHandler={name => changeIgnoreHandler(i, name)}
+                mergeResults={mergeResults}
+                options={options}
               />
             </li>
           ))}

--- a/src/components/SearchByIDA/index.js
+++ b/src/components/SearchByIDA/index.js
@@ -39,7 +39,10 @@ const PanelIDA = (
   removeEntryHandler: function,
   changeEntryHandler: function,
   changeIgnoreHandler: function,
-  removeIgnoreHandler: function
+  removeIgnoreHandler: function,
+  markerBeforeEntry: ?string,
+  handleMoveMarker: function,
+  handleMoveEntry: function,
   } */,
 ) => (
   <div className={f('panels')}>
@@ -96,11 +99,17 @@ PanelIDA.propTypes = {
   changeEntryHandler: T.func,
   changeIgnoreHandler: T.func,
   goToCustomLocation: T.func,
+  markerBeforeEntry: T.string,
+  handleMoveMarker: T.func,
+  handleMoveEntry: T.func,
 };
 
 /*:: type Props = {
   customLocation: CustomLocation,
   goToCustomLocation: goToCustomLocation,
+}; */
+/*:: type State = {
+  markerBeforeEntry: ?string,
 }; */
 
 /*:: type SearchProps = {
@@ -108,7 +117,7 @@ PanelIDA.propTypes = {
   ida_ignore?: string,
   ordered?: boolean,
 }; */
-export class SearchByIDA extends PureComponent /*:: <Props> */ {
+export class SearchByIDA extends PureComponent /*:: <Props, State> */ {
   static propTypes = {
     customLocation: T.shape({
       description: T.object.isRequired,

--- a/src/components/SearchByIDA/index.js
+++ b/src/components/SearchByIDA/index.js
@@ -81,7 +81,9 @@ const PanelIDA = (
       </div>
     </div>
     <div className={f('ida-ignore')}>
-      <header>Architectures must exclude</header>
+      <header>
+        Architectures must <u>not</u> include
+      </header>
       <ul className={f('ida-list', 'ignore')}>
         {ignoreList &&
           ignoreList.map((e, i) => (
@@ -313,21 +315,35 @@ export class SearchByIDA extends PureComponent /*:: <Props, State> */ {
                     <DomainButton label="✖️️" fill="#bf4540" stroke="#bf4540" />{' '}
                     <span>Add Domain to exclude</span>
                   </button>
-                  <label htmlFor="ordered">
-                    <input
-                      type="checkbox"
-                      id="ordered"
-                      checked={order}
-                      onChange={event =>
-                        this._handleSubmit({
-                          order: event.target.checked,
-                          entries,
-                          ignore,
-                        })
-                      }
-                    />{' '}
-                    Order sensitivity
-                  </label>
+                  <div className={f('switch', 'tiny')}>
+                    <label htmlFor="ordered">
+                      <input
+                        className={f('switch-input')}
+                        type="checkbox"
+                        id="ordered"
+                        checked={order}
+                        onChange={event =>
+                          this._handleSubmit({
+                            order: event.target.checked,
+                            entries,
+                            ignore,
+                          })
+                        }
+                      />{' '}
+                      Order of domain matters:{' '}
+                      <span className={f('switch-paddle')}>
+                        <span className={f('switch-active')} aria-hidden="true">
+                          Yes
+                        </span>
+                        <span
+                          className={f('switch-inactive')}
+                          aria-hidden="true"
+                        >
+                          No
+                        </span>
+                      </span>
+                    </label>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/SearchByIDA/index.js
+++ b/src/components/SearchByIDA/index.js
@@ -29,6 +29,8 @@ const PanelIDA = (
     changeEntryHandler,
     changeIgnoreHandler,
     removeIgnoreHandler,
+    mergeResults,
+    options,
     markerBeforeEntry = null,
     markerAfterEntry = null,
     handleMoveMarker,
@@ -41,6 +43,8 @@ const PanelIDA = (
   changeEntryHandler: function,
   changeIgnoreHandler: function,
   removeIgnoreHandler: function,
+  mergeResults: function,
+  options: {},
   markerBeforeEntry: ?string,
   markerAfterEntry: ?string,
   handleMoveMarker: function,
@@ -66,6 +70,8 @@ const PanelIDA = (
                     handleMoveEntry={handleMoveEntry(i)}
                     removeEntryHandler={() => removeEntryHandler(i)}
                     changeEntryHandler={name => changeEntryHandler(i, name)}
+                    mergeResults={mergeResults}
+                    options={options}
                   />
                 </li>
                 {markerAfterEntry === e && <div>|</div>}
@@ -115,6 +121,7 @@ PanelIDA.propTypes = {
 /*:: type State = {
   markerBeforeEntry: ?string,
   markerAfterEntry: ?string,
+  options: {},
 }; */
 
 /*:: type SearchProps = {
@@ -133,6 +140,7 @@ export class SearchByIDA extends PureComponent /*:: <Props, State> */ {
   state = {
     markerBeforeEntry: null,
     markerAfterEntry: null,
+    options: {},
   };
   _handleSubmit = ({ entries, order, ignore }) => {
     const search /*: SearchProps */ = {
@@ -180,6 +188,16 @@ export class SearchByIDA extends PureComponent /*:: <Props, State> */ {
 
     this._handleSubmit({ entries, order: true, ignore });
   };
+
+  _mergeResults = data => {
+    if (!data || !data.ok) return;
+    const options = { ...this.state.options };
+    for (const e of data.payload.results) {
+      options[e.metadata.accession] = e.metadata;
+    }
+    this.setState({ options });
+  };
+
   render() {
     const {
       ida_search: searchFromURL,
@@ -226,6 +244,8 @@ export class SearchByIDA extends PureComponent /*:: <Props, State> */ {
                     markerAfterEntry={this.state.markerAfterEntry}
                     handleMoveMarker={this._handleMoveMarker(entries)}
                     handleMoveEntry={this._handleMoveEntry(entries, ignore)}
+                    mergeResults={this._mergeResults}
+                    options={this.state.options}
                     removeEntryHandler={n =>
                       this._handleSubmit({
                         entries: entries

--- a/src/components/SearchByIDA/index.js
+++ b/src/components/SearchByIDA/index.js
@@ -112,6 +112,8 @@ PanelIDA.propTypes = {
   markerAfterEntry: T.string,
   handleMoveMarker: T.func,
   handleMoveEntry: T.func,
+  mergeResults: T.func,
+  options: T.object,
 };
 
 /*:: type Props = {

--- a/src/components/SearchByIDA/style.css
+++ b/src/components/SearchByIDA/style.css
@@ -94,7 +94,7 @@ ul.ordered {
   //border: black solid 2px;
   border-radius: var(--entry-padding);
 
-  @nest & button {
+  @nest & button.close {
     position: absolute;
     background: transparent;
     font-size: 0.8em;
@@ -104,8 +104,32 @@ ul.ordered {
     //border: black solid 1px;
     width: 1em;
   }
-  @nest & button:hover {
+  @nest & button.drag {
+    position: absolute;
+    background: transparent;
+    font-size: 0.8em;
+    left: 0.4em;
+    top: -0.3em;
+    width: 1em;
+  }
+  @nest & button.close:hover {
     font-weight: bold;
+  }
+  @nest & button.drag {
+    position: absolute;
+    background: transparent;
+    font-size: 0.8em;
+    left: 1.3em;
+    top: 1em;
+    color: var(--colors-ulightgray);
+    width: 1em;
+    cursor: grabbing;
+  }
+  @nest & button.nodata {
+    top: 0.5em;
+  }
+  @nest & button.drag {
+    color: var(--colors-nearly-white);
   }
   @nest & input {
     width: var(--entry-width);

--- a/src/components/SearchByIDA/style.css
+++ b/src/components/SearchByIDA/style.css
@@ -52,6 +52,12 @@
       font-size: 1.2em;
     }
   }
+  & label {
+    display: flex;
+    & > span {
+      margin-left: 1em;
+    }
+  }
 }
 
 .ida-button {
@@ -94,6 +100,10 @@ ul.ordered {
   background: #75bf40;
   //border: black solid 2px;
   border-radius: var(--entry-padding);
+
+  & > div {
+    padding-left: 0.3em;
+  }
 
   @nest & button.close {
     position: absolute;
@@ -161,5 +171,11 @@ ul.ordered {
   border-left: 0.5em solid var(--colors-very-white);
   @nest & ul.ida-list {
     justify-content: flex-start;
+  }
+}
+
+input:checked ~ .switch-paddle {
+  & .switch-active {
+    display: block;
   }
 }

--- a/src/components/SearchByIDA/style.css
+++ b/src/components/SearchByIDA/style.css
@@ -19,7 +19,7 @@
         height: 85%;
         padding: 0.2em 0 0;
         overflow: scroll;
-        max-width: calc(100vh - var(--entry-width) + var(--entry-padding) * 4);
+        max-width: calc(100vw - var(--entry-width) + var(--entry-padding) * 4);
       }
     }
     @nest & div.ida-ignore {
@@ -43,6 +43,7 @@
   min-height: 50px;
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
   & button.button.secondary {
     & * {
       vertical-align: middle;

--- a/src/reducers/ui/idaAccessionDB/index.js
+++ b/src/reducers/ui/idaAccessionDB/index.js
@@ -1,0 +1,15 @@
+import { TOGGLE_ACCESSION_DB_FOR_IDA } from 'actions/types';
+
+/*:: export type AccessionDB = string; */
+
+export default (
+  state /*: AccessionDB */ = 'pfam',
+  action /*: Object */,
+) /*: AccessionDB */ => {
+  switch (action.type) {
+    case TOGGLE_ACCESSION_DB_FOR_IDA:
+      return state === 'pfam' ? 'interpro' : 'pfam';
+    default:
+      return state;
+  }
+};

--- a/src/reducers/ui/index.js
+++ b/src/reducers/ui/index.js
@@ -4,14 +4,17 @@ import { combineReducers } from 'redux';
 import emblMapNav from './emblMapNav';
 import sideNav from './sideNav';
 import stuck from './stuck';
+import idaAccessionDB from './idaAccessionDB';
 
 /*:: import type { EMBLMapNav } from './emblMapNav'; */
 /*:: import type { SideNav } from './sideNav'; */
 /*:: import type { Stuck } from './stuck'; */
+/*:: import type { AccessionDB } from './idaAccessionDB'; */
 /*:: export type UI = {|
   emblMapNav: EMBLMapNav,
   sideNav: SideNav,
   stuck: Stuck,
+  idaAccessionDB: AccessionDB,
 |}; */
 /*:: import type { State } from 'reducers'; */
 
@@ -19,6 +22,7 @@ export default (combineReducers({
   emblMapNav,
   sideNav,
   stuck,
+  idaAccessionDB,
 }) /*: (UI | void, any) => UI */);
 
 export const uiSelector = (state /*: State */) => state.ui;


### PR DESCRIPTION
Improvements on the Search by IDA:

* The domains can be dragged to reorder them.
* A domain that matches an accession, is painted with the color of it
* Changing the display of pfam or InterPro accessions is now in the redux state
* Minor style fixes.