### PR TITLE
Retry408

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -68,6 +68,8 @@ pages:
   result:
 pagination:
   pageSize: 20
+timeout:
+  secondsToRetry: 20
 cache:
   enabled: true
 colors:

--- a/src/components/EdgeCase/index.js
+++ b/src/components/EdgeCase/index.js
@@ -63,25 +63,24 @@ const EdgeCase = ({
   return (
     <div className={f('callout', 'info', 'withicon')}>
       <b>{text}</b>
-      {shouldRedirect ||
-        (status === STATUS_TIMEOUT && (
-          <>
-            <br />
-            <span>
-              {status === STATUS_TIMEOUT
-                ? 'Checking again in '
-                : 'Redirecting to Search in '}
-              {Math.ceil((limit - count) / HERTZ)} seconds.
-            </span>
-            <ProgressButton
-              downloading={true}
-              success={true}
-              progress={count / limit}
-              failed={true}
-              showIcon={false}
-            />
-          </>
-        ))}
+      {(shouldRedirect || status === STATUS_TIMEOUT) && (
+        <>
+          <br />
+          <span>
+            {status === STATUS_TIMEOUT
+              ? 'Checking again in '
+              : 'Redirecting to Search in '}
+            {Math.ceil((limit - count) / HERTZ)} seconds.
+          </span>
+          <ProgressButton
+            downloading={true}
+            success={true}
+            progress={count / limit}
+            failed={true}
+            showIcon={false}
+          />
+        </>
+      )}
     </div>
   );
 };
@@ -89,6 +88,8 @@ EdgeCase.propTypes = {
   text: T.string.isRequired,
   accession: T.string,
   status: T.number,
+  shouldRedirect: T.bool,
+  secondsToRetry: T.number,
   goToCustomLocation: T.func.isRequired,
 };
 const mapStateToProps = createSelector(

--- a/src/components/EdgeCase/index.js
+++ b/src/components/EdgeCase/index.js
@@ -29,22 +29,29 @@ const useInterval = (callback, delay) => {
   }, [delay]);
 };
 
-const SECONDS = 3;
 const ONE_SECOND = 1000;
 const HERTZ = 10;
 
-const EdgeCase = ({ text, accession, goToCustomLocation }) => {
+export const STATUS_TIMEOUT = 408;
+
+const EdgeCase = ({
+  text,
+  status,
+  shouldRedirect = true,
+  accession,
+  secondsToRetry,
+  goToCustomLocation,
+}) => {
   const [count, setCount] = useState(0);
+  const limit = HERTZ * secondsToRetry;
 
   useInterval(() => {
     // Your custom logic here
-    setCount(count + 1);
+    setCount(count + 1 > limit ? 0 : count + 1);
   }, ONE_SECOND / HERTZ);
 
-  const limit = HERTZ * SECONDS;
-
   useEffect(() => {
-    if (count >= limit) {
+    if (shouldRedirect && status !== STATUS_TIMEOUT && count >= limit) {
       goToCustomLocation({
         description: {
           main: { key: 'search' },
@@ -56,38 +63,46 @@ const EdgeCase = ({ text, accession, goToCustomLocation }) => {
   return (
     <div className={f('callout', 'info', 'withicon')}>
       <b>{text}</b>
-      <br />
-      <span>
-        Redirecting to Search in {Math.ceil((limit - count) / HERTZ)} seconds.
-      </span>
-      <ProgressButton
-        downloading={true}
-        success={true}
-        progress={count / limit}
-        failed={true}
-        showIcon={false}
-      />
+      {shouldRedirect ||
+        (status === STATUS_TIMEOUT && (
+          <>
+            <br />
+            <span>
+              {status === STATUS_TIMEOUT
+                ? 'Checking again in '
+                : 'Redirecting to Search in '}
+              {Math.ceil((limit - count) / HERTZ)} seconds.
+            </span>
+            <ProgressButton
+              downloading={true}
+              success={true}
+              progress={count / limit}
+              failed={true}
+              showIcon={false}
+            />
+          </>
+        ))}
     </div>
   );
 };
 EdgeCase.propTypes = {
   text: T.string.isRequired,
   accession: T.string,
+  status: T.number,
   goToCustomLocation: T.func.isRequired,
 };
 const mapStateToProps = createSelector(
   state => state.customLocation.description,
-  description => {
+  state => state.settings.navigation.secondsToRetry,
+  (description, secondsToRetry) => {
     const { key } = description.main;
     return {
       accession: description[key].accession,
+      secondsToRetry,
     };
   },
 );
 
-export default connect(
-  mapStateToProps,
-  {
-    goToCustomLocation,
-  },
-)(EdgeCase);
+export default connect(mapStateToProps, {
+  goToCustomLocation,
+})(EdgeCase);

--- a/src/components/Protein/ProteinListFilters/FragmentFilter.js
+++ b/src/components/Protein/ProteinListFilters/FragmentFilter.js
@@ -61,7 +61,8 @@ class FragmentFilter extends PureComponent /*:: <Props> */ {
       data: { loading, payload },
       customLocation: { search },
     } = this.props;
-    const groupsPayload = loading || !payload ? {} : payload.is_fragment;
+    const groupsPayload =
+      loading || !payload?.is_fragment ? {} : payload.is_fragment;
     const names = new Map([
       ['true', 'Fragment'],
       ['false', 'Complete Sequence'],

--- a/src/components/Protein/ProteinListFilters/FragmentFilter.js
+++ b/src/components/Protein/ProteinListFilters/FragmentFilter.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React, { PureComponent } from 'react';
 import T from 'prop-types';
 import { createSelector } from 'reselect';

--- a/src/components/Related/DomainsOnProtein/index.js
+++ b/src/components/Related/DomainsOnProtein/index.js
@@ -448,7 +448,11 @@ export class DomainOnProteinWithoutData extends PureComponent /*:: <DPWithoutDat
 
     if (!data || data.loading) return <Loading />;
     if (!data.payload || !data.payload.results) {
-      return <div className={f('callout')}>No entries match this protein.</div>;
+      return data.payload.status === 408 ? (
+        <div className={f('callout')}>No entries match this protein.</div>
+      ) : (
+        <div className={f('callout')}>No entries match this protein.</div>
+      );
     }
 
     const { interpro, unintegrated, other } = processData({

--- a/src/components/Related/DomainsOnProtein/index.js
+++ b/src/components/Related/DomainsOnProtein/index.js
@@ -12,6 +12,8 @@ import { processData } from 'components/ProtVista/utils';
 import { formatGenome3dIntoProtVistaPanels } from 'components/Genome3D';
 
 import Loading from 'components/SimpleCommonComponents/Loading';
+import { edgeCases, STATUS_TIMEOUT } from 'utils/server-message';
+import EdgeCase from 'components/EdgeCase';
 
 import loadable from 'higherOrder/loadable';
 
@@ -448,8 +450,9 @@ export class DomainOnProteinWithoutData extends PureComponent /*:: <DPWithoutDat
 
     if (!data || data.loading) return <Loading />;
     if (!data.payload || !data.payload.results) {
-      return data.payload.status === 408 ? (
-        <div className={f('callout')}>No entries match this protein.</div>
+      const edgeCaseText = edgeCases.get(STATUS_TIMEOUT);
+      return data.payload?.detail === 'Query timed out' ? (
+        <EdgeCase text={edgeCaseText} status={STATUS_TIMEOUT} />
       ) : (
         <div className={f('callout')}>No entries match this protein.</div>
       );

--- a/src/components/Table/Body/index.js
+++ b/src/components/Table/Body/index.js
@@ -6,6 +6,8 @@ import Loading from 'components/SimpleCommonComponents/Loading';
 import Row from '../Row';
 
 import getStatusMessage from 'utils/server-message';
+import { edgeCases } from 'utils/server-message';
+import EdgeCase from 'components/EdgeCase';
 
 import { foundationPartial } from 'styles/foundation';
 
@@ -89,8 +91,20 @@ class Body extends PureComponent /*:: <BodyProps> */ {
       notFound,
       rowClassName,
     } = this.props;
-    const message = getStatusMessage(status);
-    if (message) return <NoRows>{message}</NoRows>;
+    const edgeCaseText = edgeCases.get(status);
+    if (edgeCaseText)
+      return (
+        <NoRows>
+          <EdgeCase
+            text={edgeCaseText}
+            status={status}
+            shouldRedirect={false}
+          />
+        </NoRows>
+      );
+
+    // const message = getStatusMessage(status);
+    // if (message) return <NoRows>{message}</NoRows>;
     // don't change next line to “!ok”, might be undefined
     if (ok === false) return <NoRows>The API request failed</NoRows>;
     if (notFound || !rows.length) {

--- a/src/components/Table/Body/index.js
+++ b/src/components/Table/Body/index.js
@@ -5,7 +5,6 @@ import Loading from 'components/SimpleCommonComponents/Loading';
 
 import Row from '../Row';
 
-import getStatusMessage from 'utils/server-message';
 import { edgeCases } from 'utils/server-message';
 import EdgeCase from 'components/EdgeCase';
 

--- a/src/components/Table/views/Tree/index.js
+++ b/src/components/Table/views/Tree/index.js
@@ -244,11 +244,13 @@ class TreeView extends Component /*:: <TreeViewProps, State> */ {
         this._initialLoad = false;
       }
     }
-    this.setState(({ data }) => ({
-      data: {
-        ...mergeData(data, payload.metadata, payload.names, payload.children),
-      },
-    }));
+    if (payload.metadata) {
+      this.setState(({ data }) => ({
+        data: {
+          ...mergeData(data, payload.metadata, payload.names, payload.children),
+        },
+      }));
+    }
   };
 
   _handleNewFocus = taxID => {

--- a/src/components/Taxonomy/KeySpeciesTable/index.js
+++ b/src/components/Taxonomy/KeySpeciesTable/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import loadData from 'higherOrder/loadData';
-import { STATUS_OK } from 'higherOrder/loadData/defaults';
+import { STATUS_OK } from 'utils/server-message';
 import { getReversedUrl } from 'higherOrder/loadData/defaults';
 import Loading from 'components/SimpleCommonComponents/Loading';
 import { Column } from 'components/Table';

--- a/src/higherOrder/loadData/defaults/index.js
+++ b/src/higherOrder/loadData/defaults/index.js
@@ -159,24 +159,3 @@ export const getUrlForApi = (...parameters) =>
     .replace('/sequence', '/')
     .replace('/genome3d', '/')
     .replace('/similar_proteins', '/');
-
-export const STATUS_OK = 200;
-export const STATUS_NO_CONTENT = 204;
-export const STATUS_NOT_FOUND = 404;
-export const STATUS_TIMEOUT = 408;
-export const STATUS_GONE = 410;
-export const STATUS_SERVER_ERROR = 500;
-
-export const edgeCases = new Map([
-  [STATUS_NO_CONTENT, 'There is no data associated with this accession'],
-  [STATUS_NOT_FOUND, 'This is not a valid accession'],
-  [
-    STATUS_TIMEOUT,
-    'The server takes too long to respond. Your request is running in the background. Please check again in a while for the results',
-  ],
-  [STATUS_GONE, 'The data associated with this accession has been removed'],
-  [
-    STATUS_SERVER_ERROR,
-    'The API reported an error, but the cause has not been determined',
-  ],
-]);

--- a/src/higherOrder/loadData/index.js
+++ b/src/higherOrder/loadData/index.js
@@ -13,6 +13,9 @@ import getFetch from './getFetch';
 
 import { UnconnectedErrorBoundary } from 'wrappers/ErrorBoundary';
 
+const msToRetry = 10000;
+const TIMEOUT = 408;
+
 const mapStateToState = createSelector(
   state => state,
   appState => ({ appState }),
@@ -60,6 +63,7 @@ const loadData = params => {
           url,
           data: newData(url),
           staleData: null,
+          retries: 0,
         };
       }
 
@@ -79,7 +83,10 @@ const loadData = params => {
 
       componentDidUpdate(prevProps, prevState) {
         // if the url has changed
-        if (prevState.url !== this.state.url) {
+        if (
+          prevState.url !== this.state.url ||
+          prevState.retries !== this.state.retries
+        ) {
           // cancel current request
           this._cancel();
           // and start new one
@@ -139,6 +146,14 @@ const loadData = params => {
           });
           // Progress: 1
           this.props.dataProgressInfo(this._id, 1, weight);
+
+          // Schedulling to retry because we got a 408
+          if (response.status === TIMEOUT) {
+            setTimeout(() => {
+              console.log('Retrying the Timed out query');
+              this.setState({ retries: this.state.retries + 1 });
+            }, msToRetry);
+          }
         } catch (error) {
           // If request has been canceled, it means we did it, on purpose, so
           // just ignore, otherwise it's a real error
@@ -192,10 +207,11 @@ const loadData = params => {
       }
     }
 
-    return connect(
-      mapStateToState,
-      { dataProgressInfo, dataProgressUnload, ...mapDispatchToProps },
-    )(DataWrapper);
+    return connect(mapStateToState, {
+      dataProgressInfo,
+      dataProgressUnload,
+      ...mapDispatchToProps,
+    })(DataWrapper);
   };
 };
 

--- a/src/higherOrder/loadData/index.js
+++ b/src/higherOrder/loadData/index.js
@@ -13,8 +13,8 @@ import getFetch from './getFetch';
 
 import { UnconnectedErrorBoundary } from 'wrappers/ErrorBoundary';
 
-const msToRetry = 10000;
 const TIMEOUT = 408;
+const MS = 1000;
 
 const mapStateToState = createSelector(
   state => state,
@@ -97,6 +97,9 @@ const loadData = params => {
       // cancel current request on unmount
       componentWillUnmount() {
         this._cancel();
+        if (this.timeoutID) {
+          clearTimeout(this.timeoutID);
+        }
       }
 
       _cancel = () => {
@@ -147,9 +150,11 @@ const loadData = params => {
           // Progress: 1
           this.props.dataProgressInfo(this._id, 1, weight);
 
+          const msToRetry =
+            this.props.appState.settings.navigation.secondsToRetry * MS;
           // Schedulling to retry because we got a 408
           if (response.status === TIMEOUT) {
-            setTimeout(() => {
+            this.timeoutID = setTimeout(() => {
               console.log('Retrying the Timed out query');
               this.setState({ retries: this.state.retries + 1 });
             }, msToRetry);

--- a/src/pages/Settings/index.js
+++ b/src/pages/Settings/index.js
@@ -30,6 +30,8 @@ import local from './styles.css';
 
 const f = foundationPartial(ebiGlobalStyles, fonts, theme, local);
 
+const DEFAULT_SEC = 20;
+
 // Generate async components
 const Advanced = loadable({
   loader: () =>
@@ -85,7 +87,7 @@ const NavigationSettings = (
                 min="5"
                 max="120"
                 step="5"
-                value={secondsToRetry || 20}
+                value={secondsToRetry || DEFAULT_SEC}
                 name="secondsToRetry"
                 className={local.fullwidth}
                 onChange={noop}
@@ -101,6 +103,7 @@ const NavigationSettings = (
 NavigationSettings.propTypes = {
   navigation: T.shape({
     pageSize: T.number.isRequired,
+    secondsToRetry: T.number.isRequired,
   }).isRequired,
   handleChange: T.func.isRequired,
 };

--- a/src/pages/Settings/index.js
+++ b/src/pages/Settings/index.js
@@ -40,7 +40,7 @@ const Advanced = loadable({
 
 const NavigationSettings = (
   {
-    navigation: { pageSize },
+    navigation: { pageSize, secondsToRetry },
   } /*: {navigation: {pageSize: number}, handleChange: function} */,
 ) => (
   <form data-category="navigation">
@@ -70,6 +70,28 @@ const NavigationSettings = (
               />
             </div>
             <div className={f('medium-8', 'column')}>{pageSize}</div>
+          </div>
+        </label>
+      </div>
+    </div>
+    <div className={f('row')}>
+      <div className={f('medium-12', 'column')}>
+        <label>
+          Time (sec) to retry timed out queries:
+          <div className={f('row')}>
+            <div className={f('medium-4', 'column')}>
+              <input
+                type="range"
+                min="10"
+                max="200"
+                step="10"
+                value={secondsToRetry || 20}
+                name="secondsToRetry"
+                className={local.fullwidth}
+                onChange={noop}
+              />
+            </div>
+            <div className={f('medium-8', 'column')}>{secondsToRetry}</div>
           </div>
         </label>
       </div>
@@ -540,10 +562,7 @@ class _AddToHomeScreen extends PureComponent /*:: <Props> */ {
     );
   }
 }
-const AddToHomeScreen = connect(
-  undefined,
-  { addToast },
-)(_AddToHomeScreen);
+const AddToHomeScreen = connect(undefined, { addToast })(_AddToHomeScreen);
 
 /*:: type SettingsProps = {
   settings: {
@@ -659,7 +678,6 @@ const mapStateToProps = createSelector(
   settings => ({ settings }),
 );
 
-export default connect(
-  mapStateToProps,
-  { changeSettings, resetSettings },
-)(Settings);
+export default connect(mapStateToProps, { changeSettings, resetSettings })(
+  Settings,
+);

--- a/src/pages/Settings/index.js
+++ b/src/pages/Settings/index.js
@@ -82,9 +82,9 @@ const NavigationSettings = (
             <div className={f('medium-4', 'column')}>
               <input
                 type="range"
-                min="10"
-                max="200"
-                step="10"
+                min="5"
+                max="120"
+                step="5"
                 value={secondsToRetry || 20}
                 name="secondsToRetry"
                 className={local.fullwidth}

--- a/src/pages/Taxonomy/index.js
+++ b/src/pages/Taxonomy/index.js
@@ -337,11 +337,11 @@ const TaxonomyCard = (
     <SummaryCounterOrg
       entryDB={entryDB}
       metadata={data.metadata}
-      counters={data.extra_fields.counters}
+      counters={data?.extra_fields?.counters || {}}
     />
 
     <div className={f('card-footer')}>
-      {data.extra_fields.lineage && (
+      {data?.extra_fields?.lineage && (
         <Lineage lineage={data.extra_fields.lineage} />
       )}
       <div>

--- a/src/pages/Taxonomy/index.js
+++ b/src/pages/Taxonomy/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/display-name */
+/* eslint-disable camelcase */
 // @flow
 import React, { PureComponent, useState } from 'react';
 import T from 'prop-types';

--- a/src/pages/endpoint-page.js
+++ b/src/pages/endpoint-page.js
@@ -11,7 +11,7 @@ import Switch from 'components/generic/Switch';
 import { mainDBLocationSelector } from 'reducers/custom-location/description';
 import { getUrlForApi, getUrlForMeta } from 'higherOrder/loadData/defaults';
 import loadData from 'higherOrder/loadData';
-import { edgeCases } from 'higherOrder/loadData/defaults';
+import { edgeCases } from 'utils/server-message';
 import { toPlural } from 'utils/pages';
 
 import Loading from 'components/SimpleCommonComponents/Loading';
@@ -112,7 +112,7 @@ class Summary extends PureComponent {
       },
     } = customLocation;
     const edgeCaseText = edgeCases.get(status);
-    if (edgeCaseText) return <EdgeCase text={edgeCaseText} />;
+    if (edgeCaseText) return <EdgeCase text={edgeCaseText} status={status} />;
     if (loading || (!locationhasDetailOrFilter(customLocation) && !payload)) {
       return <Loading />;
     }

--- a/src/reducers/settings/category/index.js
+++ b/src/reducers/settings/category/index.js
@@ -4,6 +4,7 @@ import config from 'config';
 import { EntryColorMode } from 'utils/entry-color';
 
 const DEFAULT_HTTP_PORT = 80;
+const DEFAULT_SECONDS_TO_RETRY = 10;
 
 /*:: type Category = 'navigation' | 'notifications' | 'ui' | 'cache' | 'ebi' | 'api' | 'ipScan'; */
 
@@ -12,6 +13,8 @@ export const getDefaultSettingsFor = (category /*: Category */) => {
     case 'navigation':
       return {
         pageSize: config.pagination.pageSize,
+        secondsToRetry:
+          config?.timeout?.secondsToRetry || DEFAULT_SECONDS_TO_RETRY,
       };
     case 'notifications':
       return {

--- a/src/store/utils/get-initial-state/index.js
+++ b/src/store/utils/get-initial-state/index.js
@@ -46,7 +46,12 @@ export default history => {
   if (settings?.api?.hostname === 'www.ebi.ac.uk') {
     settings.api.root = settings.api.root.replace('/api/', '/wwwapi/');
   }
-  const description = pathToDescription(pathname);
+  let description = { other: ['NotFound'] };
+  try {
+    description = pathToDescription(pathname);
+  } catch {
+    console.error('Unable to identify resouce based on the URL request');
+  }
   return {
     customLocation: {
       description,

--- a/src/utils/server-message/__snapshots__/test.js.snap
+++ b/src/utils/server-message/__snapshots__/test.js.snap
@@ -28,7 +28,7 @@ exports[`server-message should render 4`] = `
 <div
   className="callout withicon alert"
 >
-  The server takes too long to respond. Your request is running in the background. Please check again in a while for the results
+  The query is still running in the background. We will update the page once the data is ready
 </div>
 `;
 

--- a/src/utils/server-message/__snapshots__/test.js.snap
+++ b/src/utils/server-message/__snapshots__/test.js.snap
@@ -4,7 +4,7 @@ exports[`server-message should render 1`] = `
 <div
   className="callout withicon info"
 >
-  Valid query, but unfortunately no data was available on the server
+  There is no data associated with this request
 </div>
 `;
 
@@ -36,6 +36,6 @@ exports[`server-message should render 5`] = `
 <div
   className="callout withicon alert"
 >
-  There was an error while getting data from the server
+  The API reported an error, but the cause has not been determined
 </div>
 `;

--- a/src/utils/server-message/index.js
+++ b/src/utils/server-message/index.js
@@ -8,35 +8,46 @@ import ipro from 'styles/interpro-new.css';
 
 const f = foundationPartial(ipro);
 
+export const STATUS_OK = 200;
+export const STATUS_NO_CONTENT = 204;
+export const STATUS_BAD_REQUEST = 400;
+export const STATUS_NOT_FOUND = 404;
+export const STATUS_TIMEOUT = 408;
+export const STATUS_GONE = 410;
+export const STATUS_SERVER_ERROR = 500;
+
+export const edgeCases /*: Map<number, string>*/ = new Map([
+  [STATUS_NO_CONTENT, 'There is no data associated with this request'],
+  [
+    STATUS_NOT_FOUND,
+    'There was an error, this is not a known resource on the server',
+  ],
+  [
+    STATUS_TIMEOUT,
+    'The query is still running in the background. We will update the page once the data is ready',
+  ],
+  [STATUS_GONE, 'The data associated with this accession has been removed'],
+  [
+    STATUS_SERVER_ERROR,
+    'The API reported an error, but the cause has not been determined',
+  ],
+  [
+    STATUS_BAD_REQUEST,
+    'There was an error, this is not a valid request to the server',
+  ],
+]);
+
 const message = (text, info = false) => (
   <div className={f('callout', 'withicon', { info, alert: !info })}>{text}</div>
 );
 
 const statusMessages = new Map([
-  [
-    204,
-    message(
-      'Valid query, but unfortunately no data was available on the server',
-      true,
-    ),
-  ],
-  [
-    400,
-    message('There was an error, this is not a valid request to the server'),
-  ],
-  [
-    404,
-    message('There was an error, this is not a known resource on the server'),
-  ],
-  [
-    408,
-    message(
-      'The query is still running in the background. We will update the page once the data is ready',
-    ),
-  ],
-  [500, message('There was an error while getting data from the server')],
-  [502, message('There was an error while getting data from the server')],
-  [503, message('There was an error while getting data from the server')],
+  [STATUS_NO_CONTENT, message(edgeCases.get(STATUS_NO_CONTENT), true)],
+  [STATUS_BAD_REQUEST, message(edgeCases.get(STATUS_BAD_REQUEST))],
+  [STATUS_NOT_FOUND, message(edgeCases.get(STATUS_NOT_FOUND))],
+  [STATUS_TIMEOUT, message(edgeCases.get(STATUS_TIMEOUT))],
+  [STATUS_SERVER_ERROR, message(edgeCases.get(STATUS_SERVER_ERROR))],
+  [503, message(edgeCases.get(STATUS_SERVER_ERROR))],
 ]);
 
 export default (status /*:: ?: number */) => {

--- a/src/utils/server-message/index.js
+++ b/src/utils/server-message/index.js
@@ -31,7 +31,7 @@ const statusMessages = new Map([
   [
     408,
     message(
-      'The query is still running in the background. Please reload in a short while to see the results.',
+      'The query is still running in the background. We will update the page once the data is ready',
     ),
   ],
   [500, message('There was an error while getting data from the server')],


### PR DESCRIPTION
In this PR I have extended the loadData to automatically retry queries which response code was 408.

It uses a configuration parameter `secondsToRetry` that the user can change in settings to define how long it should wait before trying again.

This required a few changes in some components to be able to display the correct message,