### PR TITLE
Protvista refactor

### DIFF
--- a/src/components/ProtVista/Popup/ColorScale/index.js
+++ b/src/components/ProtVista/Popup/ColorScale/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import T from 'prop-types';
 
 import { foundationPartial } from 'styles/foundation';
 import localCSS from '../../style.css';
@@ -27,5 +28,11 @@ const ColorScale = ({
     <span>{domain[1]}</span>
   </div>
 );
+ColorScale.propTypes = {
+  domain: T.arrayOf(T.number),
+  range: T.arrayOf(T.number),
+  width: T.number,
+  height: T.number,
+};
 
 export default ColorScale;

--- a/src/components/ProtVista/Popup/ColorScale/index.js
+++ b/src/components/ProtVista/Popup/ColorScale/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { foundationPartial } from 'styles/foundation';
+import localCSS from '../../style.css';
+
+const f = foundationPartial(localCSS);
+
+const COLOR_SCALE_WIDTH = 80;
+const COLOR_SCALE_HEIGHT = 20;
+const ColorScale = ({
+  domain,
+  range,
+  width = COLOR_SCALE_WIDTH,
+  height = COLOR_SCALE_HEIGHT,
+}) => (
+  <div className={f('color-scale')}>
+    <span>{domain[0]}</span>
+    <svg height={height} width={width}>
+      <defs>
+        <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" style={{ stopColor: range[0] }} />
+          <stop offset="100%" style={{ stopColor: range[1] }} />
+        </linearGradient>
+      </defs>
+      <rect width="100%" height={height} fill="url(#grad1)" />
+    </svg>
+    <span>{domain[1]}</span>
+  </div>
+);
+
+export default ColorScale;

--- a/src/components/ProtVista/Popup/Conservation/index.js
+++ b/src/components/ProtVista/Popup/Conservation/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import T from 'prop-types';
 
 import ColorScale from '../ColorScale';
 
@@ -65,5 +66,12 @@ const ProtVistaConservationPopup = ({ detail, data }) => {
       </div>
     </section>
   );
+};
+ProtVistaConservationPopup.propTypes = {
+  detail: T.shape({
+    feature: T.object,
+    highlight: T.string,
+  }),
+  data: T.array,
 };
 export default ProtVistaConservationPopup;

--- a/src/components/ProtVista/Popup/Conservation/index.js
+++ b/src/components/ProtVista/Popup/Conservation/index.js
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import ColorScale from '../ColorScale';
+
+const getConservationScore = (highlight, match, scale) => {
+  const start = parseInt(highlight.split(':')[0], 10);
+  const matchFragment = match.locations[0].fragments.find((fragment) => {
+    return start >= fragment.start && start <= fragment.end;
+  });
+  const scaleEntry = scale.find((element) => {
+    return matchFragment.color === element.color;
+  });
+  return `${scaleEntry.min} - ${scaleEntry.max}`;
+};
+
+const ProtVistaConservationPopup = ({ detail, data }) => {
+  // return <div>xxx</div>;
+  const match = detail.feature;
+  const sourceDatabase = 'Pfam'; // TODO: get it from match.accession;
+  const startLocation = match.locations[0];
+  const endLocation = match.locations[match.locations.length - 1];
+  const start = startLocation.fragments[0].start;
+  const end = endLocation.fragments[endLocation.fragments.length - 1].end;
+  const matchConservation = data.find((element) => {
+    if (element[0] && element[0].toLowerCase() === 'match conservation') {
+      return element[1].find(
+        (e) => (e.type && e.type.toLowerCase()) === 'sequence_conservation',
+      );
+    }
+    return false;
+  });
+
+  const scale = matchConservation[1].find((element) => {
+    return (
+      element.type && element.type.toLowerCase() === 'sequence_conservation'
+    );
+  }).range;
+  const score = getConservationScore(detail.highlight, match, scale);
+  const accession = startLocation.match;
+
+  return (
+    <section>
+      <h6>{accession}</h6>
+
+      <div>
+        <div>{sourceDatabase}</div>
+
+        <p>
+          {start && end && (
+            <>
+              {start} - {end}
+            </>
+          )}
+        </p>
+        {score && <p>Conservation : {score}</p>}
+        {scale && (
+          <>
+            Scale:{' '}
+            <ColorScale
+              domain={[scale[0].min, scale[scale.length - 1].max]}
+              range={[scale[0].color, scale[scale.length - 1].color]}
+            />
+          </>
+        )}
+      </div>
+    </section>
+  );
+};
+export default ProtVistaConservationPopup;

--- a/src/components/ProtVista/Popup/Entry/index.js
+++ b/src/components/ProtVista/Popup/Entry/index.js
@@ -1,0 +1,119 @@
+import React from 'react';
+
+import { foundationPartial } from 'styles/foundation';
+import ipro from 'styles/interpro-new.css';
+import localCSS from '../../style.css';
+
+const f = foundationPartial(ipro, localCSS);
+
+const getSecondaryStructureType = (locations) => {
+  let type = null;
+  if (locations && locations.length > 0) {
+    if (locations[0].fragments && locations[0].fragments[0]) {
+      const shape = locations[0].fragments[0].shape;
+      type = shape.charAt(0).toUpperCase() + shape.slice(1);
+    }
+  }
+  return type;
+};
+
+const ProtVistaEntryPopup = ({
+  detail,
+  sourceDatabase,
+  goToCustomLocation,
+  protein,
+}) => {
+  const {
+    accession,
+    description,
+    name,
+    type: originalType,
+    entry,
+    locations,
+    confidence,
+  } = detail?.feature || {};
+  const isInterPro = sourceDatabase.toLowerCase() === 'interpro';
+
+  // To include the type of fragment of the secondary structure
+  let type = originalType;
+  if (originalType === 'secondary_structure') {
+    type = `Secondary Structure: ${getSecondaryStructureType(locations)}`;
+  }
+
+  // To only show the location of the currntly selected fragment
+  const highlightChild =
+    detail.target &&
+    detail.target.classList.contains('child-fragment') &&
+    detail.highlight;
+  let newLocations = null;
+  if (highlightChild) {
+    newLocations = highlightChild.split(',').map((loc) => {
+      const [start, end] = loc.split(':');
+      return { fragments: [{ start, end }] };
+    });
+  }
+  const handleClick = (start, end) => () => {
+    goToCustomLocation({
+      description: {
+        main: { key: 'protein' },
+        protein: {
+          db: protein.source_database,
+          accession: protein.accession,
+          detail: 'sequence',
+        },
+      },
+      hash: `${start}-${end}`,
+    });
+  };
+  return (
+    <section>
+      <h6>
+        {accession}
+        {description && <p>[{description}]</p>}
+      </h6>
+
+      {name && <h4>{name}</h4>}
+
+      <div className={f('pop-wrapper')}>
+        <div>
+          {isInterPro && (
+            <interpro-type
+              type={type.replace('_', ' ')}
+              dimension="1.4em"
+              aria-label="Entry type"
+            />
+          )}
+        </div>
+        <div>
+          {sourceDatabase} {(type || '').replace('_', ' ')}
+        </div>
+      </div>
+      <p>
+        <small>{entry && <>({entry})</>}</small>
+      </p>
+      <ul>
+        {(newLocations || locations || []).map(
+          ({ fragments, model_acc: model }, j) => (
+            <li key={j}>
+              {model && model !== accession && <>Model: {model}</>}
+              <ul>
+                {(fragments || []).map(({ start, end }, i) => (
+                  <li key={i}>
+                    <button
+                      className={f('button', 'secondary')}
+                      onClick={handleClick(start, end)}
+                    >
+                      {start} - {end}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ),
+        )}
+      </ul>
+      {confidence && <p>Confidence: ${confidence}</p>}
+    </section>
+  );
+};
+export default ProtVistaEntryPopup;

--- a/src/components/ProtVista/Popup/Entry/index.js
+++ b/src/components/ProtVista/Popup/Entry/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import T from 'prop-types';
 
 import { foundationPartial } from 'styles/foundation';
 import ipro from 'styles/interpro-new.css';
@@ -116,4 +117,15 @@ const ProtVistaEntryPopup = ({
     </section>
   );
 };
+ProtVistaEntryPopup.propTypes = {
+  detail: T.shape({
+    feature: T.object,
+    highlight: T.string,
+    target: T.element,
+  }),
+  sourceDatabase: T.string,
+  goToCustomLocation: T.func,
+  protein: T.object,
+};
+
 export default ProtVistaEntryPopup;

--- a/src/components/ProtVista/Popup/Hydro/index.js
+++ b/src/components/ProtVista/Popup/Hydro/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import T from 'prop-types';
 
 import ColorScale from '../ColorScale';
 
@@ -18,6 +19,12 @@ const HydroPopup = ({ detail }) => {
       </div>
     </section>
   );
+};
+HydroPopup.propTypes = {
+  detail: T.shape({
+    feature: T.object,
+    target: T.element,
+  }),
 };
 
 export default HydroPopup;

--- a/src/components/ProtVista/Popup/Hydro/index.js
+++ b/src/components/ProtVista/Popup/Hydro/index.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import ColorScale from '../ColorScale';
+
+const HydroPopup = ({ detail }) => {
+  const element = detail?.target.closest('protvista-coloured-sequence');
+  if (!element) return null;
+  return (
+    <section>
+      <h6>
+        Residue {detail.feature.start}: {detail.feature.aa}
+      </h6>
+      <div>
+        <b>Hydrophobicity:</b> {detail.feature.value}
+        <br />
+        <b>Scale:</b> <ColorScale {...element.colorScale} />
+        <br />
+      </div>
+    </section>
+  );
+};
+
+export default HydroPopup;

--- a/src/components/ProtVista/Popup/Residue/index.js
+++ b/src/components/ProtVista/Popup/Residue/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import T from 'prop-types';
 
 const ProtVistaResiduePopup = ({ detail, sourceDatabase }) => {
   const { accession, type, currentResidue } = detail?.feature || {};
@@ -25,5 +26,10 @@ const ProtVistaResiduePopup = ({ detail, sourceDatabase }) => {
     </section>
   );
 };
-
+ProtVistaResiduePopup.propTypes = {
+  detail: T.shape({
+    feature: T.object,
+  }),
+  sourceDatabase: T.string,
+};
 export default ProtVistaResiduePopup;

--- a/src/components/ProtVista/Popup/Residue/index.js
+++ b/src/components/ProtVista/Popup/Residue/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const ProtVistaResiduePopup = ({ detail, sourceDatabase }) => {
+  const { accession, type, currentResidue } = detail?.feature || {};
+
+  const start = currentResidue?.start;
+  const description = currentResidue?.description || '';
+  const residue = currentResidue?.residue || currentResidue?.residues || '';
+  return (
+    <section>
+      <h6>
+        {accession}
+        {description && <p>[{description}]</p>}
+      </h6>
+
+      <div>
+        <div>
+          Residue in {sourceDatabase} {type && type.replace('_', ' ')}
+        </div>
+        <ul>
+          <li>Position: {start}</li>
+          <li>Residue: {residue}</li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default ProtVistaResiduePopup;

--- a/src/components/ProtVista/Popup/index.js
+++ b/src/components/ProtVista/Popup/index.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import ProtVistaHydroPopup from './Hydro';
+import ProtVistaResiduePopup from './Residue';
+import ProtVistaEntryPopup from './Entry';
+import ProtVistaConservationPopup from './Conservation';
+
+const ProtVistaPopup = ({
+  detail,
+  sourceDatabase,
+  data,
+  protein,
+  goToCustomLocation,
+}) => {
+  // comes from the conservation track
+  if (detail.feature.type === 'sequence_conservation') {
+    return <ProtVistaConservationPopup detail={detail} data={data} />;
+  }
+
+  // comes from a residue
+  if ((detail?.target?.classList || '').contains('residue')) {
+    return (
+      <ProtVistaResiduePopup detail={detail} sourceDatabase={sourceDatabase} />
+    );
+  }
+
+  // comes from the hydrophobicity track
+  if (detail?.target.closest('protvista-coloured-sequence')) {
+    return <ProtVistaHydroPopup detail={detail} />;
+  }
+
+  // comes from the Entry track
+  return (
+    <ProtVistaEntryPopup
+      detail={detail}
+      sourceDatabase={sourceDatabase}
+      goToCustomLocation={goToCustomLocation}
+      protein={protein}
+    />
+  );
+};
+
+export default ProtVistaPopup;

--- a/src/components/ProtVista/Popup/index.js
+++ b/src/components/ProtVista/Popup/index.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import T from 'prop-types';
+
 import ProtVistaHydroPopup from './Hydro';
 import ProtVistaResiduePopup from './Residue';
 import ProtVistaEntryPopup from './Entry';
@@ -37,6 +39,17 @@ const ProtVistaPopup = ({
       protein={protein}
     />
   );
+};
+ProtVistaPopup.propTypes = {
+  detail: T.shape({
+    feature: T.object,
+    highlight: T.string,
+    target: T.element,
+  }),
+  sourceDatabase: T.string,
+  data: T.array,
+  goToCustomLocation: T.func,
+  protein: T.object,
 };
 
 export default ProtVistaPopup;

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -96,6 +96,7 @@ const loadProtVistaWebComponents = () => {
   id: string,
   showConservationButton: boolean,
   handleConservationLoad: function,
+  goToCustomLocation: function,
   children: any,
 }; */
 
@@ -121,6 +122,7 @@ class ProtVista extends Component /*:: <Props, State> */ {
     id: T.string,
     showConservationButton: T.bool,
     handleConservationLoad: T.func,
+    goToCustomLocation: T.func,
     children: T.any,
   };
 

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
+import { render } from 'react-dom';
 import T from 'prop-types';
 import { createSelector } from 'reselect';
 import { isEqual } from 'lodash-es';
 
 import ProtVistaOptions from './Options';
+import ProtVistaPopup from './Popup';
 import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 
 import Link from 'components/generic/Link';
@@ -27,6 +29,7 @@ import PopperJS from 'popper.js';
 import loadWebComponent from 'utils/load-web-component';
 
 import loadData from 'higherOrder/loadData';
+import { goToCustomLocation } from 'actions/creators';
 import { getUrlForMeta } from 'higherOrder/loadData/defaults';
 
 import { foundationPartial } from 'styles/foundation';
@@ -81,34 +84,6 @@ const loadProtVistaWebComponents = () => {
   }
   return Promise.all(webComponents);
 };
-
-const removeAllChildrenFromNode = (node) => {
-  if (node.lastChild) {
-    node.removeChild(node.lastChild);
-    removeAllChildrenFromNode(node);
-  }
-};
-
-const COLOR_SCALE_WIDTH = 80;
-const COLOR_SCALE_HEIGHT = 20;
-const getColorScaleHTML = (
-  { domain, range },
-  width = COLOR_SCALE_WIDTH,
-  height = COLOR_SCALE_HEIGHT,
-) => `
-<div class="color-scale">
-  <span>${domain[0]}</span>
-  <svg height="${height}" width="${width}">
-  <defs>
-    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:${range[0]};" />
-      <stop offset="100%" style="stop-color:${range[1]};" />
-    </linearGradient>
-  </defs>
-    <rect width="100%" height="${height}" fill="url(#grad1)"/>
-  </svg>
-  <span>${domain[1]}</span>
-</div>`;
 
 /*:: type Props = {
   protein: Object,
@@ -187,37 +162,7 @@ class ProtVista extends Component /*:: <Props, State> */ {
     this._webProteinRef.current.data = protein;
     this._hydroRef.current.data = protein;
     this.updateTracksWithData(data);
-    this._hydroRef.current.addEventListener('change', ({ detail }) => {
-      if (detail.feature) {
-        this._popperRef.current.classList.remove(f('hide'));
-        removeAllChildrenFromNode(this._popperContentRef.current);
-        const range = document.createRange();
-        range.selectNode(document.getElementsByTagName('div').item(0));
-        const element = range.createContextualFragment(`
-        <section>
-          <h6>Residue ${detail.feature.start}: ${detail.feature.aa}</h6>
-          <div>
-            <b>Hydrophobicity:</b> ${detail.feature.value}<br/>
-            <b>Scale:</b> ${getColorScaleHTML(
-              this._hydroRef.current.colorScale,
-            )}<br/>
-          </div>
-        </section>
-        `);
-        this._popperContentRef.current.appendChild(element);
-        this._isPopperTop = !this._isPopperTop;
-        const rect = this._hydroRef.current.querySelector(
-          `.base_bg[data-pos="${detail.feature.start}"]`,
-        );
-        this.popper = new PopperJS(rect, this._popperRef.current, {
-          placement: this._isPopperTop ? 'top' : 'bottom',
-          applyStyle: { enabled: false },
-        });
-      } else if (this.popper) {
-        this.popper.destroy();
-        this._popperRef.current.classList.add(f('hide'));
-      }
-    });
+    this._hydroRef.current.addEventListener('change', this._handleTrackChange);
     if (this._popperContentRef.current) {
       this._popperContentRef.current.addEventListener('mouseover', () =>
         this.setState({ overPopup: true }),
@@ -311,48 +256,7 @@ class ProtVista extends Component /*:: <Props, State> */ {
         if (isNewElement) {
           this.web_tracks[d.accession].addEventListener(
             'change',
-            ({ detail }) => {
-              if (detail) {
-                switch (detail.eventtype) {
-                  case 'click':
-                    this.handleCollapseLabels(detail.feature.accession);
-                    break;
-                  case 'mouseout':
-                    this._timeoutID = setInterval(() => {
-                      if (this.state.overPopup) return;
-                      clearInterval(this._timeoutID);
-                      removeAllChildrenFromNode(this._popperContentRef.current);
-                      this.popper.destroy();
-                      this._popperRef.current.classList.add(f('hide'));
-                      this._timeoutID = 0;
-                    }, TOOLTIP_DELAY);
-                    break;
-                  case 'mouseover':
-                    if (this.state.enableTooltip) {
-                      if (this._timeoutID > 0) {
-                        clearInterval(this._timeoutID);
-                      }
-                      this._popperRef.current.classList.remove(f('hide'));
-                      removeAllChildrenFromNode(this._popperContentRef.current);
-                      this._popperContentRef.current.appendChild(
-                        this.getElementFromDetail(detail),
-                      );
-                      this._isPopperTop = !this._isPopperTop;
-                      this.popper = new PopperJS(
-                        detail.target,
-                        this._popperRef.current,
-                        {
-                          placement: this._isPopperTop ? 'top' : 'bottom',
-                          applyStyle: { enabled: false },
-                        },
-                      );
-                    }
-                    break;
-                  default:
-                    break;
-                }
-              }
-            },
+            this._handleTrackChange,
           );
         }
         this.setObjectValueInState(
@@ -364,6 +268,56 @@ class ProtVista extends Component /*:: <Props, State> */ {
       this.setObjectValueInState('hideCategory', type[0], false);
     }
   }
+
+  _handleTrackChange = ({ detail }) => {
+    if (detail) {
+      switch (detail.eventtype) {
+        case 'click':
+          this.handleCollapseLabels(detail.feature.accession);
+          break;
+        case 'mouseout':
+          this._timeoutID = setInterval(() => {
+            if (this.state.overPopup) return;
+            clearInterval(this._timeoutID);
+            this.popper.destroy();
+            this._popperRef.current.classList.add(f('hide'));
+            this._timeoutID = 0;
+          }, TOOLTIP_DELAY);
+          break;
+        case 'mouseover':
+          if (this.state.enableTooltip) {
+            if (this._timeoutID > 0) {
+              clearInterval(this._timeoutID);
+            }
+            this._popperRef.current.classList.remove(f('hide'));
+            const sourceDatabase = this._getSourceDatabaseDisplayName(
+              detail.feature,
+              this.props?.dataDB?.payload?.databases,
+            );
+            render(
+              <ProtVistaPopup
+                detail={detail}
+                sourceDatabase={sourceDatabase}
+                data={this.props.data}
+                protein={this.props.protein}
+                // Need to pass it from here because it rendered out of the redux provider
+                goToCustomLocation={this.props.goToCustomLocation}
+              />,
+              this._popperContentRef.current,
+            );
+
+            this._isPopperTop = !this._isPopperTop;
+            this.popper = new PopperJS(detail.target, this._popperRef.current, {
+              placement: this._isPopperTop ? 'top' : 'bottom',
+              applyStyle: { enabled: false },
+            });
+          }
+          break;
+        default:
+          break;
+      }
+    }
+  };
 
   _getSourceDatabaseDisplayName = (entry, databases) => {
     let sourceDatabase = '';
@@ -382,251 +336,6 @@ class ProtVista extends Component /*:: <Props, State> */ {
     }
     return sourceDatabase;
   };
-
-  _getMobiDBLiteType = (entry) => {
-    let type = null;
-    if (entry.locations && entry.locations.length > 0) {
-      if (entry.locations[0].seq_feature) {
-        type = entry.locations[0].seq_feature;
-      }
-    }
-    return type;
-  };
-
-  _getSecondaryStructureType = (entry) => {
-    let type = null;
-    if (entry.locations && entry.locations.length > 0) {
-      if (entry.locations[0].fragments && entry.locations[0].fragments[0]) {
-        const shape = entry.locations[0].fragments[0].shape;
-        type = shape.charAt(0).toUpperCase() + shape.slice(1);
-      }
-    }
-    return type;
-  };
-
-  getHTMLStringForEntry(entry, sourceDatabase, highlightChild) {
-    let type = entry.entry_type || entry.type || '';
-    if (sourceDatabase === 'MobiDB Lite') {
-      // Handle MobiDB Lite entries
-      // TODO change how MobiDBLt entries are stored in MySQL
-      type = this._getMobiDBLiteType(entry);
-    }
-
-    if (type === 'secondary_structure') {
-      type = `Secondary Structure: ${this._getSecondaryStructureType(entry)}`;
-    }
-    let newLocations = null;
-    if (highlightChild) {
-      newLocations = highlightChild.split(',').map((loc) => {
-        const [start, end] = loc.split(':');
-        return { fragments: [{ start, end }] };
-      });
-    }
-
-    return this.getHTMLString(
-      {
-        ...entry,
-        locations: newLocations || entry.locations,
-        type,
-        sourceDatabase,
-      },
-      entry.source_database === 'interpro',
-    );
-  }
-
-  getHTMLStringForResidue(entry, sourceDatabase) {
-    const residue = entry.currentResidue;
-    return this.getHTMLString(
-      {
-        ...entry,
-        ...residue,
-        residue: residue.residue || residue.residues,
-        sourceDatabase,
-        description: residue.description || residue.location.description,
-      },
-      false,
-      true,
-    );
-  }
-
-  // eslint-disable-next-line complexity
-  getHTMLString(
-    {
-      accession,
-      sourceDatabase,
-      description,
-      name,
-      entry,
-      locations,
-      type,
-      start,
-      end,
-      residue,
-      score,
-      scale,
-      confidence,
-    },
-    isInterPro = false,
-    isResidue = false,
-  ) {
-    const scaleComponent = scale
-      ? getColorScaleHTML({
-          domain: [scale[0].min, scale[scale.length - 1].max],
-          range: [scale[0].color, scale[scale.length - 1].color],
-        })
-      : '';
-    return `
-      <section>
-        <h6>
-          ${accession}
-          ${description ? `<br/>[${description}]` : ''}
-         </h6>
-
-        ${name && !isResidue ? `<h4>${name}</h4>` : ''}
-
-        <!-- use class as Protvista is not react-->
-        <div class="${f('pop-wrapper')}" >
-          <div>${
-            isInterPro
-              ? `<interpro-type
-                      type="${type.replace('_', ' ')}"
-                      dimension="1.4em"
-                      aria-label="Entry type"
-                    />`
-              : ''
-          }
-          </div>
-          <div>
-            ${isResidue ? 'Residue in ' : ''}
-            ${sourceDatabase} ${type ? type.replace('_', ' ') : ''}
-          </div>
-        </div>
-        <p>
-          <small>
-            ${entry ? `(${entry})` : ''}
-          </small>
-        </p>
-        <ul>
-          ${
-            isResidue
-              ? `
-            <li>Position: ${start}</li>
-            <li>Residue: ${residue}</li>
-            `
-              : ''
-          }
-          ${
-            !isResidue && locations
-              ? locations
-                  .map(({ fragments, model_acc: model }) =>
-                    `
-            <li>
-            <!--location:-->
-              ${model && model !== accession ? `Model: ${model}` : ''}
-              <ul>
-                ${
-                  fragments
-                    ? fragments
-                        .map(({ start, end }) =>
-                          `
-                  <li>${start} - ${end}</li>
-                `.trim(),
-                        )
-                        .join('')
-                    : ''
-                }
-              </ul>
-            </li>
-          `.trim(),
-                  )
-                  .join('')
-              : ''
-          }
-        </ul>
-        <p>
-          ${start && end ? `${start} - ${end}` : ''}
-        </p>
-        ${score ? `<p>Conservation : ${score}</p>` : ''}
-        ${confidence ? `<p>Confidence: ${confidence}</p>` : ''}
-        ${scaleComponent ? `<p>Scale: ${scaleComponent}</p>` : ''}
-        </section>
-`.trim();
-  }
-
-  getConservationScore(highlight, match, scale) {
-    const start = parseInt(highlight.split(':')[0], 10);
-    const matchFragment = match.locations[0].fragments.find((fragment) => {
-      return start >= fragment.start && start <= fragment.end;
-    });
-    const scaleEntry = scale.find((element) => {
-      return matchFragment.color === element.color;
-    });
-    return `${scaleEntry.min} - ${scaleEntry.max}`;
-  }
-
-  getElementFromDetail(detail) {
-    let databases = {};
-    const { dataDB } = this.props;
-    if (!dataDB.loading && dataDB.payload) {
-      databases = dataDB.payload.databases;
-    }
-
-    let tagString;
-    if (detail.feature.type === 'sequence_conservation') {
-      const match = detail.feature;
-      const sourceDatabase =
-        match.accession in databases
-          ? databases[match.accession].name
-          : match.accession;
-      const startLocation = match.locations[0];
-      const endLocation = match.locations[match.locations.length - 1];
-      const start = startLocation.fragments[0].start;
-      const end = endLocation.fragments[endLocation.fragments.length - 1].end;
-      const matchConservation = this.props.data.find((element) => {
-        if (element[0] && element[0].toLowerCase() === 'match conservation') {
-          return element[1].find(
-            (e) => (e.type && e.type.toLowerCase()) === 'sequence_conservation',
-          );
-        }
-        return false;
-      });
-
-      const scale = matchConservation[1].find((element) => {
-        return (
-          element.type && element.type.toLowerCase() === 'sequence_conservation'
-        );
-      }).range;
-      const score = this.getConservationScore(detail.highlight, match, scale);
-      const accession = startLocation.match;
-      tagString = this.getHTMLString({
-        accession,
-        sourceDatabase,
-        start,
-        end,
-        score,
-        scale,
-      });
-    } else {
-      const entry = detail.feature;
-      const sourceDatabase = this._getSourceDatabaseDisplayName(
-        entry,
-        databases,
-      );
-
-      const isResidue =
-        detail.target && detail.target.classList.contains('residue');
-      const highlightChild =
-        detail.target &&
-        detail.target.classList.contains('child-fragment') &&
-        detail.highlight;
-      tagString = isResidue
-        ? this.getHTMLStringForResidue(entry, sourceDatabase)
-        : this.getHTMLStringForEntry(entry, sourceDatabase, highlightChild);
-    }
-    const range = document.createRange();
-    range.selectNode(document.getElementsByTagName('div').item(0));
-    return range.createContextualFragment(tagString);
-  }
 
   setObjectValueInState = (objectName, type, value) =>
     this.setState(({ [objectName]: obj }) => ({
@@ -664,9 +373,10 @@ class ProtVista extends Component /*:: <Props, State> */ {
     });
 
   renderSwitch(label, entry) {
-    const type = entry.type ? (
-      <interpro-type type={entry.type.replace('_', ' ')} dimension="1em" />
-    ) : null;
+    const type =
+      entry.source_database === 'interpro' && entry.type ? (
+        <interpro-type type={entry.type.replace('_', ' ')} dimension="1em" />
+      ) : null;
     return (
       <>
         {type}
@@ -1082,4 +792,5 @@ export default loadData({
   getUrl: getUrlForMeta,
   propNamespace: 'DB',
   mapStateToProps,
+  mapDispatchToProps: { goToCustomLocation },
 })(ProtVista);


### PR DESCRIPTION
Cleaning up the ProtVista component.
* Separating the code for the popups in protvista
* Removing some code that wasn't in use anymore (e.g. mobidb as memberDB)
* Interpro type web element only displayed for interpro entries
* Entry popups now include a button linking to the sequence tab.

FIX #202 The sequence tab now syncs with customLocation, so show the selected region in the hash URL; and inversely to select an area based on the hash URL.