### PR TITLE
Zip cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9109,6 +9109,14 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+          "dev": true
+        }
       }
     },
     "browserslist": {
@@ -20021,10 +20029,9 @@
       }
     },
     "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -27045,6 +27052,14 @@
       "dev": true,
       "requires": {
         "pako": "^1.0.5"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+          "dev": true
+        }
       }
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "nightingale-heatmap": "^3.2.11",
     "nightingale-linegraph-track": "3.4.0",
     "nightingale-sunburst": "3.5.7",
+    "pako": "2.0.4",
     "popper.js": "1.16.1",
     "postcss": "8.3.9",
     "prop-types": "15.7.2",


### PR DESCRIPTION
The client cache is saved in localStorage, but this type of storage has a max size for the things to save there, which depends on the browser.

So I have added a compression layer for big entries that need to be saved in the cache. 

Only adding this in API response with more than 40000 character, from what I have read the limit in modern browsers is around 52000. Anything smaller just gets saved directly in the cache to save time.

The only con that I see with this approach is that it adds 40k to the initial JS file, but please let me know if you think of any other issue with this.

p.s. I'm doing the PR into `taxonomy-sunburst` from where I branched to do this.
