### PR TITLE
Isoforms improvements

### DIFF
--- a/src/components/Protein/Isoforms/Selector/index.js
+++ b/src/components/Protein/Isoforms/Selector/index.js
@@ -17,11 +17,10 @@ const f = foundationPartial(style);
 const Selector = (
   {
     data,
-    value = '',
     isoform = '',
     goToCustomLocation,
     customLocation,
-  } /*: {data: {loading: boolean, payload: Object}, value: string, onChange: function} */,
+  } /*: {data: {loading: boolean, payload: Object}, isoform?: string, goToCustomLocation: function, customLocation: {}} */,
 ) => {
   if (!data || data.loading || !data.payload) return <Loading />;
   const isoforms = data.payload.results;
@@ -44,6 +43,7 @@ const Selector = (
       {isoforms.map((acc) => (
         <option value={acc} key={acc}>
           {acc}
+          {acc.endsWith('-1') ? ' [canonical]' : ''}
         </option>
       ))}
     </select>
@@ -54,10 +54,9 @@ Selector.propTypes = {
     loading: T.bool,
     payload: T.object,
   }),
-  value: T.string,
   goToCustomLocation: T.func.isRequired,
   customLocation: T.object.isRequired,
-  onChange: T.func,
+  isoform: T.string,
 };
 
 const mapStateToProps = createSelector(

--- a/src/components/Protein/Isoforms/Viewer/index.js
+++ b/src/components/Protein/Isoforms/Viewer/index.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import T from 'prop-types';
 
@@ -7,6 +8,10 @@ import loadData from 'higherOrder/loadData';
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
 
 import NumberComponent from 'components/NumberComponent';
+import {
+  groupByEntryType,
+  byEntryType,
+} from 'components/Related/DomainsOnProtein';
 import Loading from 'components/SimpleCommonComponents/Loading';
 
 import loadable from 'higherOrder/loadable';
@@ -38,13 +43,13 @@ const features2protvista = (features) => {
   const interpro = featArray.filter(({ accession }) =>
     accession.toLowerCase().startsWith('ipr'),
   );
+  const groups = groupByEntryType(interpro);
   const unintegrated = featArray.filter(
     (f) => interpro.indexOf(f) === -1 && integrated.indexOf(f) === -1,
   );
-  return [
-    ['interpro', interpro],
-    ['unintegrated', unintegrated],
-  ];
+  return [...Object.entries(groups), ['unintegrated', unintegrated]].sort(
+    byEntryType,
+  );
 };
 
 const Viewer = (

--- a/src/components/Protein/Isoforms/Viewer/index.js
+++ b/src/components/Protein/Isoforms/Viewer/index.js
@@ -7,7 +7,6 @@ import loadData from 'higherOrder/loadData';
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
 
 import NumberComponent from 'components/NumberComponent';
-
 import Loading from 'components/SimpleCommonComponents/Loading';
 
 import loadable from 'higherOrder/loadable';
@@ -92,11 +91,20 @@ Viewer.propTypes = {
   }),
 };
 
+const mapStateToProps = createSelector(
+  (state) => state.customLocation.search,
+  ({ isoform }) => ({ isoform }),
+);
+
 const getIsoformURL = createSelector(
   (state) => state.settings.api,
   (state) => state.customLocation.description,
-  (_, props) => props.isoform,
-  ({ protocol, hostname, port, root }, { protein: { accession } }, isoform) => {
+  (state) => state.customLocation.search,
+  (
+    { protocol, hostname, port, root },
+    { protein: { accession } },
+    { isoform },
+  ) => {
     const description = {
       main: { key: 'protein' },
       protein: { db: 'uniprot', accession },
@@ -113,4 +121,4 @@ const getIsoformURL = createSelector(
     });
   },
 );
-export default loadData(getIsoformURL)(Viewer);
+export default loadData({ getUrl: getIsoformURL, mapStateToProps })(Viewer);

--- a/src/components/Protein/Isoforms/Viewer/index.js
+++ b/src/components/Protein/Isoforms/Viewer/index.js
@@ -24,9 +24,31 @@ const ProtVista = loadable({
   loader: () =>
     import(/* webpackChunkName: "protvista" */ 'components/ProtVista'),
 });
+/*::
+  type Feature = {
+    accession: string,
+    name: string,
+    source_database: string,
+    type: string,
+    children: Array<Object>,
+    integrated: ?string,
+    locations: [],
+  }
+  type FeatureMap = {
+    [string]: Feature,
+  }
+  type IsoformPayload = {
+    accession: string,
+    length: number,
+    protein_acc: string,
+    sequence: string,
+    features: FeatureMap,
+  }
+ */
 
-const features2protvista = (features) => {
-  const featArray = Object.values(features || {});
+const features2protvista = (features /*: FeatureMap */) => {
+  // prettier-ignore
+  const featArray /*: Array<Feature> */ = (Object.values(features || {})/*: any */);
   const integrated = [];
   for (const feature of featArray) {
     if (feature.integrated && feature.integrated in features) {
@@ -56,7 +78,7 @@ const Viewer = (
   {
     isoform,
     data,
-  } /*: {isoform: string, data: {loading: boolean, payload: Object}} */,
+  } /*: {isoform: string, data: {loading: boolean, payload: IsoformPayload}} */,
 ) => {
   if (!isoform) return null;
   if (

--- a/src/components/Protein/Summary/__snapshots__/test.js.snap
+++ b/src/components/Protein/Summary/__snapshots__/test.js.snap
@@ -200,9 +200,7 @@ exports[`<SummaryProtein /> should render 1`] = `
       </div>
     </div>
   </section>
-  <Memo(Connect(loadData(Viewer)))
-    isoform=""
-  />
+  <Memo(Connect(loadData(Viewer))) />
   <section>
     <div
       className="row"

--- a/src/components/Protein/Summary/__snapshots__/test.js.snap
+++ b/src/components/Protein/Summary/__snapshots__/test.js.snap
@@ -200,74 +200,78 @@ exports[`<SummaryProtein /> should render 1`] = `
       </div>
     </div>
   </section>
-  <Memo(Connect(loadData(Viewer))) />
-  <section>
-    <div
-      className="row"
-    >
+  <section
+    className=""
+  >
+    <Memo(Connect(loadData(Viewer))) />
+    <section>
       <div
-        className="medium-12 columns margin-bottom-large"
+        className="row"
       >
-        <Memo(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(DomainOnProteinWithoutData)))))))))
-          mainData={
-            Object {
-              "metadata": Object {
-                "accession": "A0A000",
-                "counters": Object {
-                  "dbEntries": Object {
-                    "cathgene3d": 2,
-                    "cdd": 1,
-                    "interpro": 5,
-                    "panther": 2,
-                    "pfam": 1,
-                    "ssf": 1,
-                    "tigrfams": 1,
-                  },
-                  "entries": 13,
-                  "idas": 323222,
-                  "isoforms": 0,
-                  "proteome": 0,
-                  "proteomes": 0,
-                  "sets": 3,
-                  "similar_proteins": 323222,
-                  "structures": 0,
-                  "taxa": 1,
-                  "taxonomy": 1,
-                },
-                "description": Array [],
-                "gene": "moeA5",
-                "go_terms": Array [
-                  Object {
-                    "category": Object {
-                      "code": "F",
-                      "name": "molecular_function",
+        <div
+          className="medium-12 columns margin-bottom-large"
+        >
+          <Memo(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(DomainOnProteinWithoutData)))))))))
+            mainData={
+              Object {
+                "metadata": Object {
+                  "accession": "A0A000",
+                  "counters": Object {
+                    "dbEntries": Object {
+                      "cathgene3d": 2,
+                      "cdd": 1,
+                      "interpro": 5,
+                      "panther": 2,
+                      "pfam": 1,
+                      "ssf": 1,
+                      "tigrfams": 1,
                     },
-                    "identifier": "GO:0030170",
-                    "name": "pyridoxal phosphate binding",
+                    "entries": 13,
+                    "idas": 323222,
+                    "isoforms": 0,
+                    "proteome": 0,
+                    "proteomes": 0,
+                    "sets": 3,
+                    "similar_proteins": 323222,
+                    "structures": 0,
+                    "taxa": 1,
+                    "taxonomy": 1,
                   },
-                ],
-                "id": "A0A000_STRVD",
-                "ida_accession": "220d43766bfe69807874ea078bc783ea7854e968",
-                "is_fragment": false,
-                "length": 394,
-                "name": Object {
-                  "name": "MoeA5",
+                  "description": Array [],
+                  "gene": "moeA5",
+                  "go_terms": Array [
+                    Object {
+                      "category": Object {
+                        "code": "F",
+                        "name": "molecular_function",
+                      },
+                      "identifier": "GO:0030170",
+                      "name": "pyridoxal phosphate binding",
+                    },
+                  ],
+                  "id": "A0A000_STRVD",
+                  "ida_accession": "220d43766bfe69807874ea078bc783ea7854e968",
+                  "is_fragment": false,
+                  "length": 394,
+                  "name": Object {
+                    "name": "MoeA5",
+                  },
+                  "protein_evidence": 4,
+                  "proteome": null,
+                  "sequence": "MDFFVRLARETGDRKREFLELGRKAGRFPAASTSNGEISIWCSNDYLGMGQHPDVLDAMKRSVDEYGGGSGGSRNTGGTNHFHVALEREPAEPHGKEDAVLFTSGYSAN",
+                  "source_database": "unreviewed",
+                  "source_organism": Object {
+                    "fullName": "Streptomyces viridosporus",
+                    "scientificName": "Streptomyces viridosporus",
+                    "taxId": "67581",
+                  },
                 },
-                "protein_evidence": 4,
-                "proteome": null,
-                "sequence": "MDFFVRLARETGDRKREFLELGRKAGRFPAASTSNGEISIWCSNDYLGMGQHPDVLDAMKRSVDEYGGGSGGSRNTGGTNHFHVALEREPAEPHGKEDAVLFTSGYSAN",
-                "source_database": "unreviewed",
-                "source_organism": Object {
-                  "fullName": "Streptomyces viridosporus",
-                  "scientificName": "Streptomyces viridosporus",
-                  "taxId": "67581",
-                },
-              },
+              }
             }
-          }
-        />
+          />
+        </div>
       </div>
-    </div>
+    </section>
   </section>
   <GoTerms
     terms={

--- a/src/components/Protein/Summary/index.js
+++ b/src/components/Protein/Summary/index.js
@@ -155,10 +155,7 @@ const SummaryProtein = (
                       </Tooltip>
                     </td>
                     <td>
-                      <IsoformSelector
-                        value={isoform}
-                        onChange={(event) => setIsoform(event.target.value)}
-                      />
+                      <IsoformSelector />
                     </td>
                   </tr>
                 ) : null}

--- a/src/components/Protein/Summary/index.js
+++ b/src/components/Protein/Summary/index.js
@@ -1,6 +1,8 @@
 // @flow
-import React from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import T from 'prop-types';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
 
 import GoTerms from 'components/GoTerms';
 import Length from 'components/Protein/Length';
@@ -25,14 +27,25 @@ import IsoformViewer from 'components/Protein/Isoforms/Viewer';
 import Loading from 'components/SimpleCommonComponents/Loading';
 import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 import HmmerButton from 'components/Protein/Sequence/HmmerButton';
+import FullScreenButton from 'components/SimpleCommonComponents/FullScreenButton';
 
 import { foundationPartial } from 'styles/foundation';
 
 import ebiStyles from 'ebi-framework/css/ebi-global.css';
 import sequenceStyles from '../Sequence/style.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
+import local from './style.css';
+import summary from 'styles/summary.css';
+import theme from 'styles/theme-interpro.css';
 
-const f = foundationPartial(ebiStyles, sequenceStyles, fonts);
+const f = foundationPartial(
+  summary,
+  theme,
+  ebiStyles,
+  sequenceStyles,
+  fonts,
+  local,
+);
 
 /*:: type Props = {
   data: {
@@ -45,9 +58,19 @@ const SchemaOrgData = loadable({
   loading: () => null,
 });
 
-const SummaryProtein = (
-  { data, loading } /*: {data: Object, loading: boolean} */,
+export const SummaryProtein = (
+  {
+    data,
+    loading,
+    isoform,
+  } /*: {data: Object, loading: boolean, isoform?: string} */,
 ) => {
+  const comparisonContainerRef = useRef();
+  const [renderComparisonButton, setRenderComparisonButton] = useState(false);
+  const [comparisonMode, setComparisonMode] = useState(false);
+  useEffect(() => {
+    setRenderComparisonButton(true);
+  }, [comparisonContainerRef]);
   if (loading || !data || !data.metadata) return <Loading />;
   const metadata = data.metadata;
 
@@ -153,8 +176,24 @@ const SummaryProtein = (
                         />
                       </Tooltip>
                     </td>
-                    <td>
+                    <td style={{ display: 'flex' }}>
                       <IsoformSelector />
+                      {renderComparisonButton ? (
+                        <FullScreenButton
+                          element={comparisonContainerRef.current}
+                          className={f(
+                            'button',
+                            'comparison-button',
+                            'icon',
+                            'icon-common',
+                          )}
+                          disabled={!isoform}
+                          dataIcon={'\uF0DB'}
+                          tooltip="View in comparison mode"
+                          onFullScreenHook={() => setComparisonMode(true)}
+                          onExitFullScreenHook={() => setComparisonMode(false)}
+                        />
+                      ) : null}
                     </td>
                   </tr>
                 ) : null}
@@ -206,13 +245,18 @@ const SummaryProtein = (
           </div>
         </div>
       </section>
-      <IsoformViewer />
-      <section>
-        <div className={f('row')}>
-          <div className={f('medium-12', 'columns', 'margin-bottom-large')}>
-            <DomainsOnProtein mainData={data} />
+      <section
+        ref={comparisonContainerRef}
+        className={f({ splitfullscreen: comparisonMode })}
+      >
+        <IsoformViewer />
+        <section>
+          <div className={f('row')}>
+            <div className={f('medium-12', 'columns', 'margin-bottom-large')}>
+              <DomainsOnProtein mainData={data} />
+            </div>
           </div>
-        </div>
+        </section>
       </section>
       {metadata.go_terms && (
         <GoTerms terms={metadata.go_terms} type="protein" />
@@ -225,6 +269,12 @@ SummaryProtein.propTypes = {
     metadata: T.object,
   }).isRequired,
   loading: T.bool.isRequired,
+  isoform: T.string,
 };
 
-export default SummaryProtein;
+const mapStateToProps = createSelector(
+  (state) => state.customLocation.search,
+  ({ isoform }) => ({ isoform }),
+);
+
+export default connect(mapStateToProps)(SummaryProtein);

--- a/src/components/Protein/Summary/index.js
+++ b/src/components/Protein/Summary/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from 'react';
+import React from 'react';
 import T from 'prop-types';
 
 import GoTerms from 'components/GoTerms';
@@ -48,7 +48,6 @@ const SchemaOrgData = loadable({
 const SummaryProtein = (
   { data, loading } /*: {data: Object, loading: boolean} */,
 ) => {
-  const [isoform, setIsoform] = useState('');
   if (loading || !data || !data.metadata) return <Loading />;
   const metadata = data.metadata;
 
@@ -207,7 +206,7 @@ const SummaryProtein = (
           </div>
         </div>
       </section>
-      <IsoformViewer isoform={isoform} />
+      <IsoformViewer />
       <section>
         <div className={f('row')}>
           <div className={f('medium-12', 'columns', 'margin-bottom-large')}>

--- a/src/components/Protein/Summary/style.css
+++ b/src/components/Protein/Summary/style.css
@@ -1,0 +1,19 @@
+.splitfullscreen {
+  display: flex;
+  background-color: white;
+  overflow: scroll;
+  & > * {
+    width: 50%;
+  }
+}
+.comparison-button {
+  margin-left: 0.3em;
+}
+@media (orientation: portrait) {
+  .splitfullscreen {
+    flex-direction: column;
+    & > * {
+      width: 100%;
+    }
+  }
+}

--- a/src/components/Protein/Summary/test.js
+++ b/src/components/Protein/Summary/test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
-import SummaryProtein from '.';
+import { SummaryProtein } from '.';
 
 const renderer = new ShallowRenderer();
 

--- a/src/components/Related/DomainsOnProtein/index.js
+++ b/src/components/Related/DomainsOnProtein/index.js
@@ -130,8 +130,8 @@ const processConservationData = (entry, match) => {
 };
 
 const addExistingEntiesToConservationResults = (
-  data,
-  conservationDatabases,
+  data /*: {[string]: Array<Object>} */,
+  conservationDatabases /*: Array<string> */,
 ) => {
   /* eslint-disable max-depth */
   for (const matches of [data.domain, data.family, data.repeat]) {
@@ -154,7 +154,10 @@ const addExistingEntiesToConservationResults = (
   }
 };
 
-const mergeConservationData = (data, conservationData) => {
+const mergeConservationData = (
+  data /*: { match_conservation?: Array<Object>} */,
+  conservationData /*: { [string]: {entries: ?{}}} */,
+) => {
   data.match_conservation = [];
   const conservationDatabases = [];
   for (const db of Object.keys(conservationData)) {
@@ -182,7 +185,7 @@ const mergeConservationData = (data, conservationData) => {
           }
         }
         /* eslint-enable max-depth */
-        data.match_conservation.push(dbConservationScores);
+        data.match_conservation?.push(dbConservationScores);
         // add data from integrated and unintegrated matches to panel for ease of use
         addExistingEntiesToConservationResults(data, conservationDatabases);
       }
@@ -191,7 +194,9 @@ const mergeConservationData = (data, conservationData) => {
 };
 
 const mergeResidues = (data, residues) => {
-  Object.values(data).forEach((group) =>
+  // prettier-ignore
+  (Object.values(data)/*: any */).forEach(
+    (group/*: Array<{accession:string, residues: Array<Object>, children: any}> */) =>
     group.forEach((entry) => {
       if (residues[entry.accession])
         entry.residues = [residues[entry.accession]];
@@ -243,7 +248,8 @@ const mergeExtraFeatures = (data, extraFeatures) => {
     );
   }
   data.other_features = data.other_features.concat(
-    Object.values(extraFeatures).filter(
+    // prettier-ignore
+    (Object.values(extraFeatures)/*: any */).filter(
       ({ source_database: db }) => db !== 'mobidblt',
     ),
   );
@@ -258,7 +264,9 @@ export const groupByEntryType = (interpro) => {
     if (!groups[entry.type]) groups[entry.type] = [];
     groups[entry.type].push(entry);
   }
-  Object.values(groups).forEach((g) => g.sort(orderByAccession));
+  // prettier-ignore
+  (Object.values(groups) /*: any */)
+    .forEach((g) => g.sort(orderByAccession));
   return groups;
 };
 
@@ -287,7 +295,7 @@ export const byEntryType = ([a], [b]) => {
   return a > b ? 1 : 0;
 };
 
-const getExtraURL = (query) =>
+const getExtraURL = (query /*: string */) =>
   createSelector(
     (state) => state.settings.api,
     (state) => state.customLocation.description,
@@ -308,8 +316,9 @@ const getExtraURL = (query) =>
 /*:: type Props = {
   mainData: Object,
   dataMerged: Object,
-  showConservationButton: boolean,
-  handleConservationLoad: function,
+  showConservationButton?: boolean,
+  handleConservationLoad?: function,
+  children: any,
 }; */
 export class DomainOnProteinWithoutMergedData extends PureComponent /*:: <Props> */ {
   static propTypes = {
@@ -350,7 +359,12 @@ export class DomainOnProteinWithoutMergedData extends PureComponent /*:: <Props>
   }
 }
 
-const ConservationProvider = ({ handleLoaded, dataConservation }) => {
+const ConservationProvider = (
+  {
+    handleLoaded,
+    dataConservation,
+  } /*: { handleLoaded: function, dataConservation?: { loading: boolean, payload: {}} } */,
+) => {
   useEffect(() => {
     if (
       dataConservation &&
@@ -362,21 +376,37 @@ const ConservationProvider = ({ handleLoaded, dataConservation }) => {
   });
   return null;
 };
+ConservationProvider.propTypes = {
+  handleLoaded: T.func,
+  dataConservation: T.shape({
+    loading: T.bool,
+    payload: T.object,
+  }),
+};
 
 const ConservationProviderLoaded = loadData({
   getUrl: getExtraURL('conservation'),
   propNamespace: 'Conservation',
 })(ConservationProvider);
 
-/*:: type DPWithoutDataProps = {
+/*::
+type DPWithoutDataProps = {
   mainData: Object,
   data: Object,
   dataResidues: Object,
   dataFeatures: Object,
-  dataGenome3d: Object
-}; */
+  dataGenome3d: Object,
+  children: mixed,
+};
+type DPState ={
+  generateConservationData: boolean,
+  showConservationButton: boolean,
+  dataConservation: ?{ [string]: {entries: ?{}}},
 
-export class DomainOnProteinWithoutData extends PureComponent /*:: <DPWithoutDataProps> */ {
+}
+*/
+
+export class DomainOnProteinWithoutData extends PureComponent /*:: <DPWithoutDataProps, DPState> */ {
   static propTypes = {
     mainData: T.object.isRequired,
     data: T.object.isRequired,
@@ -386,7 +416,7 @@ export class DomainOnProteinWithoutData extends PureComponent /*:: <DPWithoutDat
     children: T.any,
   };
 
-  constructor(props /*: Props */) {
+  constructor(props /*: DPWithoutDataProps */) {
     super(props);
     this.state = {
       generateConservationData: false,
@@ -493,8 +523,9 @@ export class DomainOnProteinWithoutData extends PureComponent /*:: <DPWithoutDat
 
     if (
       !Object.keys(mergedData).length ||
-      !Object.values(mergedData)
-        .map((x) => x.length)
+      // prettier-ignore
+      !(Object.values(mergedData)/*: any */)
+        .map((x/*: Array<Object> */) => x.length)
         .reduce((agg, v) => agg + v, 0)
     ) {
       return <div className={f('callout')}>No entries match this protein.</div>;

--- a/src/components/Related/DomainsOnProtein/index.js
+++ b/src/components/Related/DomainsOnProtein/index.js
@@ -251,7 +251,7 @@ const mergeExtraFeatures = (data, extraFeatures) => {
 };
 
 const orderByAccession = (a, b) => (a.accession > b.accession ? 1 : -1);
-const groupByEntryType = (interpro) => {
+export const groupByEntryType = (interpro) => {
   const groups = {};
   for (const entry of interpro) {
     if (!groups[entry.type]) groups[entry.type] = [];

--- a/src/components/Related/DomainsOnProtein/index.js
+++ b/src/components/Related/DomainsOnProtein/index.js
@@ -1,3 +1,4 @@
+// @flow
 /* eslint-disable no-param-reassign */
 import React, { PureComponent, useEffect } from 'react';
 import T from 'prop-types';
@@ -262,7 +263,7 @@ export const groupByEntryType = (interpro) => {
 };
 
 const UNDERSCORE = /_/g;
-const sortFunction = ([a], [b]) => {
+export const byEntryType = ([a], [b]) => {
   const firsts = [
     'family',
     'domain',
@@ -327,7 +328,7 @@ export class DomainOnProteinWithoutMergedData extends PureComponent /*:: <Props>
       handleConservationLoad,
     } = this.props;
     const sortedData = Object.entries(dataMerged)
-      .sort(sortFunction)
+      .sort(byEntryType)
       // “Binding_site” -> “Binding site”
       .map(([key, value]) => [
         key === 'ptm' ? 'PTM' : key.replace(UNDERSCORE, ' '),

--- a/src/components/SimpleCommonComponents/FullScreenButton/index.js
+++ b/src/components/SimpleCommonComponents/FullScreenButton/index.js
@@ -19,9 +19,10 @@ const FullScreenButton = (
     tooltip,
     className,
     dataIcon,
+    disabled = false,
     onFullScreenHook = noop,
     onExitFullScreenHook = noop,
-  } /*: {onFullScreenHook?: function,onExitFullScreenHook?: function, element?: any, tooltip: string, className?: string, dataIcon?: string} */,
+  } /*: {onFullScreenHook?: function,onExitFullScreenHook?: function, element?: any, tooltip: string, className?: string, dataIcon?: string, disabled?: boolean} */,
 ) => {
   const [isFull, setFull] = useState(false);
   const onFullscreen = () => {
@@ -55,6 +56,7 @@ const FullScreenButton = (
         data-icon={icon}
         title="Full screen"
         className={_className}
+        disabled={disabled}
       />
     </Tooltip>
   );
@@ -68,6 +70,7 @@ FullScreenButton.propTypes = {
   tooltip: T.string,
   className: T.string,
   dataIcon: T.string,
+  disabled: T.bool,
 };
 
 export default FullScreenButton;

--- a/stories/Link.stories.js
+++ b/stories/Link.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';


### PR DESCRIPTION
A few improvements when displaying protein isoforms:

* The selected isoform is now included in the URL (e.g. `protein/UniProt/P31749/?isoform=P31749-2`) and corresponding part of the redux state (e.g. `{customLocation: {search: {isoform: 'P31749-2'}, ...}, ...}`)
* The order and groups on the protvista graphic for an isoform is similar to the one for a protein. Only missing residues and extra features because that data is not available for isoforms
* When an isoform is selected, it could be displayed fullscreen together with the protein for comparison purposes.