### PR TITLE
"Color by" propagates to multiple protvista instances in the same page

### DIFF
--- a/src/components/ProtVista/Options/index.js
+++ b/src/components/ProtVista/Options/index.js
@@ -6,7 +6,7 @@ import loadWebComponent from 'utils/load-web-component';
 import ProtvistaSaver from 'protvista-saver';
 
 import Tooltip from 'components/SimpleCommonComponents/Tooltip';
-import { getTrackColor, EntryColorMode } from 'utils/entry-color';
+import { EntryColorMode } from 'utils/entry-color';
 import ReactToPrint from 'react-to-print';
 import FullScreenButton from 'components/SimpleCommonComponents/FullScreenButton';
 import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
@@ -164,12 +164,6 @@ class ProtVistaOptions extends Component /*:: <Props, State> */ {
   };
 
   changeColor = ({ target: { value: colorMode } }) => {
-    for (const track of (Object.values(this.props.webTracks) /*: any */)) {
-      for (const d of [...track._data, ...(track._contributors || [])]) {
-        d.color = getTrackColor(d, colorMode);
-      }
-      track.refresh();
-    }
     this.props.changeSettingsRaw('ui', 'colorDomainsBy', colorMode);
   };
 

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -214,6 +214,13 @@ export class ProtVista extends Component /*:: <Props, State> */ {
         this._webProteinRef.current.data = this.props.protein;
         this._hydroRef.current.data = this.props.protein;
       }
+    } else if (prevProps.colorDomainsBy !== this.props.colorDomainsBy) {
+      for (const track of (Object.values(this.web_tracks) /*: any */)) {
+        for (const d of [...track._data, ...(track._contributors || [])]) {
+          d.color = getTrackColor(d, this.props.colorDomainsBy);
+        }
+        track.refresh();
+      }
     }
   }
 


### PR DESCRIPTION
Fix: #296 

The `<Options>` component only set the ColorBy setting dispatching an action.

The actual effect of coloring by is now in the `componentDidUpdate` of `<ProtVista>`