### PR TITLE
Rerun ipscan

### DIFF
--- a/src/components/IPScan/Actions/index.js
+++ b/src/components/IPScan/Actions/index.js
@@ -23,11 +23,13 @@ const f = foundationPartial(fonts, ipro, local);
   localID: string,
   status: string,
   withTitle: boolean,
+  versionMismatch: boolean,
   jobs: Object,
   updateJob: function,
   deleteJob: function,
   goToCustomLocation: function,
-  keepJobAsLocal: function
+  keepJobAsLocal: function,
+  sequence: string,
 }*/
 
 export class Actions extends PureComponent /*:: <Props> */ {
@@ -35,17 +37,31 @@ export class Actions extends PureComponent /*:: <Props> */ {
     localID: T.string.isRequired,
     status: T.string,
     withTitle: T.bool,
+    versionMismatch: T.bool,
     jobs: T.object.isRequired,
     updateJob: T.func.isRequired,
     deleteJob: T.func.isRequired,
     goToCustomLocation: T.func.isRequired,
     keepJobAsLocal: T.func.isRequired,
+    sequence: T.string.isRequired,
   };
 
   _handleSaveToggle = () => {
     const { localID, jobs, updateJob } = this.props;
     const { metadata } = jobs[localID];
     updateJob({ metadata: { ...metadata, saved: !metadata.saved } });
+  };
+  _handleReRun = () => {
+    const { sequence, goToCustomLocation } = this.props;
+    goToCustomLocation({
+      description: {
+        main: { key: 'search' },
+        search: {
+          type: 'sequence',
+          value: (sequence || '').match(/(.{1,60})/g).join('\n'),
+        },
+      },
+    });
   };
 
   _handleDelete = () => {
@@ -61,7 +77,8 @@ export class Actions extends PureComponent /*:: <Props> */ {
 
   render() {
     // const { localID, withTitle, jobs } = this.props;
-    const { withTitle, status, localID, keepJobAsLocal } = this.props;
+    const { withTitle, status, localID, keepJobAsLocal, versionMismatch } =
+      this.props;
     // const { saved } = (jobs[localID] || {}).metadata || {};
     return (
       <nav className={f('buttons')}>
@@ -107,6 +124,24 @@ export class Actions extends PureComponent /*:: <Props> */ {
               data-icon="&#x53;"
               onClick={() => keepJobAsLocal(localID)}
               aria-label="Save results in Browser"
+            />
+          </Tooltip>
+        )}
+        {versionMismatch && (
+          <Tooltip
+            title={
+              <div>
+                <b>Execute the job again</b>: We detected the current results
+                were executed with a previous version of InterProScan. Click in
+                the button to create a new job with the most recent version.
+              </div>
+            }
+          >
+            <button
+              className={f('icon', 'icon-common', 'ico-neutral')}
+              data-icon="&#xf1da;"
+              onClick={this._handleReRun}
+              aria-label="Execute the job again"
             />
           </Tooltip>
         )}

--- a/src/components/IPScan/Actions/index.js
+++ b/src/components/IPScan/Actions/index.js
@@ -23,13 +23,18 @@ const f = foundationPartial(fonts, ipro, local);
   localID: string,
   status: string,
   withTitle: boolean,
-  versionMismatch: boolean,
+  versionMismatch?: boolean,
   jobs: Object,
   updateJob: function,
   deleteJob: function,
   goToCustomLocation: function,
   keepJobAsLocal: function,
-  sequence: string,
+  sequence?: string,
+  attributes?: {
+    applications: string[] | null,
+    goterms: boolean | null,
+    pathways: boolean | null,
+  }
 }*/
 
 export class Actions extends PureComponent /*:: <Props> */ {
@@ -44,6 +49,11 @@ export class Actions extends PureComponent /*:: <Props> */ {
     goToCustomLocation: T.func.isRequired,
     keepJobAsLocal: T.func.isRequired,
     sequence: T.string.isRequired,
+    attributes: T.shape({
+      applications: T.arrayOf(T.string),
+      goterms: T.bool,
+      pathways: T.bool,
+    }),
   };
 
   _handleSaveToggle = () => {
@@ -52,15 +62,22 @@ export class Actions extends PureComponent /*:: <Props> */ {
     updateJob({ metadata: { ...metadata, saved: !metadata.saved } });
   };
   _handleReRun = () => {
-    const { sequence, goToCustomLocation } = this.props;
+    const { sequence, attributes, goToCustomLocation } = this.props;
+    const search = {};
+    if (attributes?.applications) search.applications = attributes.applications;
+    if (![null, undefined].includes(attributes?.goterms))
+      search.goterms = !!attributes?.goterms;
+    if (![null, undefined].includes(attributes?.pathways))
+      search.pathways = !!attributes?.pathways;
     goToCustomLocation({
       description: {
         main: { key: 'search' },
         search: {
           type: 'sequence',
-          value: (sequence || '').match(/(.{1,60})/g).join('\n'),
+          value: ((sequence || '').match(/(.{1,60})/g) || []).join('\n'),
         },
       },
+      search,
     });
   };
 

--- a/src/components/IPScan/Actions/index.js
+++ b/src/components/IPScan/Actions/index.js
@@ -32,8 +32,6 @@ const f = foundationPartial(fonts, ipro, local);
   sequence?: string,
   attributes?: {
     applications: string[] | null,
-    goterms: boolean | null,
-    pathways: boolean | null,
   }
 }*/
 
@@ -51,8 +49,6 @@ export class Actions extends PureComponent /*:: <Props> */ {
     sequence: T.string.isRequired,
     attributes: T.shape({
       applications: T.arrayOf(T.string),
-      goterms: T.bool,
-      pathways: T.bool,
     }),
   };
 
@@ -65,10 +61,6 @@ export class Actions extends PureComponent /*:: <Props> */ {
     const { sequence, attributes, goToCustomLocation } = this.props;
     const search = {};
     if (attributes?.applications) search.applications = attributes.applications;
-    if (![null, undefined].includes(attributes?.goterms))
-      search.goterms = !!attributes?.goterms;
-    if (![null, undefined].includes(attributes?.pathways))
-      search.pathways = !!attributes?.pathways;
     goToCustomLocation({
       description: {
         main: { key: 'search' },

--- a/src/components/IPScan/Actions/style.css
+++ b/src/components/IPScan/Actions/style.css
@@ -5,6 +5,7 @@
 .buttons {
   display: flex;
   & button {
-    margin-right: 1em;
+    margin: 0 0.5rem;
+    cursor: pointer;
   }
 }

--- a/src/components/IPScan/AdvancedOptions/index.js
+++ b/src/components/IPScan/AdvancedOptions/index.js
@@ -94,12 +94,17 @@ const labels = new Map([
   ['PrositeProfiles', 'PROSITE profiles'],
   ['PrositePatterns', 'PROSITE patterns'],
 ]);
-const groupApplications = (applications) => {
+const groupApplications = (applications, initialOptions) => {
   const mdb1 = [];
   const mdb2 = [];
   const other = [];
   const noCategory = [];
   for (const application of applications) {
+    if (initialOptions?.applications?.length) {
+      application.defaultValue = initialOptions.applications.includes(
+        application.value,
+      );
+    }
     if (mdb1Values.has(application.value)) mdb1.push(application);
     else if (mdb2Values.has(application.value)) mdb2.push(application);
     else if (otherValues.has(application.value)) other.push(application);
@@ -164,6 +169,7 @@ export class AdvancedOptions extends PureComponent /*:: <AdvancedOptionsProps> *
     }).isRequired,
     title: T.string,
     changeTitle: T.func,
+    initialOptions: T.object,
   };
 
   constructor(props /*: AdvancedOptionsProps */) {
@@ -190,11 +196,13 @@ export class AdvancedOptions extends PureComponent /*:: <AdvancedOptionsProps> *
     const {
       data: { loading, payload, ok },
       title,
+      initialOptions,
     } = this.props;
     if (loading) return 'Loading…';
     if (!ok) return 'Failed…';
     const { mdb1, mdb2, other, noCategory } = groupApplications(
       payload.values.values,
+      initialOptions,
     );
     return (
       <div className={f('row')}>

--- a/src/components/IPScan/IPScanVersionCheck/index.js
+++ b/src/components/IPScan/IPScanVersionCheck/index.js
@@ -17,7 +17,11 @@ const DAYS_TO_UPDATE_IPSCAN = 5;
   type Props = {
     data?: {
       loading:Boolean,
-      payload: ?{databases: {}}
+      payload: ?{databases: {
+        [string]: {
+          [string]: any,
+        }
+      }}
     },
     ipScanVersion?: string,
     callback: boolean => void
@@ -27,7 +31,7 @@ const DAYS_TO_UPDATE_IPSCAN = 5;
 const IPScanVersionCheck = ({ data, ipScanVersion, callback } /*: Props */) => {
   const currentVersion = data?.payload?.databases?.interpro?.version;
   const currentVersionReleaseDate = new Date(
-    data?.payload?.databases?.interpro?.releaseDate,
+    data?.payload?.databases?.interpro?.releaseDate || 0,
   );
   const [_, jobVersion] = (ipScanVersion || '').split('-');
   useEffect(() => {

--- a/src/components/IPScan/IPScanVersionCheck/index.js
+++ b/src/components/IPScan/IPScanVersionCheck/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { useEffect } from 'react';
 import T from 'prop-types';
 
 import loadData from 'higherOrder/loadData';
@@ -20,23 +20,27 @@ const DAYS_TO_UPDATE_IPSCAN = 5;
       payload: ?{databases: {}}
     },
     ipScanVersion?: string,
+    callback: boolean => void
   }
 */
 
-const IPScanVersionCheck = ({ data, ipScanVersion } /*: Props */) => {
-  if (!data || data.loading || !ipScanVersion) return <Loading inline={true} />;
-  const currentVersion = data.payload?.databases?.interpro?.version;
+const IPScanVersionCheck = ({ data, ipScanVersion, callback } /*: Props */) => {
+  const currentVersion = data?.payload?.databases?.interpro?.version;
   const currentVersionReleaseDate = new Date(
-    data.payload?.databases?.interpro?.releaseDate,
+    data?.payload?.databases?.interpro?.releaseDate,
   );
   const [_, jobVersion] = (ipScanVersion || '').split('-');
+  useEffect(() => {
+    callback(currentVersion !== jobVersion);
+  }, [currentVersion, jobVersion]);
+
+  if (!data || data.loading || !ipScanVersion) return <Loading inline={true} />;
 
   // eslint-disable-next-line no-magic-numbers
   const msPerDay = 24 * 60 * 60 * 1000; // Number of milliseconds per day
   const daysSinceRelease = Math.round(
     (new Date().getTime() - currentVersionReleaseDate.getTime()) / msPerDay,
   );
-
   if (currentVersion !== jobVersion) {
     return (
       <div className={f('callout', 'info', 'withicon')}>
@@ -71,5 +75,6 @@ IPScanVersionCheck.propTypes = {
     payload: T.object,
   }),
   ipScanVersion: T.string,
+  callback: T.func,
 };
 export default loadData(getUrlForMeta)(IPScanVersionCheck);

--- a/src/components/IPScan/Search/__snapshots__/test.js.snap
+++ b/src/components/IPScan/Search/__snapshots__/test.js.snap
@@ -265,6 +265,7 @@ exports[`<IPScanSearch /> should render 1`] = `
           </div>
           <Memo(Connect(loadData(AdvancedOptions)))
             changeTitle={[Function]}
+            initialOptions={null}
             title=""
           />
           <div

--- a/src/components/IPScan/Search/index.js
+++ b/src/components/IPScan/Search/index.js
@@ -365,8 +365,6 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
       data: {
         input: lines.join('\n'),
         applications: getCheckedApplications(this._formRef.current),
-        goterms: true,
-        pathways: true,
       },
     });
     // Request browser notification

--- a/src/components/IPScan/Search/index.js
+++ b/src/components/IPScan/Search/index.js
@@ -221,6 +221,8 @@ InfoMessages.propTypes = {
   ipScan: Object,
   value: string,
   main: string,
+  search: Object,
+
 }*/
 
 /*:: type State = {
@@ -240,6 +242,7 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
     ipScan: T.object.isRequired,
     value: T.string,
     main: T.string,
+    search: T.object,
   };
 
   constructor(props /*: Props */) {
@@ -250,6 +253,7 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
     let tooShort = true;
     let headerIssues = false;
     let title = '';
+    let initialAdvancedOptions = null;
     if (props.value) {
       editorState = EditorState.createWithContent(
         ContentState.createFromText(decodeURIComponent(props.value)),
@@ -266,12 +270,16 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
     } else {
       editorState = EditorState.createEmpty(compositeDecorator);
     }
+    if (props.search) {
+      initialAdvancedOptions = props.search;
+    }
     this.state = {
       editorState,
       valid,
       tooShort,
       headerIssues,
       title,
+      initialAdvancedOptions,
     };
 
     this._formRef = React.createRef();
@@ -624,6 +632,7 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
                 <AdvancedOptions
                   title={this.state.title}
                   changeTitle={this._changeTitle}
+                  initialOptions={this.state.initialAdvancedOptions}
                 />
 
                 <div className={f('row')}>
@@ -673,7 +682,13 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
 const mapStateToProps = createSelector(
   (state) => state.settings.ipScan,
   (state) => state.customLocation.description,
-  (ipScan, desc) => ({ ipScan, value: desc.search.value, main: desc.main.key }),
+  (state) => state.customLocation.search,
+  (ipScan, desc, search) => ({
+    ipScan,
+    value: desc.search.value,
+    main: desc.main.key,
+    search,
+  }),
 );
 
 export default connect(mapStateToProps, {

--- a/src/components/IPScan/Summary/index.js
+++ b/src/components/IPScan/Summary/index.js
@@ -250,6 +250,11 @@ const SummaryIPScanJob = ({
                 status={status}
                 versionMismatch={versionMismatch}
                 sequence={metadata.sequence}
+                attributes={{
+                  applications: localPayload?.applications,
+                  goterms: localPayload?.goterms,
+                  pathways: localPayload?.pathways,
+                }}
               />
             </section>
           </section>

--- a/src/components/IPScan/Summary/index.js
+++ b/src/components/IPScan/Summary/index.js
@@ -118,6 +118,7 @@ const SummaryIPScanJob = ({
   updateJobTitle,
 }) => {
   const [mergedData, setMergedData] = useState({});
+  const [versionMismatch, setVersionMismatch] = useState(false);
   const [familyHierarchyData, setFamilyHierarchyData] = useState([]);
 
   useEffect(() => {
@@ -202,7 +203,10 @@ const SummaryIPScanJob = ({
             Using data stored in your browser
           </div>
         ) : null}
-        <IPScanVersionCheck ipScanVersion={payload['interproscan-version']} />
+        <IPScanVersionCheck
+          ipScanVersion={payload['interproscan-version']}
+          callback={setVersionMismatch}
+        />
         <NucleotideSummary payload={payload} />
         <IPScanTitle
           localTitle={localTitle}
@@ -239,9 +243,14 @@ const SummaryIPScanJob = ({
         </section>
         {localID && (
           <section className={f('summary-row')}>
-            <header>Action</header>
+            <header>Actions</header>
             <section>
-              <Actions localID={localID} status={status} />
+              <Actions
+                localID={localID}
+                status={status}
+                versionMismatch={versionMismatch}
+                sequence={metadata.sequence}
+              />
             </section>
           </section>
         )}

--- a/src/pages/Sequence/index.js
+++ b/src/pages/Sequence/index.js
@@ -169,8 +169,6 @@ class IPScanResult extends PureComponent /*:: <Props, State> */ {
           group: meta?.group,
           orf: data?.results?.[0]?.orf,
           applications: data?.applications,
-          goterms: data?.goterms,
-          pathways: data?.pathways,
         },
       });
     });

--- a/src/pages/Sequence/index.js
+++ b/src/pages/Sequence/index.js
@@ -168,6 +168,9 @@ class IPScanResult extends PureComponent /*:: <Props, State> */ {
           ],
           group: meta?.group,
           orf: data?.results?.[0]?.orf,
+          applications: data?.applications,
+          goterms: data?.goterms,
+          pathways: data?.pathways,
         },
       });
     });

--- a/src/store/enhancer/jobs-middleware/index.js
+++ b/src/store/enhancer/jobs-middleware/index.js
@@ -106,19 +106,11 @@ const updateJobInDB = async (metadata, data, title) => {
 
 const processImportedAttributes = (
   payload /*: ImportedParametersPayload */,
-) /*:  { goterms: boolean|null, pathways: boolean|null, applications: string[]|null } */ => {
-  let goterms = null;
-  let pathways = null;
+) /*:  { applications: string[]|null } */ => {
   let applications = null;
   const parameters = payload?.execution?.userParameters?.entry || [];
   parameters.forEach((parameter) => {
     switch (parameter?.string) {
-      case 'goterms':
-        goterms = parameter?.boolean ?? null;
-        break;
-      case 'pathways':
-        pathways = parameter?.boolean ?? null;
-        break;
       case 'appl':
         applications = parameter?.['string-array']?.string || [];
         break;
@@ -126,7 +118,7 @@ const processImportedAttributes = (
         break;
     }
   });
-  return { goterms, pathways, applications };
+  return { applications };
 };
 
 const middleware /*: Middleware<*, *, *> */ = ({ dispatch, getState }) => {
@@ -138,9 +130,7 @@ const middleware /*: Middleware<*, *, *> */ = ({ dispatch, getState }) => {
     if (meta.status === 'failed') return;
     if (meta.status === 'created') {
       const dataT = await dataTA;
-      const { input, applications, goterms, pathways } = await dataT.get(
-        localID,
-      );
+      const { input, applications } = await dataT.get(localID);
 
       const ipScanInfo = getState().settings.ipScan;
 
@@ -162,8 +152,6 @@ const middleware /*: Middleware<*, *, *> */ = ({ dispatch, getState }) => {
                 title: localID,
                 sequence: input,
                 appl: applications,
-                goterms,
-                pathways,
               },
             })
             .replace(/^\?/, ''),
@@ -281,7 +269,6 @@ const middleware /*: Middleware<*, *, *> */ = ({ dispatch, getState }) => {
           }),
         );
       } else {
-        console.log('GOT here', data1, data2);
         dispatch(
           updateJob({
             metadata: { ...meta, hasResults: false, status: 'error' },

--- a/src/styles/interpro-new.css
+++ b/src/styles/interpro-new.css
@@ -139,6 +139,11 @@ mark {
   color: var(--colors-all);
 }
 
+.ico-neutral:hover::before {
+  opacity: 1;
+  color: var(--colors-black);
+}
+
 .ico-notfound::before {
   color: var(--colors-alert-main);
 }

--- a/src/utils/cached-fetch/index.js
+++ b/src/utils/cached-fetch/index.js
@@ -139,6 +139,12 @@ const commonCachedFetch =
     } else if (responseType === 'yaml') {
       const yaml = await import(/* webpackChunkName: "js-yaml" */ 'js-yaml');
       payloadP = yaml.load(await response.text(), { json: true });
+    } else if (responseType === 'xml') {
+      const { XMLParser } = await import(
+        /* webpackChunkName: "fast-xml-parser" */ 'fast-xml-parser'
+      );
+      const xmlParser = new XMLParser();
+      payloadP = xmlParser.parse(await response.text());
     }
     const output /*: FetchOutput */ = {
       status: response.status,
@@ -158,5 +164,6 @@ export const cachedFetchText = commonCachedFetch('text');
 export const cachedFetchJSON = commonCachedFetch('json');
 export const cachedFetchYAML = commonCachedFetch('yaml');
 export const cachedFetchGZIP = commonCachedFetch('gzip');
+export const cachedFetchXML = commonCachedFetch('xml');
 
 export default commonCachedFetch();


### PR DESCRIPTION
Resolves #363 

A new action to re-run a job is now included in the overview of an existing job. This option is only available when a there is a version mismatch.

When the user clicks on the rerun button, the search by sequence page is open pre filling the sequence and the advanced options. The capability of pre-fill the advanced options.