### PR TITLE
cleaning description

### DIFF
--- a/src/utils/processDescription/descriptionToDescription/index.js
+++ b/src/utils/processDescription/descriptionToDescription/index.js
@@ -50,6 +50,19 @@ export default (description /*: {[key: string]: string} */ = {}) => {
         _description[endpoint].order || _description.main.numberOfFilters;
     }
   }
+
+  // To clean any leftover from the previous description that should not be used
+  Object.keys(_description).forEach((key) => {
+    if (
+      key !== 'main' && // it's not the block defining the main
+      key !== _description.main.key && // it's not the main block
+      !_description[key].isFilter // it's not a filter
+    ) {
+      Object.keys(_description[key]).forEach(
+        (k) => (_description[key][k] = null),
+      );
+    }
+  });
   // Specific logic for 'other'
   _description.other.push(...(description.other || []));
   Object.seal(_description.other);


### PR DESCRIPTION
As pointed by typhaine there are cases in the browse section where the active class of the selected endpoint is not applied.
For example:

![Screenshot 2020-10-19 at 16 12 45](https://user-images.githubusercontent.com/46671268/96470216-f517ce00-1225-11eb-9e8c-f96ca7604af3.png)

To get to this state, go to https://www.ebi.ac.uk/interpro/protein/UniProt/entry/pfam/taxonomy/uniprot/10090/?search=#table and then select other member DB.

The problem is that the new location includes the taxonomy values of the old URL, even if its flag `isFilter` is now `null`.
I have added some logic on `descriptionToDescription` that cleans any data in the new location that doesn't belong to the main endpoint or `isFilter!==true`.

I don't think there are side effects of this strategy, but I would like another set of eyes in it, as  `descriptionToDescription` is used in every single link in the page.


