### PR TITLE
Pfam changes

### DIFF
--- a/src/components/Matches/index.js
+++ b/src/components/Matches/index.js
@@ -684,7 +684,7 @@ const Matches = (
               search: { type: 'seed' },
             })}
           >
-            Seed Aligment
+            Link
           </Link>
         )}
       >

--- a/src/components/Matches/index.js
+++ b/src/components/Matches/index.js
@@ -668,7 +668,7 @@ const Matches = (
         displayIf={
           primary === 'entry' &&
           secondary === 'set' &&
-          description?.entry?.db == 'pfam'
+          description?.entry?.db === 'pfam'
         }
         renderer={(accession /*: string */) => (
           <Link
@@ -688,7 +688,36 @@ const Matches = (
           </Link>
         )}
       >
-        Links
+        Aligments
+      </Column>
+      <Column
+        dataKey="accession"
+        defaultKey="ida"
+        headerClassName={f('table-center')}
+        cellClassName={f('table-center')}
+        displayIf={
+          primary === 'entry' &&
+          secondary === 'set' &&
+          description?.entry?.db === 'pfam'
+        }
+        renderer={(accession /*: string */) => (
+          <Link
+            to={(customLocation) => ({
+              description: {
+                main: { key: 'entry' },
+                entry: {
+                  db: customLocation.description.set.db,
+                  accession,
+                  detail: 'domain_architecture',
+                },
+              },
+            })}
+          >
+            IDA Table
+          </Link>
+        )}
+      >
+        Domain architectures
       </Column>
     </Table>
   );

--- a/src/components/Matches/index.js
+++ b/src/components/Matches/index.js
@@ -660,6 +660,36 @@ const Matches = (
       >
         Actions
       </Column>
+      <Column
+        dataKey="accession"
+        defaultKey="seedAlignment"
+        headerClassName={f('table-center')}
+        cellClassName={f('table-center')}
+        displayIf={
+          primary === 'entry' &&
+          secondary === 'set' &&
+          description?.entry?.db == 'pfam'
+        }
+        renderer={(accession /*: string */) => (
+          <Link
+            to={(customLocation) => ({
+              description: {
+                main: { key: 'entry' },
+                entry: {
+                  db: customLocation.description.set.db,
+                  accession,
+                  detail: 'entry_alignments',
+                },
+              },
+              search: { type: 'seed' },
+            })}
+          >
+            Seed Aligment
+          </Link>
+        )}
+      >
+        Links
+      </Column>
     </Table>
   );
 };

--- a/src/components/Matches/index.js
+++ b/src/components/Matches/index.js
@@ -688,7 +688,7 @@ const Matches = (
           </Link>
         )}
       >
-        Aligments
+        Seed alignment
       </Column>
       <Column
         dataKey="accession"

--- a/src/components/Matches/index.js
+++ b/src/components/Matches/index.js
@@ -713,7 +713,7 @@ const Matches = (
               },
             })}
           >
-            IDA Table
+            Link
           </Link>
         )}
       >

--- a/src/components/Related/RelatedTable/index.js
+++ b/src/components/Related/RelatedTable/index.js
@@ -162,16 +162,6 @@ const RelatedTable = (
         focusType={focusType}
         databases={databases}
       />
-      {mainType === 'set' &&
-        focusType === 'entry' &&
-        mainData?.source_database === 'pfam' && (
-          <div className={f('callout', 'info', 'withicon')}>
-            For more information about the different domain architectures of the
-            Pfam entries included in this clan, you can click on a Pfam
-            accession in the table below and go to the Domain architectures tab
-            of the Pfam entry.
-          </div>
-        )}
       <div className={f('filters-and-table')}>
         {hasFilters && (
           <nav>

--- a/src/components/Related/RelatedTable/index.js
+++ b/src/components/Related/RelatedTable/index.js
@@ -162,6 +162,16 @@ const RelatedTable = (
         focusType={focusType}
         databases={databases}
       />
+      {mainType === 'set' &&
+        focusType === 'entry' &&
+        mainData?.source_database === 'pfam' && (
+          <div className={f('callout', 'info', 'withicon')}>
+            For more information about the different domain architectures of the
+            Pfam entries included in this clan, you can click on a Pfam
+            accession in the table below and go to the Domain architectures tab
+            of the Pfam entry.
+          </div>
+        )}
       <div className={f('filters-and-table')}>
         {hasFilters && (
           <nav>

--- a/src/components/Set/Summary/index.js
+++ b/src/components/Set/Summary/index.js
@@ -173,10 +173,7 @@ class SummarySet extends PureComponent /*:: <Props, State> */ {
       element: this._ref.current,
       useCtrlToZoom: true,
       height: 600,
-      nodeLabel: (node) => {
-        console.log(node);
-        return getTextForLabel(node, this.props.label);
-      },
+      nodeLabel: (node) => getTextForLabel(node, this.props.label),
     });
     if (
       this.props.data &&

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -10,7 +10,9 @@ import theme from 'styles/theme-interpro.css';
 const f = foundationPartial(ebiGlobalStyles, fonts, ipro, theme);
 
 /*:: type Props = {
-  children: any
+  selectedTab?: string,
+  onTabSelected?: (tab: string) => void,
+  children: any,
 }; */
 
 /*:: type State = {
@@ -19,6 +21,8 @@ const f = foundationPartial(ebiGlobalStyles, fonts, ipro, theme);
 export default class Tabs extends PureComponent /*:: <Props, State> */ {
   static propTypes = {
     children: T.any,
+    selectedTab: T.string,
+    onTabSelected: T.func,
   };
 
   constructor(props /*: Props */) {
@@ -26,12 +30,23 @@ export default class Tabs extends PureComponent /*:: <Props, State> */ {
     this.state = { activeTab: 0 };
   }
 
-  _handleChangeTab = index => () => this.setState({ activeTab: index });
+  _handleChangeTab = (index) => () => {
+    const { children, onTabSelected } = this.props;
+    if (onTabSelected) {
+      const id = Children.toArray(children)?.[index]?.props?.title || '';
+      onTabSelected(id);
+    } else {
+      this.setState({ activeTab: index });
+    }
+  };
 
   render() {
-    const { children } = this.props;
-    const { activeTab } = this.state;
+    const { children, selectedTab } = this.props;
     const _children = Children.toArray(children);
+    const index = _children.findIndex(
+      (ch) => ch.props.title.toLowerCase() === selectedTab?.toLowerCase(),
+    );
+    const activeTab = index >= 0 ? index : this.state.activeTab;
     const _child = _children[activeTab];
     return (
       <div>

--- a/src/pages/Download/InterPro/index.js
+++ b/src/pages/Download/InterPro/index.js
@@ -1,0 +1,251 @@
+// @flow
+import React from 'react';
+
+import Link from 'components/generic/Link';
+import { foundationPartial } from 'styles/foundation';
+
+import ipro from 'styles/interpro-new.css';
+import ebiGlobalStyles from 'ebi-framework/css/ebi-global.css';
+import fonts from 'EBI-Icon-fonts/fonts.css';
+
+const f = foundationPartial(ebiGlobalStyles, fonts, ipro);
+
+const InterProDownloads = () => {
+  const IS_UNIPARC_READY = true;
+  const UniparcLink = IS_UNIPARC_READY ? Link : 'span';
+  return (
+    <>
+      <table className={f('classic')}>
+        <thead>
+          <tr>
+            <th className={f('min-width-sm')}>Name</th>
+            <th>Description</th>
+            <th className={f('xs-hide')}>File name</th>
+            <th className={f('xs-hide')}>Format</th>
+            <th className={f('xs-hide')}>Links</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/entry.list">
+                InterPro entry list
+              </Link>
+            </td>
+            <td>
+              TSV file listing basic InterPro entry information - the
+              accessions, types and names.
+            </td>
+            <td className={f('xs-hide')}>entry.list</td>
+            <td className={f('xs-hide')}>TSV</td>
+            <td style={{ whiteSpace: 'nowrap' }}>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/entry.list">
+                <span
+                  className={f('icon', 'icon-common', 'font-l')}
+                  data-icon="&#x3d;"
+                />
+              </Link>
+              <br />
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              {' '}
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro.xml.gz">
+                InterPro entry details
+              </Link>
+            </td>
+            <td>
+              XML file listing each InterPro entry, the signatures that it
+              contains, its abstract, GO terms, etc. - it contains the
+              equivalent to the Entry pages on the web interface. A{' '}
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro.dtd">
+                DTD file
+              </Link>{' '}
+              exists describing the format.
+            </td>
+            <td className={f('xs-hide')}>interpro.xml.gz</td>
+            <td className={f('xs-hide')}>gzipped</td>
+            <td>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro.xml.gz">
+                <span
+                  className={f('icon', 'icon-common', 'font-l')}
+                  data-icon="&#x3d;"
+                />
+              </Link>
+              <br />
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              {' '}
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/match_complete.xml.gz">
+                Protein matched complete
+              </Link>
+            </td>
+            <td>
+              All UniProtKB proteins and the InterPro entries and individual
+              signatures they match, in XML format. Proteins without any matches
+              to InterPro are also included. A{' '}
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/match_complete.dtd">
+                DTD file
+              </Link>{' '}
+              exists describing the format.
+            </td>
+            <td className={f('xs-hide')}>match_complete.xml.gz</td>
+            <td className={f('xs-hide')}>gzipped</td>
+            <td>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/match_complete.xml.gz">
+                <span
+                  className={f('icon', 'icon-common', 'font-l')}
+                  data-icon="&#x3d;"
+                />
+              </Link>
+              <br />
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <UniparcLink href="https://ftp.ebi.ac.uk/pub/databases/interpro/uniparc_match.tar.gz">
+                Uniparc sequences
+              </UniparcLink>
+            </td>
+            <td>
+              All uniparc (UniProt Archive) sequences and the InterPro entries
+              and individual signatures they match, in XML format.
+              {!IS_UNIPARC_READY && (
+                <div>
+                  <br />
+                  <b>Note:</b>The Uniparc file is still been generated for this
+                  version. We will update this link once is ready.
+                </div>
+              )}
+            </td>
+            <td className={f('xs-hide')}>uniparc_match.tar.gz</td>
+            <td className={f('xs-hide')}>gzipped</td>
+            <td>
+              <UniparcLink href="https://ftp.ebi.ac.uk/pub/databases/interpro/uniparc_match.tar.gz">
+                <span
+                  className={f('icon', 'icon-common', 'font-l')}
+                  data-icon="&#x3d;"
+                />
+              </UniparcLink>
+              <br />
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/protein2ipr.dat.gz">
+                UniProtKB proteins
+              </Link>
+            </td>
+            <td>
+              All UniProtKB proteins and the InterPro entries and individual
+              signatures they match, in a tab-delimited format.
+            </td>
+            <td className={f('xs-hide')}>protein2ipr.dat.gz</td>
+            <td className={f('xs-hide')}>gzipped</td>
+            <td>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/protein2ipr.dat.gz">
+                <span
+                  className={f('icon', 'icon-common', 'font-l')}
+                  data-icon="&#x3d;"
+                />
+              </Link>
+              <br />
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/ParentChildTreeFile.txt">
+                Entry relationships tree
+              </Link>
+            </td>
+            <td>
+              File describing the hierarchy of relationships between
+              InterPro&quot;s entries (i.e. families and their subfamilies) in a
+              simple text-based format.
+            </td>
+            <td className={f('xs-hide')}>ParentChildTreeFile.txt</td>
+            <td className={f('xs-hide')}>TXT</td>
+            <td>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/ParentChildTreeFile.txt">
+                <span
+                  className={f('icon', 'icon-common', 'font-l')}
+                  data-icon="&#x3d;"
+                />
+              </Link>
+              <br />
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              {' '}
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro2go">
+                List of GO terms
+              </Link>
+            </td>
+            <td>Mappings of InterPro entries to Gene Ontology (GO) terms.</td>
+            <td className={f('xs-hide')}>interpro2go</td>
+            <td className={f('xs-hide')}>TXT</td>
+            <td>
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro2go">
+                <span
+                  className={f('icon', 'icon-common', 'font-l')}
+                  data-icon="&#x3d;"
+                />
+              </Link>
+              <br />
+            </td>
+          </tr>
+
+          {
+            <tr>
+              <td>
+                <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/release_notes.txt">
+                  Latest release note
+                </Link>
+              </td>
+              <td>The current release notes, in text-based format.</td>
+              <td>release_notes.txt</td>
+              <td>TXT</td>
+              <td>
+                <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/release_notes.txt">
+                  <span
+                    className={f('icon', 'icon-common', 'font-l')}
+                    data-icon="&#x3d;"
+                  />
+                </Link>
+                <br />
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+
+      <p className={f('small', 'margin-top-small')}>
+        See all downloads available on the{' '}
+        <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/">
+          FTP Site
+        </Link>
+      </p>
+
+      <h5>From individual web pages</h5>
+      <ul>
+        <li>
+          A JSON or TSV file containing all entries is available for download
+          from the Browse Entry, Browse Protein, Browse Structure, Browse
+          Taxonomy, Browse proteome and Browse Set result page
+        </li>
+      </ul>
+    </>
+  );
+};
+
+export default InterProDownloads;

--- a/src/pages/Download/InterPro/index.js
+++ b/src/pages/Download/InterPro/index.js
@@ -11,8 +11,6 @@ import fonts from 'EBI-Icon-fonts/fonts.css';
 const f = foundationPartial(ebiGlobalStyles, fonts, ipro);
 
 const InterProDownloads = () => {
-  const IS_UNIPARC_READY = true;
-  const UniparcLink = IS_UNIPARC_READY ? Link : 'span';
   return (
     <>
       <table className={f('classic')}>
@@ -109,30 +107,23 @@ const InterProDownloads = () => {
 
           <tr>
             <td>
-              <UniparcLink href="https://ftp.ebi.ac.uk/pub/databases/interpro/uniparc_match.tar.gz">
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/uniparc_match.tar.gz">
                 Uniparc sequences
-              </UniparcLink>
+              </Link>
             </td>
             <td>
               All uniparc (UniProt Archive) sequences and the InterPro entries
               and individual signatures they match, in XML format.
-              {!IS_UNIPARC_READY && (
-                <div>
-                  <br />
-                  <b>Note:</b>The Uniparc file is still been generated for this
-                  version. We will update this link once is ready.
-                </div>
-              )}
             </td>
             <td className={f('xs-hide')}>uniparc_match.tar.gz</td>
             <td className={f('xs-hide')}>gzipped</td>
             <td>
-              <UniparcLink href="https://ftp.ebi.ac.uk/pub/databases/interpro/uniparc_match.tar.gz">
+              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/uniparc_match.tar.gz">
                 <span
                   className={f('icon', 'icon-common', 'font-l')}
                   data-icon="&#x3d;"
                 />
-              </UniparcLink>
+              </Link>
               <br />
             </td>
           </tr>

--- a/src/pages/Download/InterProScan/index.js
+++ b/src/pages/Download/InterProScan/index.js
@@ -21,7 +21,7 @@ const InterProScanDownloads = () => (
       <Link href="https://ftp.ebi.ac.uk/pub/software/unix/iprscan/5/">
         FTP Site
       </Link>
-      . InterProScan's source code is available on{' '}
+      . InterProScan&#39;s source code is available on{' '}
       <Link
         href="//github.com/ebi-pf-team/interproscan"
         className={f('ext')}

--- a/src/pages/Download/InterProScan/index.js
+++ b/src/pages/Download/InterProScan/index.js
@@ -21,14 +21,13 @@ const InterProScanDownloads = () => (
       <Link href="https://ftp.ebi.ac.uk/pub/software/unix/iprscan/5/">
         FTP Site
       </Link>
-      . You can find, clone, and download the full InterProScan source code on
-      the{' '}
+      . InterProScan's source code is available on{' '}
       <Link
         href="//github.com/ebi-pf-team/interproscan"
         className={f('ext')}
         target="_blank"
       >
-        Github repository
+        Github
       </Link>
       .
     </p>

--- a/src/pages/Download/InterProScan/index.js
+++ b/src/pages/Download/InterProScan/index.js
@@ -1,0 +1,38 @@
+// @flow
+import React from 'react';
+
+import Link from 'components/generic/Link';
+import DownloadTable from 'components/IPScan/DownloadTable';
+import { foundationPartial } from 'styles/foundation';
+
+import ipro from 'styles/interpro-new.css';
+import ebiGlobalStyles from 'ebi-framework/css/ebi-global.css';
+import fonts from 'EBI-Icon-fonts/fonts.css';
+
+const f = foundationPartial(ebiGlobalStyles, fonts, ipro);
+
+const InterProScanDownloads = () => (
+  <>
+    <DownloadTable />
+    <p className={f('small', 'margin-top-small')}>
+      To ensure you have the latest data and software enhancements we always
+      recommend you download the latest version of InterProScan. However all
+      previous releases are archived on the{' '}
+      <Link href="https://ftp.ebi.ac.uk/pub/software/unix/iprscan/5/">
+        FTP Site
+      </Link>
+      . You can find, clone, and download the full InterProScan source code on
+      the{' '}
+      <Link
+        href="//github.com/ebi-pf-team/interproscan"
+        className={f('ext')}
+        target="_blank"
+      >
+        Github repository
+      </Link>
+      .
+    </p>
+  </>
+);
+
+export default InterProScanDownloads;

--- a/src/pages/Download/Pfam/index.js
+++ b/src/pages/Download/Pfam/index.js
@@ -1,0 +1,119 @@
+// @flow
+import React from 'react';
+
+import Link from 'components/generic/Link';
+import { foundationPartial } from 'styles/foundation';
+
+import ipro from 'styles/interpro-new.css';
+import ebiGlobalStyles from 'ebi-framework/css/ebi-global.css';
+import fonts from 'EBI-Icon-fonts/fonts.css';
+
+const f = foundationPartial(ebiGlobalStyles, fonts, ipro);
+
+const PfamDownloads = () => (
+  <>
+    <table className={f('classic')}>
+      <thead>
+        <tr>
+          <th className={f('min-width-sm')}>Name</th>
+          <th>Description</th>
+          <th className={f('xs-hide')}>File name</th>
+          <th className={f('xs-hide')}>Format</th>
+          <th className={f('xs-hide')}>Links</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz">
+              Pfam-A models
+            </Link>
+          </td>
+          <td>
+            Pfam-A HMMs in an HMM library searchable with the hmmscan program.
+          </td>
+          <td className={f('xs-hide')}>Pfam-A.hmm.gz</td>
+          <td className={f('xs-hide')}>gzipped</td>
+          <td style={{ whiteSpace: 'nowrap' }}>
+            <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz">
+              <span
+                className={f('icon', 'icon-common', 'font-l')}
+                data-icon="&#x3d;"
+              />
+            </Link>
+            <br />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.dat.gz">
+              Pfam-A HMM data
+            </Link>
+          </td>
+          <td>Data associated with each HMM required for pfam_scan.pl</td>
+          <td className={f('xs-hide')}>Pfam-A.hmm.dat.gz</td>
+          <td className={f('xs-hide')}>gzipped</td>
+          <td style={{ whiteSpace: 'nowrap' }}>
+            <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.dat.gz">
+              <span
+                className={f('icon', 'icon-common', 'font-l')}
+                data-icon="&#x3d;"
+              />
+            </Link>
+            <br />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.seed.gz">
+              Pfam-A Seed alignment
+            </Link>
+          </td>
+          <td>
+            Annotation and seed alignments of all Pfam-A families in Pfam
+            format.
+          </td>
+          <td className={f('xs-hide')}>Pfam-A.seed.gz</td>
+          <td className={f('xs-hide')}>gzipped</td>
+          <td style={{ whiteSpace: 'nowrap' }}>
+            <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.seed.gz">
+              <span
+                className={f('icon', 'icon-common', 'font-l')}
+                data-icon="&#x3d;"
+              />
+            </Link>
+            <br />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.full.gz">
+              Pfam-A Full alignment
+            </Link>
+          </td>
+          <td>
+            Annotation and full alignments of all Pfam-A families in Pfam
+            format.
+          </td>
+          <td className={f('xs-hide')}>Pfam-A.full.gz</td>
+          <td className={f('xs-hide')}>gzipped</td>
+          <td style={{ whiteSpace: 'nowrap' }}>
+            <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.full.gz">
+              <span
+                className={f('icon', 'icon-common', 'font-l')}
+                data-icon="&#x3d;"
+              />
+            </Link>
+            <br />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p className={f('small', 'margin-top-small')}>
+      See all downloads available on the{' '}
+      <Link href="https://ftp.ebi.ac.uk/pub/databases/Pfam/">FTP Site</Link>
+    </p>
+  </>
+);
+
+export default PfamDownloads;

--- a/src/pages/Download/index.js
+++ b/src/pages/Download/index.js
@@ -1,12 +1,20 @@
 // @flow
-import React, { PureComponent } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import { Helmet } from 'react-helmet-async';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { goToCustomLocation } from 'actions/creators';
+import { customLocationSelector } from 'reducers/custom-location';
 
-import Link from 'components/generic/Link';
-import DownloadTable from 'components/IPScan/DownloadTable';
+import Tabs from 'components/Tabs';
 import loadable from 'higherOrder/loadable';
 import { schemaProcessDataPageSection } from 'schema_org/processors';
 import TooltipAndRTDLink from 'components/Help/TooltipAndRTDLink';
+
+import InterProScanDownloads from './InterProScan';
+import InterProDownloads from './InterPro';
+import PfamDownloads from './Pfam';
 
 import { foundationPartial } from 'styles/foundation';
 
@@ -21,292 +29,63 @@ const SchemaOrgData = loadable({
   loading: () => null,
 });
 
-class Download extends PureComponent /*:: <{}> */ {
-  render() {
-    const IS_UNIPARC_READY = true;
-    const UniparcLink = IS_UNIPARC_READY ? Link : 'span';
-    return (
-      <div className={f('row')}>
-        <div className={f('columns')}>
-          <section>
-            <Helmet>
-              <title>Download</title>
-            </Helmet>
-            <h3>
-              Download{' '}
-              <TooltipAndRTDLink rtdPage="download.html#download-page" />
-            </h3>
-            <SchemaOrgData
-              data={{
-                name: 'InterPro Download Page',
-                description:
-                  'Includes links to pre-generated files for the current version of InterPro',
-              }}
-              processData={schemaProcessDataPageSection}
-            />
-
-            <DownloadTable />
-            <h4>InterProScan</h4>
-
-            <p className={f('small', 'margin-top-small')}>
-              To ensure you have the latest data and software enhancements we
-              always recommend you download the latest version of InterProScan.
-              However all previous releases are archived on the{' '}
-              <Link href="https://ftp.ebi.ac.uk/pub/software/unix/iprscan/5/">
-                FTP Site
-              </Link>
-              . You can find, clone, and download the full InterProScan source
-              code on the{' '}
-              <Link
-                href="//github.com/ebi-pf-team/interproscan"
-                className={f('ext')}
-                target="_blank"
-              >
-                Github repository
-              </Link>
-              .
-            </p>
-          </section>
-
-          <section>
-            <h4>InterPro</h4>
-            <table className={f('classic')}>
-              <thead>
-                <tr>
-                  <th className={f('min-width-sm')}>Name</th>
-                  <th>Description</th>
-                  <th className={f('xs-hide')}>File name</th>
-                  <th className={f('xs-hide')}>Format</th>
-                  <th className={f('xs-hide')}>Links</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/entry.list">
-                      InterPro entry list
-                    </Link>
-                  </td>
-                  <td>
-                    TSV file listing basic InterPro entry information - the
-                    accessions, types and names.
-                  </td>
-                  <td className={f('xs-hide')}>entry.list</td>
-                  <td className={f('xs-hide')}>TSV</td>
-                  <td style={{ whiteSpace: 'nowrap' }}>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/entry.list">
-                      <span
-                        className={f('icon', 'icon-common', 'font-l')}
-                        data-icon="&#x3d;"
-                      />
-                    </Link>
-                    <br />
-                  </td>
-                </tr>
-
-                <tr>
-                  <td>
-                    {' '}
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro.xml.gz">
-                      InterPro entry details
-                    </Link>
-                  </td>
-                  <td>
-                    XML file listing each InterPro entry, the signatures that it
-                    contains, its abstract, GO terms, etc. - it contains the
-                    equivalent to the Entry pages on the web interface. A{' '}
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro.dtd">
-                      DTD file
-                    </Link>{' '}
-                    exists describing the format.
-                  </td>
-                  <td className={f('xs-hide')}>interpro.xml.gz</td>
-                  <td className={f('xs-hide')}>gzipped</td>
-                  <td>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro.xml.gz">
-                      <span
-                        className={f('icon', 'icon-common', 'font-l')}
-                        data-icon="&#x3d;"
-                      />
-                    </Link>
-                    <br />
-                  </td>
-                </tr>
-
-                <tr>
-                  <td>
-                    {' '}
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/match_complete.xml.gz">
-                      Protein matched complete
-                    </Link>
-                  </td>
-                  <td>
-                    All UniProtKB proteins and the InterPro entries and
-                    individual signatures they match, in XML format. Proteins
-                    without any matches to InterPro are also included. A{' '}
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/match_complete.dtd">
-                      DTD file
-                    </Link>{' '}
-                    exists describing the format.
-                  </td>
-                  <td className={f('xs-hide')}>match_complete.xml.gz</td>
-                  <td className={f('xs-hide')}>gzipped</td>
-                  <td>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/match_complete.xml.gz">
-                      <span
-                        className={f('icon', 'icon-common', 'font-l')}
-                        data-icon="&#x3d;"
-                      />
-                    </Link>
-                    <br />
-                  </td>
-                </tr>
-
-                <tr>
-                  <td>
-                    <UniparcLink href="https://ftp.ebi.ac.uk/pub/databases/interpro/uniparc_match.tar.gz">
-                      Uniparc sequences
-                    </UniparcLink>
-                  </td>
-                  <td>
-                    All uniparc (UniProt Archive) sequences and the InterPro
-                    entries and individual signatures they match, in XML format.
-                    {!IS_UNIPARC_READY && (
-                      <div>
-                        <br />
-                        <b>Note:</b>The Uniparc file is still been generated for
-                        this version. We will update this link once is ready.
-                      </div>
-                    )}
-                  </td>
-                  <td className={f('xs-hide')}>uniparc_match.tar.gz</td>
-                  <td className={f('xs-hide')}>gzipped</td>
-                  <td>
-                    <UniparcLink href="https://ftp.ebi.ac.uk/pub/databases/interpro/uniparc_match.tar.gz">
-                      <span
-                        className={f('icon', 'icon-common', 'font-l')}
-                        data-icon="&#x3d;"
-                      />
-                    </UniparcLink>
-                    <br />
-                  </td>
-                </tr>
-
-                <tr>
-                  <td>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/protein2ipr.dat.gz">
-                      UniProtKB proteins
-                    </Link>
-                  </td>
-                  <td>
-                    All UniProtKB proteins and the InterPro entries and
-                    individual signatures they match, in a tab-delimited format.
-                  </td>
-                  <td className={f('xs-hide')}>protein2ipr.dat.gz</td>
-                  <td className={f('xs-hide')}>gzipped</td>
-                  <td>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/protein2ipr.dat.gz">
-                      <span
-                        className={f('icon', 'icon-common', 'font-l')}
-                        data-icon="&#x3d;"
-                      />
-                    </Link>
-                    <br />
-                  </td>
-                </tr>
-
-                <tr>
-                  <td>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/ParentChildTreeFile.txt">
-                      Entry relationships tree
-                    </Link>
-                  </td>
-                  <td>
-                    File describing the hierarchy of relationships between
-                    InterPro&quot;s entries (i.e. families and their
-                    subfamilies) in a simple text-based format.
-                  </td>
-                  <td className={f('xs-hide')}>ParentChildTreeFile.txt</td>
-                  <td className={f('xs-hide')}>TXT</td>
-                  <td>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/ParentChildTreeFile.txt">
-                      <span
-                        className={f('icon', 'icon-common', 'font-l')}
-                        data-icon="&#x3d;"
-                      />
-                    </Link>
-                    <br />
-                  </td>
-                </tr>
-
-                <tr>
-                  <td>
-                    {' '}
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro2go">
-                      List of GO terms
-                    </Link>
-                  </td>
-                  <td>
-                    Mappings of InterPro entries to Gene Ontology (GO) terms.
-                  </td>
-                  <td className={f('xs-hide')}>interpro2go</td>
-                  <td className={f('xs-hide')}>TXT</td>
-                  <td>
-                    <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/interpro2go">
-                      <span
-                        className={f('icon', 'icon-common', 'font-l')}
-                        data-icon="&#x3d;"
-                      />
-                    </Link>
-                    <br />
-                  </td>
-                </tr>
-
-                {
-                  <tr>
-                    <td>
-                      <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/release_notes.txt">
-                        Latest release note
-                      </Link>
-                    </td>
-                    <td>The current release notes, in text-based format.</td>
-                    <td>release_notes.txt</td>
-                    <td>TXT</td>
-                    <td>
-                      <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/release_notes.txt">
-                        <span
-                          className={f('icon', 'icon-common', 'font-l')}
-                          data-icon="&#x3d;"
-                        />
-                      </Link>
-                      <br />
-                    </td>
-                  </tr>
-                }
-              </tbody>
-            </table>
-
-            <p className={f('small', 'margin-top-small')}>
-              See all downloads available on the{' '}
-              <Link href="https://ftp.ebi.ac.uk/pub/databases/interpro/">
-                FTP Site
-              </Link>
-            </p>
-
-            <h5>From individual web pages</h5>
-            <ul>
-              <li>
-                A JSON or TSV file containing all entries is available for
-                download from the Browse Entry, Browse Protein, Browse
-                Structure, Browse Taxonomy, Browse proteome and Browse Set
-                result page
-              </li>
-            </ul>
-          </section>
-        </div>
-      </div>
-    );
+/*::
+  type Props = {
+    currentTab?: string,
+    goToCustomLocation: function,
   }
-}
+  */
 
-export default Download;
+const Download = ({ currentTab, goToCustomLocation }) => {
+  return (
+    <div className={f('row')}>
+      <div className={f('columns')}>
+        <section>
+          <Helmet>
+            <title>Download</title>
+          </Helmet>
+          <h3>
+            Download <TooltipAndRTDLink rtdPage="download.html#download-page" />
+          </h3>
+          <SchemaOrgData
+            data={{
+              name: 'InterPro Download Page',
+              description:
+                'Includes links to pre-generated files for the current version of InterPro',
+            }}
+            processData={schemaProcessDataPageSection}
+          />
+          <Tabs
+            selectedTab={currentTab || 'InterPro'}
+            onTabSelected={(tabId) => {
+              goToCustomLocation({
+                description: { other: ['download', tabId] },
+              });
+            }}
+          >
+            <div title="InterPro">
+              <InterProDownloads />
+            </div>
+            <div title="InterProScan">
+              <InterProScanDownloads />
+            </div>
+            <div title="Pfam">
+              <PfamDownloads />
+            </div>
+          </Tabs>
+        </section>
+      </div>
+    </div>
+  );
+};
+Download.propTypes = {
+  currentTab: T.string,
+  goToCustomLocation,
+};
+
+const mapStateToProps = createSelector(
+  customLocationSelector,
+  (customLocation) => ({ currentTab: customLocation.description.other?.[1] }),
+);
+
+export default connect(mapStateToProps, { goToCustomLocation })(Download);

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -170,7 +170,7 @@ const Announcement = () => (
   <div className={f('row')}>
     <div className={f('columns', 'large-12', 'margin-bottom-xlarge')}>
       <div
-        className={f('callout', 'info')}
+        className={f('callout', 'warning')}
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -182,25 +182,16 @@ const Announcement = () => (
             color: 'darkblue',
             paddingRight: '1rem',
           }}
-          className={f('small', 'icon', 'icon-species')}
-          data-icon="v"
+          className={f('small', 'icon', 'icon-common', 'icon-announcement')}
         />{' '}
-        You can see the special page created to compile all the information for:{' '}
-        <Link
-          to={{
-            description: {
-              main: { key: 'proteome' },
-              proteome: { db: 'uniprot', accession: 'UP000464024' },
-            },
-          }}
-          style={{
-            color: '#003457',
-          }}
-        >
-          {' '}
-          SARS-CoV-2
-        </Link>
-        .
+        <p>
+          The Pfam website will be decomissioned on October 5th 2022. All Pfam
+          data of this, and future versions, will be available here at the
+          InterPro website. You can read more about it in our{' '}
+          <a href="http://proteinswebteam.github.io/interpro-blog/">
+            blog post
+          </a>
+        </p>
       </div>
     </div>
   </div>

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -186,7 +186,7 @@ const Announcement = () => (
         />{' '}
         <p>
           The Pfam website will be decomissioned on October 5th 2022. All Pfam
-          data of this, and future versions, will be available here at the
+          data for this, and future versions, will be available here on the
           InterPro website. You can read more about it in our{' '}
           <a href="http://proteinswebteam.github.io/interpro-blog/">
             blog post


### PR DESCRIPTION
This includes a set of changes to be ready for the decommission of the Pfam website.

* Announcement in the home page the Pfam website is to be retired
* Links to IDA and seed alignments added in Pfam sets, while listing the entries.
* The downloads page now is split in tabs:
  * InterPro
  * InterProScan
  * Pfam **(new)**