### PR TITLE
Minor ipscan changes

### DIFF
--- a/src/components/IPScan/Actions/__snapshots__/test.js.snap
+++ b/src/components/IPScan/Actions/__snapshots__/test.js.snap
@@ -1,9 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Actions /> should render 1`] = `
-<React.Fragment>
+<nav
+  className="buttons"
+>
   <Tooltip
-    title="Delete job"
+    title={
+      <div>
+        <b>
+          Delete job
+        </b>
+        : This remove this job from your browser. Remember that job's data is only kept in our servers for 7 days
+      </div>
+    }
   >
     <button
       aria-label="Delete job"
@@ -12,5 +21,22 @@ exports[`<Actions /> should render 1`] = `
       onClick={[Function]}
     />
   </Tooltip>
-</React.Fragment>
+  <Tooltip
+    title={
+      <div>
+        <b>
+          Save in Browser
+        </b>
+        : If you save the data of this job in your browser, you will be able to display it here even if it gets deleted in our servers or you lost internet connection.
+      </div>
+    }
+  >
+    <button
+      aria-label="Save in Browser"
+      className="icon icon-common ico-neutral"
+      data-icon="S"
+      onClick={[Function]}
+    />
+  </Tooltip>
+</nav>
 `;

--- a/src/components/IPScan/Actions/__snapshots__/test.js.snap
+++ b/src/components/IPScan/Actions/__snapshots__/test.js.snap
@@ -8,14 +8,14 @@ exports[`<Actions /> should render 1`] = `
     title={
       <div>
         <b>
-          Delete job
+          Delete search
         </b>
-        : This remove this job from your browser. Remember that job's data is only kept in our servers for 7 days
+        : This will remove the stored data from your browser. Remember that search results are only retained on our servers for 7 days
       </div>
     }
   >
     <button
-      aria-label="Delete job"
+      aria-label="Delete Results"
       className="icon icon-common ico-neutral"
       data-icon=""
       onClick={[Function]}
@@ -25,14 +25,14 @@ exports[`<Actions /> should render 1`] = `
     title={
       <div>
         <b>
-          Save in Browser
+          Save results in Browser
         </b>
-        : If you save the data of this job in your browser, you will be able to display it here even if it gets deleted in our servers or you lost internet connection.
+        : If you save the results of this search in your browser, you will be able to view it here even after it is deleted from our servers or when you are offline.
       </div>
     }
   >
     <button
-      aria-label="Save in Browser"
+      aria-label="Save results in Browser"
       className="icon icon-common ico-neutral"
       data-icon="S"
       onClick={[Function]}

--- a/src/components/IPScan/Actions/index.js
+++ b/src/components/IPScan/Actions/index.js
@@ -79,9 +79,9 @@ export class Actions extends PureComponent /*:: <Props> */ {
         <Tooltip
           title={
             <div>
-              <b>Delete job</b>: This remove this job from your browser.
-              Remember that job&apos;s data is only kept in our servers for 7
-              days
+              <b>Delete search</b>: This will remove the stored data from your
+              browser. Remember that search results are only retained on our
+              servers for 7 days
             </div>
           }
         >
@@ -89,16 +89,16 @@ export class Actions extends PureComponent /*:: <Props> */ {
             className={f('icon', 'icon-common', 'ico-neutral')}
             onClick={this._handleDelete}
             data-icon="&#xf1f8;"
-            aria-label="Delete job"
+            aria-label="Delete Results"
           />
         </Tooltip>
         {status === 'finished' && (
           <Tooltip
             title={
               <div>
-                <b>Save in Browser</b>: If you save the data of this job in your
-                browser, you will be able to display it here even if it gets
-                deleted in our servers or you lost internet connection.
+                <b>Save results in Browser</b>: If you save the results of this
+                search in your browser, you will be able to view it here even
+                after it is deleted from our servers or when you are offline.
               </div>
             }
           >
@@ -106,7 +106,7 @@ export class Actions extends PureComponent /*:: <Props> */ {
               className={f('icon', 'icon-common', 'ico-neutral')}
               data-icon="&#x53;"
               onClick={() => keepJobAsLocal(localID)}
-              aria-label="Save in Browser"
+              aria-label="Save results in Browser"
             />
           </Tooltip>
         )}

--- a/src/components/IPScan/Actions/index.js
+++ b/src/components/IPScan/Actions/index.js
@@ -80,7 +80,8 @@ export class Actions extends PureComponent /*:: <Props> */ {
           title={
             <div>
               <b>Delete job</b>: This remove this job from your browser.
-              Remember that job's data is only keep in our servers for 7 days
+              Remember that job&apos;s data is only kept in our servers for 7
+              days
             </div>
           }
         >

--- a/src/components/IPScan/Actions/index.js
+++ b/src/components/IPScan/Actions/index.js
@@ -5,7 +5,12 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import Tooltip from 'components/SimpleCommonComponents/Tooltip';
-import { updateJob, deleteJob, goToCustomLocation } from 'actions/creators';
+import {
+  updateJob,
+  deleteJob,
+  goToCustomLocation,
+  keepJobAsLocal,
+} from 'actions/creators';
 import { foundationPartial } from 'styles/foundation';
 
 import ipro from 'styles/interpro-new.css';
@@ -16,21 +21,25 @@ const f = foundationPartial(fonts, ipro, local);
 
 /*:: type Props = {
   localID: string,
+  status: string,
   withTitle: boolean,
   jobs: Object,
   updateJob: function,
   deleteJob: function,
-  goToCustomLocation: function
+  goToCustomLocation: function,
+  keepJobAsLocal: function
 }*/
 
 export class Actions extends PureComponent /*:: <Props> */ {
   static propTypes = {
     localID: T.string.isRequired,
+    status: T.string,
     withTitle: T.bool,
     jobs: T.object.isRequired,
     updateJob: T.func.isRequired,
     deleteJob: T.func.isRequired,
     goToCustomLocation: T.func.isRequired,
+    keepJobAsLocal: T.func.isRequired,
   };
 
   _handleSaveToggle = () => {
@@ -52,10 +61,10 @@ export class Actions extends PureComponent /*:: <Props> */ {
 
   render() {
     // const { localID, withTitle, jobs } = this.props;
-    const { withTitle } = this.props;
+    const { withTitle, status, localID, keepJobAsLocal } = this.props;
     // const { saved } = (jobs[localID] || {}).metadata || {};
     return (
-      <>
+      <nav className={f('buttons')}>
         {withTitle && 'Actions: '}
         {/* <Tooltip title="Save job"> */}
         {/* <button */}
@@ -67,7 +76,14 @@ export class Actions extends PureComponent /*:: <Props> */ {
         {/* ★ */}
         {/* </button> */}
         {/* </Tooltip> */}
-        <Tooltip title="Delete job">
+        <Tooltip
+          title={
+            <div>
+              <b>Delete job</b>: This remove this job from your browser.
+              Remember that job's data is only keep in our servers for 7 days
+            </div>
+          }
+        >
           <button
             className={f('icon', 'icon-common', 'ico-neutral')}
             onClick={this._handleDelete}
@@ -75,18 +91,37 @@ export class Actions extends PureComponent /*:: <Props> */ {
             aria-label="Delete job"
           />
         </Tooltip>
-      </>
+        {status === 'finished' && (
+          <Tooltip
+            title={
+              <div>
+                <b>Save in Browser</b>: If you save the data of this job in your
+                browser, you will be able to display it here even if it gets
+                deleted in our servers or you lost internet connection.
+              </div>
+            }
+          >
+            <button
+              className={f('icon', 'icon-common', 'ico-neutral')}
+              data-icon="&#x53;"
+              onClick={() => keepJobAsLocal(localID)}
+              aria-label="Save in Browser"
+            />
+          </Tooltip>
+        )}
+      </nav>
     );
   }
 }
 
 const mapStateToProps = createSelector(
-  state => state.jobs,
-  jobs => ({ jobs }),
+  (state) => state.jobs,
+  (jobs) => ({ jobs }),
 );
 
 export default connect(mapStateToProps, {
   updateJob,
   deleteJob,
   goToCustomLocation,
+  keepJobAsLocal,
 })(Actions);

--- a/src/components/IPScan/Actions/style.css
+++ b/src/components/IPScan/Actions/style.css
@@ -1,3 +1,10 @@
 .button {
   margin-bottom: 0;
 }
+
+.buttons {
+  display: flex;
+  & button {
+    margin-right: 1em;
+  }
+}

--- a/src/components/IPScan/Actions/test.js
+++ b/src/components/IPScan/Actions/test.js
@@ -29,8 +29,10 @@ describe('<Actions />', () => {
         }}
         deleteJob={() => {}}
         goToCustomLocation={() => {}}
+        keepJobAsLocal={() => {}}
         updateJob={() => {}}
         withTitle={false}
+        status="finished"
       />,
     );
     expect(renderer.getRenderOutput()).toMatchSnapshot();

--- a/src/components/IPScan/IPScanVersionCheck/index.js
+++ b/src/components/IPScan/IPScanVersionCheck/index.js
@@ -12,6 +12,7 @@ import ebiGlobalStyles from 'ebi-framework/css/ebi-global.css';
 
 const f = foundationPartial(ebiGlobalStyles, fonts);
 
+const DAYS_TO_UPDATE_IPSCAN = 5;
 /*::
   type Props = {
     data?: {
@@ -30,6 +31,7 @@ const IPScanVersionCheck = ({ data, ipScanVersion } /*: Props */) => {
   );
   const [_, jobVersion] = (ipScanVersion || '').split('-');
 
+  // eslint-disable-next-line no-magic-numbers
   const msPerDay = 24 * 60 * 60 * 1000; // Number of milliseconds per day
   const daysSinceRelease = Math.round(
     (new Date().getTime() - currentVersionReleaseDate.getTime()) / msPerDay,
@@ -48,7 +50,7 @@ const IPScanVersionCheck = ({ data, ipScanVersion } /*: Props */) => {
           been deleted or changed in the current version{' '}
           <code>{currentVersion}</code>.
         </p>
-        {daysSinceRelease < 5 ? (
+        {daysSinceRelease < DAYS_TO_UPDATE_IPSCAN ? (
           <p>
             <b>Note:</b>
             InterPro version <code>{currentVersion}</code> has been released on{' '}

--- a/src/components/IPScan/IPScanVersionCheck/index.js
+++ b/src/components/IPScan/IPScanVersionCheck/index.js
@@ -22,15 +22,23 @@ const f = foundationPartial(ebiGlobalStyles, fonts);
   }
 */
 
-const IPScanVersionCheck = ({ data, ipScanVersion }) => {
+const IPScanVersionCheck = ({ data, ipScanVersion } /*: Props */) => {
   if (!data || data.loading) return <Loading inline={true} />;
   const currentVersion = data.payload?.databases?.interpro?.version;
+  const currentVersionReleaseDate = new Date(
+    data.payload?.databases?.interpro?.releaseDate,
+  );
   const [_, jobVersion] = (ipScanVersion || '').split('-');
+
+  const msPerDay = 24 * 60 * 60 * 1000; // Number of milliseconds per day
+  const daysSinceRelease = Math.round(
+    (new Date().getTime() - currentVersionReleaseDate.getTime()) / msPerDay,
+  );
 
   if (currentVersion !== jobVersion) {
     return (
       <div className={f('callout', 'info', 'withicon')}>
-        <b>Mismatched Version</b>
+        <h4 style={{ display: 'inline-block' }}>Mismatched Version</h4>
         <p>
           InterProScan version: <code>{ipScanVersion}</code>.
         </p>
@@ -40,6 +48,16 @@ const IPScanVersionCheck = ({ data, ipScanVersion }) => {
           been deleted or changed in the current version{' '}
           <code>{currentVersion}</code>.
         </p>
+        {daysSinceRelease < 5 ? (
+          <p>
+            <b>Note:</b>
+            InterPro version <code>{currentVersion}</code> has been released on{' '}
+            <i>{currentVersionReleaseDate.toLocaleDateString()}</i>. We are
+            still in the process of updating the InterProScan web service which
+            might take up to 5 days. This might explain version mismatches of
+            recently submitted jobs.
+          </p>
+        ) : null}
       </div>
     );
   }

--- a/src/components/IPScan/IPScanVersionCheck/index.js
+++ b/src/components/IPScan/IPScanVersionCheck/index.js
@@ -24,7 +24,7 @@ const DAYS_TO_UPDATE_IPSCAN = 5;
 */
 
 const IPScanVersionCheck = ({ data, ipScanVersion } /*: Props */) => {
-  if (!data || data.loading) return <Loading inline={true} />;
+  if (!data || data.loading || !ipScanVersion) return <Loading inline={true} />;
   const currentVersion = data.payload?.databases?.interpro?.version;
   const currentVersionReleaseDate = new Date(
     data.payload?.databases?.interpro?.releaseDate,
@@ -45,9 +45,9 @@ const IPScanVersionCheck = ({ data, ipScanVersion } /*: Props */) => {
           InterProScan version: <code>{ipScanVersion}</code>.
         </p>
         <p>
-          Some links might not work as they uploaded a result from a previous
-          release of InterPro <code>{jobVersion}</code> and the data might have
-          been deleted or changed in the current version{' '}
+          Some links might not work as the results are from a previous release
+          of InterPro {jobVersion ? <code>{jobVersion}</code> : null} and some
+          of the data might have been deleted or changed in the current version{' '}
           <code>{currentVersion}</code>.
         </p>
         {daysSinceRelease < DAYS_TO_UPDATE_IPSCAN ? (

--- a/src/components/IPScan/Status/index.js
+++ b/src/components/IPScan/Status/index.js
@@ -267,7 +267,9 @@ export class IPScanStatus extends PureComponent /*:: <Props> */ {
                     aria-label="Job failed or not found"
                   />
                 ) : null}
-                {['finished', 'imported file'].includes(status) && (
+                {['finished', 'imported file', 'saved in browser'].includes(
+                  status,
+                ) && (
                   <Link
                     to={{
                       description: {

--- a/src/components/IPScan/Summary/IPScanTitle/index.js
+++ b/src/components/IPScan/Summary/IPScanTitle/index.js
@@ -74,7 +74,7 @@ const IPScanTitle = (
           readOnly={readable}
           style={{ width: `${title.length}ch` }}
         />
-        {['finished', 'imported file'].includes(status) ? (
+        {['finished', 'imported file', 'saved in browser'].includes(status) ? (
           <button
             onClick={() =>
               changeTitle(

--- a/src/components/IPScan/Summary/index.js
+++ b/src/components/IPScan/Summary/index.js
@@ -32,7 +32,7 @@ import IPScanVersionCheck from 'components/IPScan/IPScanVersionCheck';
 import NucleotideSummary from 'components/IPScan/NucleotideSummary';
 import IPScanTitle from './IPScanTitle';
 import { Exporter } from 'components/Table';
-import { updateJobTitle, keepJobAsLocal } from 'actions/creators';
+import { updateJobTitle } from 'actions/creators';
 
 import { foundationPartial } from 'styles/foundation';
 import fonts from 'EBI-Icon-fonts/fonts.css';
@@ -120,7 +120,7 @@ const _StatusTooltip = ({ status /*: string */ }) => (
         {status}
       </>
     ) : null}
-    {['finished', 'imported file'].includes(status) && (
+    {['finished', 'imported file', 'saved in browser'].includes(status) && (
       <>
         <span
           className={f('icon', 'icon-common', 'ico-confirmed')}
@@ -138,6 +138,7 @@ _StatusTooltip.propTypes = {
     'created',
     'importing',
     'imported file',
+    'saved in browser',
     'submitted',
     'not found',
     'failure',
@@ -257,7 +258,6 @@ const SummaryIPScanJob = ({
   localPayload,
   api,
   updateJobTitle,
-  keepJobAsLocal,
 }) => {
   const [mergedData, setMergedData] = useState({});
   const [familyHierarchyData, setFamilyHierarchyData] = useState([]);
@@ -377,7 +377,7 @@ const SummaryIPScanJob = ({
           <section className={f('summary-row')}>
             <header>Action</header>
             <section>
-              <Actions localID={localID} />
+              <Actions localID={localID} status={status} />
             </section>
           </section>
         )}
@@ -405,16 +405,6 @@ const SummaryIPScanJob = ({
             </header>
             <section>
               {new Date(created + MAX_TIME_ON_SERVER).toDateString()}
-              <div>
-                <button
-                  className={f('button', 'icon', 'icon-common')}
-                  data-icon="&#x53;"
-                  onClick={() => keepJobAsLocal(localID)}
-                >
-                  {' '}
-                  Save in Browser
-                </button>
-              </div>
             </section>
           </section>
         )}
@@ -438,7 +428,7 @@ const SummaryIPScanJob = ({
         </div>
       </section>
 
-      {['finished', 'imported file'].includes(status) && (
+      {['finished', 'imported file', 'saved in browser'].includes(status) && (
         <>
           <DomainOnProteinWithoutMergedData
             mainData={{ metadata }}
@@ -478,7 +468,6 @@ SummaryIPScanJob.propTypes = {
   localPayload: T.object,
   api: T.object,
   updateJobTitle: T.func,
-  keepJobAsLocal: T.func,
 };
 
 const jobMapSelector = (state) => state.jobs;
@@ -514,6 +503,4 @@ const mapStateToProps = createSelector(
   }),
 );
 
-export default connect(mapStateToProps, { updateJobTitle, keepJobAsLocal })(
-  SummaryIPScanJob,
-);
+export default connect(mapStateToProps, { updateJobTitle })(SummaryIPScanJob);

--- a/src/components/IPScan/Summary/index.js
+++ b/src/components/IPScan/Summary/index.js
@@ -333,11 +333,11 @@ const SummaryIPScanJob = ({
     <div className={f('sections')}>
       <section>
         <Title metadata={metadata} mainType="protein" />
-        {data.payload ? null : (
+        {!data.payload && payload?.['interproscan-version'] ? (
           <div className={f('callout', 'info', 'withicon')}>
             Using data stored in your browser
           </div>
-        )}
+        ) : null}
         <IPScanVersionCheck ipScanVersion={payload['interproscan-version']} />
         <NucleotideSummary payload={payload} />
         <IPScanTitle

--- a/src/reducers/jobs/index.js
+++ b/src/reducers/jobs/index.js
@@ -56,7 +56,7 @@ export default (
           ...state[action.localID],
           metadata: {
             ...state[action.localID].metadata,
-            status: 'imported file',
+            status: 'saved in browser',
           },
         },
       };

--- a/src/reducers/jobs/metadata/index.js
+++ b/src/reducers/jobs/metadata/index.js
@@ -6,7 +6,7 @@ import {
   IMPORT_JOB_FROM_DATA,
 } from 'actions/types';
 
-/*:: type JobStatus = 'created' | 'submitted' | 'failed' | 'importing' | 'imported file' | 'running' | 'finished'; */
+/*:: type JobStatus = 'created' | 'submitted' | 'failed' | 'importing' | 'imported file' | 'saved in browser' | 'running' | 'finished'; */
 
 /*:: export type JobMetadata = {|
   localID: ?string,

--- a/src/store/enhancer/jobs-middleware/index.js
+++ b/src/store/enhancer/jobs-middleware/index.js
@@ -54,7 +54,7 @@ const rehydrateStoredJobs = async (dispatch) => {
     // if job expired on server, delete it
     if (
       now - (metadata.times.created || now) > MAX_TIME_ON_SERVER &&
-      metadata.status !== 'imported file'
+      !['saved in browser', 'imported file'].includes(metadata.status)
     ) {
       deleteJobInDB(localID);
     } else {
@@ -306,7 +306,7 @@ const middleware /*: Middleware<*, *, *> */ = ({ dispatch, getState }) => {
     if (action.type === KEEP_JOB_AS_LOCAL) {
       updateJobInDB({
         ...getState().jobs[action.localID].metadata,
-        status: 'imported file',
+        status: 'saved in browser',
       });
     }
 


### PR DESCRIPTION
A few changes related in the interproscan results area:

1. Save in Browser moved to the actions row in the result's summary.
2. New state for a job: `saved in browser` to differentiate wwwprod jobs that have been saved from loaded files.
3. The mismatched version warning has been updated to include a message when there is a new version of InterProData and wwwprod hasn't updated interproscan.