### PR TITLE
Show number of sequences

### DIFF
--- a/src/components/BrowseTabs/BrowseTabsLink/index.js
+++ b/src/components/BrowseTabs/BrowseTabsLink/index.js
@@ -14,7 +14,7 @@ import styles from './style.css';
 const f = foundationPartial(styles);
 
 const singleEntityNames = new Map(
-  Array.from(singleEntity).map(e => [e[1].name, e[0]]),
+  Array.from(singleEntity).map((e) => [e[1].name, e[0]]),
 );
 
 const whitelist = new Set(['Overview', 'Domain Architectures', 'Sequence']);
@@ -35,11 +35,11 @@ const getValue = (loading, payload, counter, name) => {
     Number.isFinite(payload.metadata.counters[counter])
   ) {
     return payload.metadata.counters[counter];
-  } // Enabling the menuitems that appear in the entry_annotations array.
+  } // Enabling the menuitems that appear in the entry_annotations object.
   // i.e. only enable the menu item if there is info for it
   if (
     payload.metadata.entry_annotations &&
-    payload.metadata.entry_annotations.includes(singleEntityNames.get(name))
+    singleEntityNames.get(name) in payload.metadata.entry_annotations
   ) {
     return NaN;
   }

--- a/src/components/BrowseTabs/BrowseTabsLink/index.js
+++ b/src/components/BrowseTabs/BrowseTabsLink/index.js
@@ -39,7 +39,9 @@ const getValue = (loading, payload, counter, name) => {
   // i.e. only enable the menu item if there is info for it
   if (
     payload.metadata.entry_annotations &&
-    singleEntityNames.get(name) in payload.metadata.entry_annotations
+    payload.metadata.entry_annotations.hasOwnProperty(
+      singleEntityNames.get(name),
+    )
   ) {
     return NaN;
   }

--- a/src/components/EntryMenu/EntryMenuLink/index.js
+++ b/src/components/EntryMenu/EntryMenuLink/index.js
@@ -193,7 +193,9 @@ export class EntryMenuLink extends PureComponent /*:: <Props> */ {
        */
       if (
         payload.metadata.entry_annotations &&
-        (singleEntityNames.get(name) in payload.metadata.entry_annotations ||
+        (payload.metadata.entry_annotations.hasOwnProperty(
+          singleEntityNames.get(name),
+        ) ||
           hasAlignments(name, entryDB, payload.metadata.entry_annotations))
       ) {
         value = NaN;

--- a/src/components/EntryMenu/EntryMenuLink/index.js
+++ b/src/components/EntryMenu/EntryMenuLink/index.js
@@ -107,7 +107,7 @@ EntryMenuLinkWithoutData.propTypes = {
 
 const hasAlignments = (name, db, annotations) => {
   if (name !== 'Alignment' || db === 'InterPro') return false;
-  for (const ann of annotations) {
+  for (const ann of Object.keys(annotations)) {
     if (ann.startsWith('alignment:')) return true;
   }
   return false;
@@ -193,9 +193,7 @@ export class EntryMenuLink extends PureComponent /*:: <Props> */ {
        */
       if (
         payload.metadata.entry_annotations &&
-        (payload.metadata.entry_annotations.includes(
-          singleEntityNames.get(name),
-        ) ||
+        (singleEntityNames.get(name) in payload.metadata.entry_annotations ||
           hasAlignments(name, entryDB, payload.metadata.entry_annotations))
       ) {
         value = NaN;

--- a/src/subPages/EntryAlignments/index.js
+++ b/src/subPages/EntryAlignments/index.js
@@ -141,9 +141,10 @@ const EntryAlignments = ({
   const [overlayConservation, setOverlayConservation] = useState(false);
 
   // eslint-disable-next-line camelcase
-  const types = (data?.payload?.metadata?.entry_annotations || [])
-    .filter((ann) => ann.startsWith(tag))
-    .map((ann) => ann.slice(tag.length));
+  const types = Object.entries(data?.payload?.metadata?.entry_annotations || {})
+    .filter(([type]) => type.startsWith(tag))
+    .map(([type, count]) => [type.slice(tag.length), count])
+    .sort(([aType, aCount], [bType, bCount]) => aCount - bCount);
   if (!types.length) return null;
   const handleChange = (evt) => {
     goToCustomLocation({
@@ -173,8 +174,10 @@ const EntryAlignments = ({
           <option value="" disabled>
             Choose...
           </option>
-          {types.map((t) => (
-            <option key={t}>{t}</option>
+          {types.map(([type, count]) => (
+            <option key={type}>
+              {type} ({count.toLocaleString()})
+            </option>
           ))}
         </select>
       </label>

--- a/src/subPages/EntryAlignments/index.js
+++ b/src/subPages/EntryAlignments/index.js
@@ -175,7 +175,7 @@ const EntryAlignments = ({
             Choose...
           </option>
           {types.map(([type, count]) => (
-            <option key={type}>
+            <option key={type} value={type}>
               {type} ({count.toLocaleString()})
             </option>
           ))}

--- a/src/subPages/EntryAlignments/index.js
+++ b/src/subPages/EntryAlignments/index.js
@@ -6,10 +6,6 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { goToCustomLocation } from 'actions/creators';
 
-import { format } from 'url';
-import loadData from 'higherOrder/loadData';
-import descriptionToPath from 'utils/processDescription/descriptionToPath';
-
 import Link from 'components/generic/Link';
 import Tip from 'components/Tip';
 import AlignmentViewer from './Viewer';
@@ -22,27 +18,24 @@ import fonts from 'EBI-Icon-fonts/fonts.css';
 
 const f = foundationPartial(localStyle, ipro, fonts);
 
-const _Alignment = ({
+const Alignment = ({
   type,
+  numSequences,
   colorscheme,
   onConservationProgress,
   setDisplayingAlignment,
   setColorMap,
   overlayConservation,
-  data: { payload },
 }) => {
   const [forceShow, setForceShow] = useState(false);
   const threshold = 1000;
-  // eslint-disable-next-line camelcase
-  const num = payload?.num_sequences || Infinity;
-  const show = forceShow || num < threshold;
+  const show = forceShow || numSequences < threshold;
   useEffect(() => {
     setDisplayingAlignment(show);
   }, [show]);
   useEffect(() => {
     setForceShow(false);
-  }, [payload]);
-  if (!payload) return null;
+  }, [numSequences]);
 
   return (
     <div>
@@ -51,15 +44,15 @@ const _Alignment = ({
           onConservationProgress={onConservationProgress}
           setColorMap={setColorMap}
           type={type}
-          num={num}
+          num={numSequences}
           colorscheme={colorscheme}
           overlayConservation={overlayConservation}
         />
       ) : (
         <div>
           <p>
-            This alignment has {num} sequences. This can cause memory issues in
-            your browser.
+            This alignment has {numSequences} sequences. This can cause memory
+            issues in your browser.
           </p>
           <p>
             If you still want to display it, press{' '}
@@ -72,41 +65,15 @@ const _Alignment = ({
     </div>
   );
 };
-_Alignment.propTypes = {
+Alignment.propTypes = {
   type: T.string,
+  numSequences: T.number,
   colorscheme: T.string,
   onConservationProgress: T.func,
   setDisplayingAlignment: T.func,
   setColorMap: T.func,
-  data: dataPropType,
   overlayConservation: T.bool,
 };
-
-const mapStateToPropsForAlignment = createSelector(
-  (state) => state.settings.api,
-  (state) => state.customLocation.description,
-  (_, props) => props?.type || '',
-  ({ protocol, hostname, port, root }, description, type) => {
-    // omit elements from description
-    const { ...copyOfDescription } = description;
-    if (description.main.key) {
-      copyOfDescription[description.main.key] = {
-        ...description[description.main.key],
-        detail: null,
-      };
-    }
-    // build URL
-    return format({
-      protocol,
-      hostname,
-      port,
-      pathname: root + descriptionToPath(copyOfDescription),
-      query: { 'annotation:info': type },
-    });
-  },
-);
-
-const Alignment = loadData(mapStateToPropsForAlignment)(_Alignment);
 
 const AllowedColorschemes = [
   'buried_index',
@@ -251,7 +218,10 @@ const EntryAlignments = ({
       {alignmentType !== '' && (
         <Alignment
           colorscheme={colorscheme}
-          type={`${tag}${type}`}
+          type={`${tag}${alignmentType}`}
+          numSequences={
+            data?.payload?.metadata?.entry_annotations[`${tag}${alignmentType}`]
+          }
           onConservationProgress={setConservastionProgress}
           setDisplayingAlignment={setDisplayingAlignment}
           setColorMap={setColorMap}
@@ -272,10 +242,6 @@ EntryAlignments.propTypes = {
 const mapStateToProps = createSelector(
   (state) => state.customLocation,
   (state) => state.customLocation?.search?.type,
-  (state) =>
-    mapStateToPropsForAlignment(state)
-      .replace(':info', '')
-      .replace('%3Ainfo', ''),
   (state) => state.settings.notifications.showCtrlToZoomToast,
   (customLocation, type, url, showCtrlToZoomToast) => ({
     customLocation,

--- a/src/subPages/EntryAlignments/index.js
+++ b/src/subPages/EntryAlignments/index.js
@@ -144,7 +144,7 @@ const EntryAlignments = ({
   const types = Object.entries(data?.payload?.metadata?.entry_annotations || {})
     .filter(([type]) => type.startsWith(tag))
     .map(([type, count]) => [type.slice(tag.length), count])
-    .sort(([aType, aCount], [bType, bCount]) => aCount - bCount);
+    .sort(([, aCount], [, bCount]) => aCount - bCount);
   if (!types.length) return null;
   const handleChange = (evt) => {
     goToCustomLocation({

--- a/src/subPages/EntryAlignments/index.js
+++ b/src/subPages/EntryAlignments/index.js
@@ -133,7 +133,6 @@ const EntryAlignments = ({
   goToCustomLocation,
 }) => {
   const tag = 'alignment:';
-  const disallowedList = ['ncbi', 'meta'];
   const [colorscheme, setColorscheme] = useState('clustal2');
   const [conservastionProgress, setConservastionProgress] = useState(0);
   // TODO: draw the legend using 👇🏽 the colorMap coming from events in the component.
@@ -144,8 +143,7 @@ const EntryAlignments = ({
   // eslint-disable-next-line camelcase
   const types = (data?.payload?.metadata?.entry_annotations || [])
     .filter((ann) => ann.startsWith(tag))
-    .map((ann) => ann.slice(tag.length))
-    .filter((ann) => disallowedList.indexOf(ann) === -1);
+    .map((ann) => ann.slice(tag.length));
   if (!types.length) return null;
   const handleChange = (evt) => {
     goToCustomLocation({


### PR DESCRIPTION
This PR updates the `<select>` element listing available alignments (Pfam and InterPro entries only) so the number of sequences is displayed:

![dropdown](https://user-images.githubusercontent.com/2097501/187512661-c0da5d77-f03a-4283-9951-966938bd3632.png)

Requires REST API changes described in ProteinsWebTeam/interpro7-api#88.