### PR TITLE
Set in entry overview

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -36,7 +36,6 @@ pages:
       - structure
       - taxonomy
       - proteome
-      - set
       - logo
       - entry_alignments
       - interactions

--- a/src/components/Description/index.js
+++ b/src/components/Description/index.js
@@ -236,20 +236,20 @@ class Description extends PureComponent /*:: <Props> */ {
         data-testid="description"
       >
         {sections
-          .map((section) =>
+          .map((section, i) =>
             section
               .map((p, j) => (
                 <Paragraph
-                  key={j}
+                  key={`${i}.${j}`}
                   p={p}
                   literature={literature || []}
                   accession={accession}
                   withoutIDs={withoutIDs}
                 />
               ))
-              .reduce((prev, curr) => [prev, <br key={prev} />, curr]),
+              .reduce((prev, curr, key) => [prev, <br key={key} />, curr]),
           )
-          .reduce((prev, curr) => [prev, <hr key={prev} />, curr])}
+          .reduce((prev, curr, key) => [prev, <hr key={key} />, curr])}
       </div>
     );
   }

--- a/src/components/Entry/Summary/index.js
+++ b/src/components/Entry/Summary/index.js
@@ -21,6 +21,7 @@ import CrossReferences from 'components/Entry/CrossReferences';
 import Integration from 'components/Entry/Integration';
 import ContributingSignatures from 'components/Entry/ContributingSignatures';
 import InterProHierarchy from 'components/Entry/InterProHierarchy';
+import SetLinkFromEntry from 'components/Set/SetLinkFromEntry';
 import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 import Loading from 'components/SimpleCommonComponents/Loading';
 import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
@@ -58,8 +59,10 @@ const MAX_NUMBER_OF_OVERLAPPING_ENTRIES = 5;
         overlaps_with: Object,
         cross_references: Object,
         wikipedia: Object,
+        counters: Object,
       }
  */
+
 const MemberDBSubtitle = (
   { metadata, dbInfo } /*: {metadata: Metadata, dbInfo: Object} */,
 ) => {
@@ -114,6 +117,14 @@ const MemberDBSubtitle = (
             </td>
           </tr>
         )}
+        {metadata?.counters?.sets ? (
+          <tr>
+            <td>Set</td>
+            <td>
+              <SetLinkFromEntry />
+            </td>
+          </tr>
+        ) : null}
       </tbody>
     </table>
   );

--- a/src/components/Set/SetLinkFromEntry/index.js
+++ b/src/components/Set/SetLinkFromEntry/index.js
@@ -1,0 +1,69 @@
+// @flow
+import React from 'react';
+import T from 'prop-types';
+
+import { createSelector } from 'reselect';
+import { format } from 'url';
+
+import descriptionToPath from 'utils/processDescription/descriptionToPath';
+import loadData from 'higherOrder/loadData';
+
+import Link from 'components/generic/Link';
+import Loading from 'components/SimpleCommonComponents/Loading';
+
+const SetLinkFromEntry = (
+  { data } /*: {data: {loading: boolean, payload: Object}} */,
+) => {
+  if (!data) return null;
+  if (data.loading) return <Loading inline={true} />;
+  if (!data.payload) return 'Set not found';
+  const { accession, source_database: db } = data.payload.set_subset[0];
+  return (
+    <Link
+      to={{
+        description: {
+          main: { key: 'set' },
+          set: { db, accession },
+        },
+      }}
+    >
+      {accession}
+    </Link>
+  );
+};
+SetLinkFromEntry.propTypes = {
+  data: T.shape({
+    loading: T.bool,
+    payload: T.shape({
+      set_subset: T.object,
+    }),
+  }),
+};
+const mapStateToUrl = createSelector(
+  (state) => state.settings.api,
+  (state) => state.customLocation.description.main.key,
+  (state) =>
+    state.customLocation.description.main.key &&
+    state.customLocation.description[state.customLocation.description.main.key]
+      .db,
+  (state) =>
+    state.customLocation.description.main.key &&
+    state.customLocation.description[state.customLocation.description.main.key]
+      .accession,
+  ({ protocol, hostname, port, root }, key, db, accession) => {
+    if (!accession || key !== 'entry') return;
+    return format({
+      protocol,
+      hostname,
+      port,
+      pathname:
+        root +
+        descriptionToPath({
+          main: { key },
+          [key]: { db, accession },
+          set: { db, isFilter: true },
+        }),
+    });
+  },
+);
+export default loadData(mapStateToUrl)(SetLinkFromEntry);


### PR DESCRIPTION
The subpage for sets in an entry is a bit of an overkill, as an entry can only belong to a single set.
So instead of a page with a list of 1 set, this PR shows a link to the set in the overview entry page.

