### PR TITLE
Multiple sequence search

### DIFF
--- a/src/components/IPScan/Actions/Group/index.js
+++ b/src/components/IPScan/Actions/Group/index.js
@@ -1,0 +1,77 @@
+// @flow
+import React from 'react';
+import T from 'prop-types';
+
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+import Tooltip from 'components/SimpleCommonComponents/Tooltip';
+import { deleteJob } from 'actions/creators';
+
+import { foundationPartial } from 'styles/foundation';
+
+import ipro from 'styles/interpro-new.css';
+import fonts from 'EBI-Icon-fonts/fonts.css';
+import local from '../style.css';
+
+const f = foundationPartial(fonts, ipro, local);
+
+/*::
+type Props = {
+  group: string,
+  deleteJob: (string)=>void,
+  jobs: {
+    [string]: {
+      metadata: {
+        group:string
+      }
+    }
+  },
+}
+  */
+const GroupActions = ({ group, jobs, deleteJob } /*: Props */) => {
+  const handleDelete = () => {
+    // prettier-ignore
+    (Object.values(jobs)/*: any */)
+      .filter(
+        ({ metadata } /*: {metadata:{group: string}} */) =>
+          metadata.group === group,
+      )
+      .forEach((job) => deleteJob(job));
+  };
+
+  return (
+    <nav className={f('buttons')}>
+      <Tooltip
+        title={
+          <div>
+            <b>Delete Job</b>: This will remove the stored data of all the
+            sequences associated with this job from your browser. Remember that
+            search results are only retained on our servers for 7 days
+          </div>
+        }
+      >
+        <button
+          className={f('icon', 'icon-common', 'ico-neutral', 'group')}
+          onClick={handleDelete}
+          data-icon="&#xf1f8;"
+          aria-label="Delete Results"
+        />
+      </Tooltip>
+    </nav>
+  );
+};
+GroupActions.propTypes = {
+  group: T.string.isRequired,
+  jobs: T.object,
+  deleteJob: T.func,
+};
+
+const mapStateToProps = createSelector(
+  (state) => state.jobs,
+  (jobs) => ({ jobs }),
+);
+
+export default connect(mapStateToProps, {
+  deleteJob,
+})(GroupActions);

--- a/src/components/IPScan/Actions/__snapshots__/test.js.snap
+++ b/src/components/IPScan/Actions/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`<Actions /> should render 1`] = `
     title={
       <div>
         <b>
-          Delete search
+          Delete sequence
         </b>
         : This will remove the stored data from your browser. Remember that search results are only retained on our servers for 7 days
       </div>

--- a/src/components/IPScan/Actions/index.js
+++ b/src/components/IPScan/Actions/index.js
@@ -105,7 +105,7 @@ export class Actions extends PureComponent /*:: <Props> */ {
         <Tooltip
           title={
             <div>
-              <b>Delete search</b>: This will remove the stored data from your
+              <b>Delete sequence</b>: This will remove the stored data from your
               browser. Remember that search results are only retained on our
               servers for 7 days
             </div>

--- a/src/components/IPScan/Actions/index.js
+++ b/src/components/IPScan/Actions/index.js
@@ -46,7 +46,7 @@ export class Actions extends PureComponent /*:: <Props> */ {
     deleteJob: T.func.isRequired,
     goToCustomLocation: T.func.isRequired,
     keepJobAsLocal: T.func.isRequired,
-    sequence: T.string.isRequired,
+    sequence: T.string,
     attributes: T.shape({
       applications: T.arrayOf(T.string),
     }),

--- a/src/components/IPScan/Actions/style.css
+++ b/src/components/IPScan/Actions/style.css
@@ -9,3 +9,7 @@
     cursor: pointer;
   }
 }
+
+button.group::before {
+  color: var(--colors-progress, #1f6ca2);
+}

--- a/src/components/IPScan/AdvancedOptions/__snapshots__/test.js.snap
+++ b/src/components/IPScan/AdvancedOptions/__snapshots__/test.js.snap
@@ -8,7 +8,12 @@ exports[`<AdvancedOptions /> should render 1`] = `
     className="columns margin-bottom-medium option-style"
   >
     <summary>
-      Advanced options
+      <span
+        className="triangle"
+      >
+        ►
+      </span>
+       Advanced options
     </summary>
     <fieldset
       className="fieldset"

--- a/src/components/IPScan/AdvancedOptions/index.js
+++ b/src/components/IPScan/AdvancedOptions/index.js
@@ -209,7 +209,9 @@ export class AdvancedOptions extends PureComponent /*:: <AdvancedOptionsProps> *
         <details
           className={f('columns', 'margin-bottom-medium', 'option-style')}
         >
-          <summary>Advanced options</summary>
+          <summary>
+            <span className={f('triangle')}>►</span> Advanced options
+          </summary>
           <fieldset className={f('fieldset')}>
             <legend>Job configuration</legend>
             <Tooltip title="Stay on this page after submitting a new job?">

--- a/src/components/IPScan/AdvancedOptions/style.css
+++ b/src/components/IPScan/AdvancedOptions/style.css
@@ -24,3 +24,12 @@
     margin: 0 1ch 0 0;
   }
 }
+details .triangle {
+  position: absolute;
+  left: 0;
+  transform: rotate(0deg);
+  transition: transform 0.2s;
+}
+details[open] .triangle {
+  transform: rotate(90deg);
+}

--- a/src/components/IPScan/ImportResultSearch/LoadedFileDialog/index.js
+++ b/src/components/IPScan/ImportResultSearch/LoadedFileDialog/index.js
@@ -132,6 +132,7 @@ const LoadedFileDialog = (
       } else {
         // prettier-ignore
         const result/*: ProteinResult */ = (fileContent.results[i]/*: any */);
+        result.group = fileName;
         saveJobInIDB(
           result,
           `imported_file-${fileName}-${i + 1}`,

--- a/src/components/IPScan/ResultImporter/index.js
+++ b/src/components/IPScan/ResultImporter/index.js
@@ -69,8 +69,8 @@ ResultImporter.propTypes = {
 };
 
 const mapStateToUrl = createSelector(
-  state => state.settings.ipScan,
-  state => state.customLocation.description.result.accession,
+  (state) => state.settings.ipScan,
+  (state) => state.customLocation.description.result.accession,
   ({ protocol, hostname, port, root }, accession) => {
     return format({
       protocol,
@@ -81,13 +81,13 @@ const mapStateToUrl = createSelector(
   },
 );
 const mapStateToProps = createSelector(
-  state => state.customLocation.description.result.accession,
-  accession => ({ accession }),
+  (state) => state.customLocation.description.result.accession,
+  (accession) => ({ accession }),
 );
 
 export default loadData({
   getUrl: mapStateToUrl,
   mapStateToProps,
   mapDispatchToProps: { importJob },
-  fetchOptions: { responseType: 'text' },
+  fetchOptions: { useCache: false, responseType: 'text' },
 })(ResultImporter);

--- a/src/components/IPScan/ResultImporter/index.js
+++ b/src/components/IPScan/ResultImporter/index.js
@@ -7,6 +7,7 @@ import loadData from 'higherOrder/loadData';
 
 import Loading from 'components/SimpleCommonComponents/Loading';
 import id from 'utils/cheap-unique-id';
+import { IPscanRegex } from 'utils/processDescription/handlers';
 
 import { foundationPartial } from 'styles/foundation';
 import ipro from 'styles/interpro-new.css';
@@ -15,6 +16,14 @@ import theme from 'styles/theme-interpro.css';
 const f = foundationPartial(theme, ipro);
 
 const STATUS_OK = 200;
+
+const getBaseIPScanID = (accession) => {
+  const matches = accession.match(IPscanRegex);
+  const posfix = matches[2];
+  return posfix && posfix.startsWith('-')
+    ? accession.slice(0, -posfix.length)
+    : accession;
+};
 const ResultImporter = ({
   accession,
   shouldImport,
@@ -35,7 +44,7 @@ const ResultImporter = ({
         metadata: {
           localID: id(`internal-${Date.now()}`),
           type: 'InterProScan',
-          remoteID: accession,
+          remoteID: getBaseIPScanID(accession),
         },
         data: {
           input: '',
@@ -76,7 +85,7 @@ const mapStateToUrl = createSelector(
       protocol,
       hostname,
       port,
-      pathname: `${root}/status/${accession}`,
+      pathname: `${root}/status/${getBaseIPScanID(accession)}`,
     });
   },
 );

--- a/src/components/IPScan/Search/__snapshots__/test.js.snap
+++ b/src/components/IPScan/Search/__snapshots__/test.js.snap
@@ -266,7 +266,7 @@ exports[`<IPScanSearch /> should render 1`] = `
           <Memo(Connect(loadData(AdvancedOptions)))
             changeTitle={[Function]}
             initialOptions={null}
-            title=""
+            title={null}
           />
           <div
             className="row"

--- a/src/components/IPScan/Search/index.js
+++ b/src/components/IPScan/Search/index.js
@@ -36,7 +36,7 @@ import example from './example.fasta';
 
 const f = foundationPartial(interproTheme, ipro, local);
 
-export const MAX_NUMBER_OF_SEQUENCES = 3;
+export const MAX_NUMBER_OF_SEQUENCES = 100;
 
 const SchemaOrgData = loadable({
   loader: () => import(/* webpackChunkName: "schemaOrg" */ 'schema_org'),

--- a/src/components/IPScan/Search/index.js
+++ b/src/components/IPScan/Search/index.js
@@ -489,11 +489,12 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
   };
 
   _addFastAHeaderIfNeeded = (editorState, lines) => {
+    const minLengthForHeader = 3;
     const currentContent = editorState.getCurrentContent();
     if (currentContent.hasText()) {
       const firstLine = (lines?.[0] || '').trim();
       const hasHeader = firstLine.startsWith('>');
-      if (!hasHeader && firstLine.length > 3) {
+      if (!hasHeader && firstLine.length > minLengthForHeader) {
         const localTitle = `Sequence title ${getId()}`;
         const header = `> ${localTitle}`;
         this.setState({ title: localTitle });
@@ -596,8 +597,8 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
                           ), with a maximum length of 40,000 amino acids.
                         </p>
                         <p>
-                          Please note that you can only scan one sequence at a
-                          time. Alternatively, read{' '}
+                          Please note that can scan up {MAX_NUMBER_OF_SEQUENCES}{' '}
+                          sequences at a time. Alternatively, read{' '}
                           <Link
                             to={{
                               description: { other: ['about', 'interproscan'] },

--- a/src/components/IPScan/Search/index.js
+++ b/src/components/IPScan/Search/index.js
@@ -351,24 +351,9 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
     const newTitle = this._formRef.current
       .querySelector('input[name="local-title"]')
       .value.trim();
-    // const text = this.state.editorState.getCurrentContent().getPlainText();
-    // const lines = text.split(/\n/);
-    // if (
-    //   lines.map((s) => s.trim()).filter((s) => s.startsWith('>')).length > 1
-    // ) {
     this.setState({
       title: newTitle,
     });
-    //   return;
-    // }
-    // lines[0] = `>${newTitle}`;
-    // this.setState({
-    //   title: newTitle,
-    //   editorState: EditorState.createWithContent(
-    //     ContentState.createFromText(lines.join('\n')),
-    //     compositeDecorator,
-    //   ),
-    // });
   };
 
   _handleReset = (text) => {
@@ -450,6 +435,9 @@ export class IPScanSearch extends PureComponent /*:: <Props, State> */ {
     const fr = new FileReader();
     fr.onload = () => {
       this._handleReset(fr.result);
+      this.setState({
+        title: file.name,
+      });
     };
     fr.readAsText(file);
   };

--- a/src/components/IPScan/Search/style.css
+++ b/src/components/IPScan/Search/style.css
@@ -61,6 +61,9 @@
     color: var(--colors-dark);
   }
 }
+.mono {
+  font-family: var(--fonts-mono);
+}
 
 .dragging-overlay {
   position: absolute;

--- a/src/components/IPScan/Search/test.js
+++ b/src/components/IPScan/Search/test.js
@@ -2,7 +2,13 @@
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
-import { IPScanSearch, checkValidity, isTooShort, cleanUp } from '.';
+import {
+  IPScanSearch,
+  checkValidity,
+  isTooShort,
+  cleanUp,
+  MAX_NUMBER_OF_SEQUENCES,
+} from '.';
 
 jest.mock('draft-js/lib/generateRandomKey', () => () => '123');
 
@@ -45,23 +51,54 @@ describe('checkValidity()', () => {
   test('too short', () => {
     expect(checkValidity(['A'])).toEqual(true);
     expect(isTooShort(['A'])).toEqual(true);
+    expect(isTooShort([...seq.split('\n'), '> another seq', 'A'])).toEqual(
+      true,
+    );
+    expect(
+      isTooShort([
+        ...seq.split('\n'),
+        ...seq.split('\n'),
+        '> another seq',
+        'A',
+        ...seq.split('\n'),
+      ]),
+    ).toEqual(true);
+  });
+  test('Max number of sequenceas', () => {
+    let seqs = '';
+    for (let i = 0; i < MAX_NUMBER_OF_SEQUENCES; i++) seqs += `${seq}\n`;
+    expect(checkValidity(seqs.split('\n'))).toEqual(true);
+    expect(checkValidity(`${seqs}${seq}`.split('\n'))).toEqual(false);
   });
 });
 
 describe('clenUp()', () => {
   test('already clean text', () => {
-    expect(cleanUp(seq.split('\n').map(l => ({ text: l })))).toEqual(
+    expect(cleanUp(seq.split('\n').map((l) => ({ text: l })))).toEqual(
       seq.trim(),
     );
   });
   test('cleaning other chars', () => {
     expect(
-      cleanUp(`${seq}41$9{-.`.split('\n').map(l => ({ text: l }))),
+      cleanUp(`${seq}41$9{-.`.split('\n').map((l) => ({ text: l }))),
     ).toEqual(seq.trim());
   });
-  test('multiple sequence', () => {
+  test('double headers', () => {
     expect(
-      cleanUp((seq + seq + seq).split('\n').map(l => ({ text: l }))),
-    ).toEqual(seq.trim());
+      cleanUp(
+        `${seq}\n> double header${seq}${seq}`
+          .split('\n')
+          .map((l) => ({ text: l })),
+      ),
+    ).toEqual(`${seq.trim()}\n${seq.trim()}\n${seq.trim()}`);
+    expect(
+      cleanUp(
+        `${seq}\n;comment\n> double header\n;comment${seq}${seq}`
+          .split('\n')
+          .map((l) => ({ text: l })),
+      ),
+    ).toEqual(
+      `${seq.trim()}\n;comment\n;comment\n${seq.trim()}\n${seq.trim()}`,
+    );
   });
 });

--- a/src/components/IPScan/Status/__snapshots__/test.js.snap
+++ b/src/components/IPScan/Status/__snapshots__/test.js.snap
@@ -47,6 +47,7 @@ exports[`<IPScanStatus /> should render 1`] = `
     actualSize={0}
     contentType="result"
     dataTable={Array []}
+    groupActions={[Function]}
     query={Object {}}
     rowKey="localID"
     shouldGroup={true}
@@ -71,17 +72,11 @@ exports[`<IPScanStatus /> should render 1`] = `
       </DropDownButton>
     </ExtraOptions>
     <Column
-      dataKey="localID"
+      dataKey="localTitle"
       isSearchable={true}
       renderer={[Function]}
     >
       Results
-    </Column>
-    <Column
-      dataKey="localTitle"
-      isSearchable={true}
-    >
-      Name
     </Column>
     <Column
       dataKey="times"

--- a/src/components/IPScan/Status/index.js
+++ b/src/components/IPScan/Status/index.js
@@ -204,7 +204,9 @@ export class IPScanStatus extends PureComponent /*:: <Props> */ {
                       },
                     }}
                   >
-                    {localTitle || row.remoteID || row.localID}
+                    {(localTitle === '∅' ? null : localTitle) ||
+                      row.remoteID ||
+                      row.localID}
                   </Link>
                 </span>
                 {row.remoteID && !row.remoteID.startsWith('imported') && (

--- a/src/components/IPScan/Status/index.js
+++ b/src/components/IPScan/Status/index.js
@@ -14,6 +14,7 @@ import RefreshButton from 'components/IPScan/RefreshButton';
 import ClearAllDialog from 'components/IPScan/ClearAllDialog';
 import ImportResultSearch from 'components/IPScan/ImportResultSearch';
 import Actions from 'components/IPScan/Actions';
+import GroupActions from 'components/IPScan/Actions/Group';
 import TooltipAndRTDLink from 'components/Help/TooltipAndRTDLink';
 import CopyToClipboard from 'components/SimpleCommonComponents/CopyToClipboard';
 import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
@@ -173,6 +174,7 @@ export class IPScanStatus extends PureComponent /*:: <Props> */ {
           query={search}
           showTableIcon={false}
           shouldGroup={true}
+          groupActions={(group) => () => <GroupActions group={group} />}
         >
           <ExtraOptions>
             <DropDownButton label="Clear All" icon="&#xf1f8;">
@@ -186,23 +188,25 @@ export class IPScanStatus extends PureComponent /*:: <Props> */ {
             </DropDownButton>
           </ExtraOptions>
           <Column
-            dataKey="localID"
+            dataKey="localTitle"
             isSearchable={true}
-            renderer={(localID /*: string */, row /*: Object */) => (
+            renderer={(localTitle /*: string */, row /*: Object */) => (
               <>
-                <Link
-                  to={{
-                    description: {
-                      main: { key: 'result' },
-                      result: {
-                        type: 'InterProScan',
-                        accession: row.remoteID || localID,
+                <span style={{ marginRight: '1em' }}>
+                  <Link
+                    to={{
+                      description: {
+                        main: { key: 'result' },
+                        result: {
+                          type: 'InterProScan',
+                          accession: row.remoteID || row.localID,
+                        },
                       },
-                    },
-                  }}
-                >
-                  {row.remoteID || localID}{' '}
-                </Link>
+                    }}
+                  >
+                    {localTitle || row.remoteID || row.localID}
+                  </Link>
+                </span>
                 {row.remoteID && !row.remoteID.startsWith('imported') && (
                   <CopyToClipboard
                     textToCopy={getIProScanURL(row.remoteID)}
@@ -213,9 +217,6 @@ export class IPScanStatus extends PureComponent /*:: <Props> */ {
             )}
           >
             Results
-          </Column>
-          <Column dataKey="localTitle" isSearchable={true}>
-            Name
           </Column>
           <Column
             dataKey="times"

--- a/src/components/IPScan/SubJobsBrowser/index.js
+++ b/src/components/IPScan/SubJobsBrowser/index.js
@@ -1,0 +1,111 @@
+// @flow
+import React, { useRef, useEffect, useState } from 'react';
+import T from 'prop-types';
+
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+import { IPscanRegex } from 'utils/processDescription/handlers';
+import Link from 'components/generic/Link';
+
+import { foundationPartial } from 'styles/foundation';
+import theme from 'styles/theme-interpro.css';
+import style from './style.css';
+
+const f = foundationPartial(theme, style);
+
+/*::
+type Props ={
+  accession: string,
+  jobs: {
+    remoteID: string,
+    localTitle: string,
+  }[]
+}
+  */
+
+const SubJobsBrowser = ({ jobs, accession } /*: Props */) => {
+  const scroller /*: { current: null | HTMLDivElement } */ = useRef(null);
+  const [currentJob, setCurrentJob] = useState(0);
+  useEffect(() => {
+    scroller.current?.addEventListener('scroll', () => {
+      const first = Array.from(scroller.current?.querySelectorAll('div') || [])
+        .map((e, i) => ({
+          id: e.id,
+          left: e.getBoundingClientRect().left,
+          position: i,
+        }))
+        .filter(({ left }) => left >= 0)?.[0];
+      if (first && currentJob !== first.position) setCurrentJob(first.position);
+    });
+  }, [scroller.current]);
+  if ((jobs?.length || 0) < 2) return null;
+
+  const scroll = (next /*: boolean */ = true) => {
+    if (scroller?.current) {
+      const itemSize =
+        (next ? 1 : -1) *
+        (scroller?.current?.querySelector('div')?.clientWidth || 0);
+      scroller?.current?.scrollBy(itemSize, 0);
+    }
+  };
+  const scrollNext = () => scroll(true);
+  const scrollPrev = () => scroll(false);
+  return (
+    <section className={f('callout', 'jobs-browser')}>
+      <header>This result was part of a multiple sequence job.</header>
+      <main>
+        <div className={f('counter')}>
+          {currentJob + 1} of {jobs.length}
+        </div>
+        <button onClick={scrollPrev}>◀︎</button>
+
+        <div className={f('job-slider')}>
+          <div className={f('slides')} ref={scroller}>
+            {jobs.map(({ remoteID, localTitle }) => (
+              <div key={remoteID} id={remoteID}>
+                {remoteID === accession ? (
+                  <b>{localTitle}</b>
+                ) : (
+                  <Link
+                    to={{
+                      description: {
+                        main: { key: 'result' },
+                        result: { type: 'InterProScan', accession: remoteID },
+                      },
+                    }}
+                  >
+                    {localTitle}
+                  </Link>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+        <button onClick={scrollNext}>►</button>
+      </main>
+    </section>
+  );
+};
+SubJobsBrowser.propTypes = {
+  jobs: T.arrayOf(T.object),
+  accession: T.string,
+};
+
+const mapStateToProps = createSelector(
+  (state) => state.customLocation.description.result.accession,
+  (state) => state.jobs,
+  (accession, jobs) => {
+    const matches = accession.match(IPscanRegex);
+    const posfix = matches[2] || matches[3];
+    if (!posfix || !posfix.startsWith('-')) return {};
+    const jobIDBase = accession.slice(0, -posfix.length);
+    // prettier-ignore
+    const relatedJobs = (Object.values(jobs)/*: any*/)
+      .map(({ metadata }) => metadata)
+      .filter(({ remoteID }) => remoteID.startsWith(jobIDBase));
+    return { jobs: relatedJobs, accession };
+  },
+);
+
+export default connect(mapStateToProps)(SubJobsBrowser);

--- a/src/components/IPScan/SubJobsBrowser/index.js
+++ b/src/components/IPScan/SubJobsBrowser/index.js
@@ -53,11 +53,11 @@ const SubJobsBrowser = ({ jobs, accession } /*: Props */) => {
   const scrollPrev = () => scroll(false);
   return (
     <section className={f('callout', 'jobs-browser')}>
-      <header>This result was part of a multiple sequence job.</header>
+      <header>
+        This result was part of a multiple ({jobs.length}) sequence job. You can
+        choose another sequence below:
+      </header>
       <main>
-        <div className={f('counter')}>
-          {currentJob + 1} of {jobs.length}
-        </div>
         <button onClick={scrollPrev}>◀︎</button>
 
         <div className={f('job-slider')}>

--- a/src/components/IPScan/SubJobsBrowser/style.css
+++ b/src/components/IPScan/SubJobsBrowser/style.css
@@ -1,0 +1,55 @@
+.jobs-browser {
+  background: var(--colors-very-white, #eee);
+  border: 0;
+  & header {
+    font-weight: 400;
+  }
+  & main {
+    --main-scroller-height: 3em;
+    display: flex;
+    border: 1px solid var(--colors-ulightgray, #ddd);
+    & .counter {
+      white-space: nowrap;
+      justify-content: center;
+      align-items: center;
+      margin: 0 0.5em;
+      line-height: var(--main-scroller-height, 3em);
+    }
+    & button {
+      cursor: pointer;
+      &:hover {
+        text-shadow: 2px 2px 5px yellow;
+      }
+    }
+    & .job-slider {
+      width: 100%;
+      text-align: center;
+      overflow: hidden;
+
+      & .slides {
+        display: flex;
+
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
+
+        scroll-behavior: smooth;
+        -webkit-overflow-scrolling: touch;
+
+        & > div {
+          scroll-snap-align: start;
+          flex-shrink: 0;
+          width: 100%;
+          height: var(--main-scroller-height, 3em);
+          margin-right: 50px;
+          border-radius: 10px;
+          background: #eee;
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: left;
+          padding-left: 1em;
+        }
+      }
+    }
+  }
+}

--- a/src/components/IPScan/SubJobsBrowser/style.css
+++ b/src/components/IPScan/SubJobsBrowser/style.css
@@ -7,7 +7,6 @@
   & main {
     --main-scroller-height: 3em;
     display: flex;
-    border: 1px solid var(--colors-ulightgray, #ddd);
     & .counter {
       white-space: nowrap;
       justify-content: center;
@@ -25,6 +24,7 @@
       width: 100%;
       text-align: center;
       overflow: hidden;
+      border: 1px solid var(--colors-ulightgray, #ddd);
 
       & .slides {
         display: flex;
@@ -36,13 +36,13 @@
         -webkit-overflow-scrolling: touch;
 
         & > div {
-          scroll-snap-align: start;
+          scroll-snap-align: center;
           flex-shrink: 0;
-          width: 100%;
+          width: 60%;
           height: var(--main-scroller-height, 3em);
-          margin-right: 50px;
+          margin-right: 1em;
           border-radius: 10px;
-          background: #eee;
+          background: var(--colors-almost-white, #eee);
           position: relative;
           display: flex;
           align-items: center;

--- a/src/components/IPScan/Summary/IPScanTitle/index.js
+++ b/src/components/IPScan/Summary/IPScanTitle/index.js
@@ -70,9 +70,10 @@ const IPScanTitle = (
         <input
           ref={titleInputRef}
           className={f('title')}
-          defaultValue={`${title}`}
+          value={title}
           readOnly={readable}
           style={{ width: `${title.length}ch` }}
+          onChange={(event) => setTitle(event.target.value)}
         />
         {['finished', 'imported file', 'saved in browser'].includes(status) ? (
           <button

--- a/src/components/IPScan/Summary/index.js
+++ b/src/components/IPScan/Summary/index.js
@@ -27,6 +27,7 @@ import { getIProScanURL } from 'components/IPScan/Status';
 import IPScanVersionCheck from 'components/IPScan/IPScanVersionCheck';
 import NucleotideSummary from 'components/IPScan/NucleotideSummary';
 import IPScanTitle from './IPScanTitle';
+import SubJobsBrowser from '../SubJobsBrowser';
 import { Exporter } from 'components/Table';
 import { updateJobTitle } from 'actions/creators';
 
@@ -207,6 +208,7 @@ const SummaryIPScanJob = ({
           ipScanVersion={payload['interproscan-version']}
           callback={setVersionMismatch}
         />
+        <SubJobsBrowser />
         <NucleotideSummary payload={payload} />
         <IPScanTitle
           localTitle={localTitle}

--- a/src/components/IPScan/Summary/index.js
+++ b/src/components/IPScan/Summary/index.js
@@ -18,7 +18,6 @@ import Loading from 'components/SimpleCommonComponents/Loading';
 import CopyToClipboard from 'components/SimpleCommonComponents/CopyToClipboard';
 import GoTerms from 'components/GoTerms';
 import Accession from 'components/Accession';
-import Title from 'components/Title';
 import ProteinEntryHierarchy from 'components/Protein/ProteinEntryHierarchy';
 import Length from 'components/Protein/Length';
 import { DomainOnProteinWithoutMergedData } from 'components/Related/DomainsOnProtein';
@@ -198,7 +197,6 @@ const SummaryIPScanJob = ({
   return (
     <div className={f('sections')}>
       <section>
-        <Title metadata={metadata} mainType="protein" />
         {!data.payload && payload?.['interproscan-version'] ? (
           <div className={f('callout', 'info', 'withicon')}>
             Using data stored in your browser

--- a/src/components/IPScan/Summary/index.js
+++ b/src/components/IPScan/Summary/index.js
@@ -339,10 +339,10 @@ const SummaryIPScanJob = ({
 };
 SummaryIPScanJob.propTypes = {
   accession: T.string.isRequired,
-  localID: T.string.isRequired,
+  localID: T.string,
   remoteID: T.string,
   localTitle: T.string,
-  status: T.string.isRequired,
+  status: T.string,
   data: dataPropType,
   localPayload: T.object,
   api: T.object,
@@ -375,11 +375,11 @@ const mapStateToProps = createSelector(
   jobSelector,
   (state) => state.settings.api,
   (state) => state.settings.ipScan,
-  (accession, { metadata: { localID, remoteID, status } }, api, ipScan) => ({
+  (accession, job, api, ipScan) => ({
     accession,
-    localID,
-    remoteID,
-    status,
+    localID: job?.metadata?.localID,
+    remoteID: job?.metadata?.remoteID,
+    status: job?.metadata?.status,
     api,
     ipScan,
   }),

--- a/src/components/Table/Body/index.js
+++ b/src/components/Table/Body/index.js
@@ -74,6 +74,7 @@ class NoRows extends PureComponent /*:: <Props> */ {
   columns: Array<string>,
   rowClassName:string | function,
   groups?: Array<string>,
+  groupActions?: (string)=>any,
   notFound: boolean
 } */
 
@@ -88,6 +89,7 @@ class Body extends PureComponent /*:: <BodyProps> */ {
     notFound: T.bool,
     rowClassName: T.oneOfType([T.string, T.func]),
     groups: T.arrayOf(T.string),
+    groupActions: T.object,
   };
 
   static defaultProps = {
@@ -105,6 +107,7 @@ class Body extends PureComponent /*:: <BodyProps> */ {
       notFound,
       rowClassName,
       groups,
+      groupActions,
     } = this.props;
     const edgeCaseText = edgeCases.get(status);
     if (edgeCaseText)
@@ -132,10 +135,12 @@ class Body extends PureComponent /*:: <BodyProps> */ {
           const rowData = row.metadata || row;
           const extraData = row.extra_fields;
           const rcn = row.className ? row.className : rowClassName;
+          let GroupActions = null;
           const shouldRenderGroupHeader =
             groups?.length && row.group && curentGroup !== row.group;
           if (shouldRenderGroupHeader) {
             curentGroup = row.group;
+            GroupActions = groupActions?.(row.group);
           }
           return (
             <React.Fragment key={rowData[rowKey] || index}>
@@ -143,12 +148,23 @@ class Body extends PureComponent /*:: <BodyProps> */ {
                 <tr>
                   <th
                     style={{
+                      color: 'var(--colors-progress, #1f6ca2)',
                       textAlign: 'start',
                       backgroundColor: colorHash.hex(row.group),
                     }}
                   >
                     {row.group}
                   </th>
+                  {GroupActions && (
+                    <>
+                      {columns.slice(2).map((_, i) => (
+                        <th key={i} />
+                      ))}
+                      <th>
+                        <GroupActions />
+                      </th>
+                    </>
+                  )}
                 </tr>
               )}
               <Row

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -56,6 +56,7 @@ ExtraOptions.propTypes = { children: T.any };
   showTableIcon?: boolean,
   onFocusChanged?: ?function,
   shouldGroup?: boolean,
+  groupActions?: (string)=>any
 } */
 
 const TableView = loadable({
@@ -245,6 +246,7 @@ export default class Table extends PureComponent /*:: <Props> */ {
     showTableIcon: T.bool,
     shouldGroup: T.bool,
     onFocusChanged: T.func,
+    groupActions: T.func,
   };
 
   render() {
@@ -270,6 +272,7 @@ export default class Table extends PureComponent /*:: <Props> */ {
       showTableIcon,
       onFocusChanged,
       shouldGroup,
+      groupActions,
     } = this.props;
 
     const _query = query || {};
@@ -373,6 +376,7 @@ export default class Table extends PureComponent /*:: <Props> */ {
                   rowClassName={rowClassName}
                   onFocusChanged={onFocusChanged}
                   groups={groups}
+                  groupActions={groupActions}
                 />
               </div>
               <Switch

--- a/src/components/Table/views/Table/index.js
+++ b/src/components/Table/views/Table/index.js
@@ -24,6 +24,7 @@ const f = foundationPartial(styles, ipro, fonts);
   columns: Array<string>,
   rowClassName?: string | function,
   groups?: Array<string>,
+  groupActions?: Array<(string)=>any>,
 } */
 
 class TableView extends PureComponent /*:: <Props> */ {
@@ -38,6 +39,7 @@ class TableView extends PureComponent /*:: <Props> */ {
     rowKey: T.string,
     rowClassName: T.oneOfType([T.string, T.func]),
     groups: T.arrayOf(T.string),
+    groupActions: T.arrayOf(T.object),
   };
 
   render() {
@@ -52,6 +54,7 @@ class TableView extends PureComponent /*:: <Props> */ {
       rowKey,
       rowClassName,
       groups,
+      groupActions,
     } = this.props;
     return (
       <table
@@ -70,6 +73,7 @@ class TableView extends PureComponent /*:: <Props> */ {
           status={status}
           rowClassName={rowClassName}
           groups={groups}
+          groupActions={groupActions}
         />
       </table>
     );

--- a/src/components/Title/index.js
+++ b/src/components/Title/index.js
@@ -61,9 +61,7 @@ const mapNameToClass = new Map([
 const accessionDisplay = new Set(['protein', 'structure', 'proteome']);
 
 const EntryIcon = (
-  {
-    metadata,
-  } /*: {metadata: {name: { name: string, short: ?string },
+  { metadata } /*: {metadata: {name: { name: string, short: ?string },
     accession: string | number,
     source_database: string,
     type: string,
@@ -130,11 +128,7 @@ const rtdLinks = {
 };
 
 const TitleTag = (
-  {
-    metadata,
-    mainType,
-    dbLabel,
-  } /*: {metadata:
+  { metadata, mainType, dbLabel } /*: {metadata:
                     {
                       name: { name: string, short: ?string },
                       accession: string | number,
@@ -195,23 +189,21 @@ TitleTag.propTypes = {
 };
 
 const AccessionTag = (
-  {
-    metadata,
-    mainType,
-  } /*: {metadata:
-                    {
-                      name: { name: string, short: ?string },
-                      accession: string | number,
-                      source_database: string,
-                      type: string,
-                      gene?: string,
-                      experiment_type?: string,
-                      source_organism?: Object,
-                      release_date?: string,
-                      chains?: Array<string>
-                      },
-                      mainType: string
-                      } */,
+  { metadata, mainType, isIPScanResult = false } /*: {metadata:
+    {
+      name: { name: string, short: ?string },
+      accession: string | number,
+      source_database: string,
+      type: string,
+      gene?: string,
+      experiment_type?: string,
+      source_organism?: Object,
+      release_date?: string,
+      chains?: Array<string>,
+    },
+    mainType: string,
+    isIPScanResult: boolean,
+  } */,
 ) => {
   const isEntry = mainType === 'entry';
   return (
@@ -247,7 +239,7 @@ const AccessionTag = (
         // greyblueish accession: for protein , structure, and proteomes and no accession for tax
         accessionDisplay.has(mainType) &&
           metadata.source_database !== 'taxonomy' &&
-          metadata.name.name !== 'InterProScan Search Result' && (
+          !isIPScanResult && (
             // for proteins, structures and proteomes (no accession in title for taxonomy and sets)
             <span className={f('title-id-other')}>{metadata.accession}</span>
           )
@@ -258,6 +250,7 @@ const AccessionTag = (
 AccessionTag.propTypes = {
   metadata: T.object.isRequired,
   mainType: T.string.isRequired,
+  isIPScanResult: T.bool,
 };
 
 class Title extends PureComponent /*:: <Props, State> */ {
@@ -295,6 +288,7 @@ class Title extends PureComponent /*:: <Props, State> */ {
       databases && databases[metadata.source_database]
         ? databases[metadata.source_database].name
         : metadata.source_database;
+    const isIPScanResult = metadata.name.name === 'InterProScan Search Result';
 
     return (
       <div className={f('title')} data-testid="titlebar">
@@ -339,18 +333,19 @@ class Title extends PureComponent /*:: <Props, State> */ {
           </Helmet>
         )}
 
-        <div className={f('title-name')}>
+        <div
+          className={f('title-name', {
+            ipscan: isIPScanResult,
+          })}
+        >
           <div className={f('title-fav')}>
-            {
-              // add margin only for IPSCAN result page
-              metadata.name.name === 'InterProScan Search Result' ? (
-                <h3 className={f('margin-bottom-large')}>
-                  {metadata.name.name}{' '}
-                </h3>
-              ) : (
-                <h3>{metadata.name.name}</h3>
-              )
-            }
+            <h3
+              className={f({
+                'margin-bottom-large': isIPScanResult,
+              })}
+            >
+              {metadata.name.name}{' '}
+            </h3>
             {
               // Showing Favourites only for InterPro entries for now
               isEntry &&
@@ -380,7 +375,11 @@ class Title extends PureComponent /*:: <Props, State> */ {
           </div>
           <TitleTag metadata={metadata} mainType={mainType} dbLabel={dbLabel} />
         </div>
-        <AccessionTag metadata={metadata} mainType={mainType} />
+        <AccessionTag
+          metadata={metadata}
+          mainType={mainType}
+          isIPScanResult={isIPScanResult}
+        />
       </div>
     );
   }

--- a/src/components/Title/style.css
+++ b/src/components/Title/style.css
@@ -3,6 +3,9 @@
 .title {
   display: flex;
 
+  .title-name {
+    display: inline-flex;
+  }
   & > div:first-of-type:not(.icon-container):not(.title-name) {
     margin-top: 0.5rem; /* when using tooltip only way to move the SVG icon*/
   }

--- a/src/components/Title/style.css
+++ b/src/components/Title/style.css
@@ -3,7 +3,7 @@
 .title {
   display: flex;
 
-  .title-name {
+  & .title-name.ipscan {
     display: inline-flex;
   }
   & > div:first-of-type:not(.icon-container):not(.title-name) {

--- a/src/pages/Sequence/index.js
+++ b/src/pages/Sequence/index.js
@@ -4,6 +4,7 @@ import T from 'prop-types';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 
+import Title from 'components/Title';
 import { BrowseTabsWithoutData } from 'components/BrowseTabs';
 import ErrorBoundary from 'wrappers/ErrorBoundary';
 import Switch from 'components/generic/Switch';
@@ -198,6 +199,13 @@ class IPScanResult extends PureComponent /*:: <Props, State> */ {
         />
       );
     }
+    const metadata = {
+      accession,
+      counters: { entries },
+      name: {
+        name: 'InterProScan Search Result',
+      },
+    };
     return (
       <>
         <ResultImporter
@@ -210,6 +218,7 @@ class IPScanResult extends PureComponent /*:: <Props, State> */ {
               {
                 // Menu Just for InterProScan search
               }
+              <Title metadata={metadata} mainType="protein" />
 
               <BrowseTabsWithoutData
                 key="browse"
@@ -218,7 +227,7 @@ class IPScanResult extends PureComponent /*:: <Props, State> */ {
                 mainAccession={matched}
                 data={{
                   loading: false,
-                  payload: { metadata: { counters: { entries } } },
+                  payload: { metadata },
                 }}
               />
             </div>

--- a/src/store/enhancer/jobs-middleware/index.js
+++ b/src/store/enhancer/jobs-middleware/index.js
@@ -47,7 +47,7 @@ import getTableAccess, { IPScanJobsMeta, IPScanJobsData } from 'storage/idb';
 // eslint-disable-next-line no-magic-numbers
 const DEFAULT_SCHEDULE_DELAY = 1000 * 2; // 2 seconds
 // eslint-disable-next-line no-magic-numbers
-const DEFAULT_LOOP_TIMEOUT = 1000 * 6; // one minute
+const DEFAULT_LOOP_TIMEOUT = 1000 * 10; // ten seconds
 // eslint-disable-next-line no-magic-numbers
 export const MAX_TIME_ON_SERVER = 1000 * 60 * 60 * 24 * 7; // one week
 
@@ -125,6 +125,8 @@ const updateJobInDB = async (
       ...data,
       results: [data?.results?.[0]],
     };
+    newData.originalInput = newData.input;
+    delete newData.input;
 
     metadata.localTitle = title || data?.results?.[0]?.xref?.[0]?.name;
     if (data?.results?.length > 1 && !remoteID.endsWith('-1')) {

--- a/src/store/enhancer/jobs-middleware/index.js
+++ b/src/store/enhancer/jobs-middleware/index.js
@@ -130,6 +130,7 @@ const updateJobInDB = async (
 
     metadata.localTitle = title || data?.results?.[0]?.xref?.[0]?.name;
     if (data?.results?.length > 1 && !remoteID.endsWith('-1')) {
+      metadata.group = remoteID;
       metadata.remoteID = `${remoteID}-1`;
       metadata.localID = `${localID}-1`;
       metaT.delete(localID);

--- a/src/subPages/Sequence/index.js
+++ b/src/subPages/Sequence/index.js
@@ -5,31 +5,42 @@ import { dataPropType } from 'higherOrder/loadData/dataPropTypes';
 
 import Sequence, { InnerSequence } from 'components/Protein/Sequence';
 
-/*:: type Props = {
-  localPayload: {
-    sequence: string,
-    xref: [],
-    orf: {
-      dnaSequence: string,
-      start: number,
-      end: number,
-    },
-    group: string,
+/*::
+type LocalPayload = {
+  sequence: string,
+  xref: {
+      identifier: string,
+      name: string,
+    }[],
+  orf: {
+    dnaSequence: string,
+    start: number,
+    end: number,
   },
+  group: string,
+};
+type RemotePayload= {
+  metadata?: {
+    accession: string,
+    sequence: string,
+    name?: {
+      name?: string,
+    },
+  },
+  results?: {
+    xref:{
+      identifier: string,
+      name: string,
+    }[]
+  }
+};
+type Props = {
+  localPayload: LocalPayload,
   localTitle: string,
   data: {
     loading: boolean,
     ok: boolean,
-    payload:
-      {
-        metadata: {
-          accession: string,
-          sequence: string,
-          name?: {
-            name?: string,
-          },
-        },
-      },
+    payload: RemotePayload,
   }
 }; */
 
@@ -44,20 +55,25 @@ class SequenceSubPage extends PureComponent /*:: <Props> */ {
     let accession;
     let sequence;
     let name;
-    let { payload } = this.props.data;
-    const { loading, ok } = this.props.data;
-    if (ok && !loading && !payload?.metadata)
-      payload = payload?.results?.[0] || this.props.localPayload;
-    if (!payload) return null;
     const local = this.props.localPayload;
-    if (payload.metadata) {
-      accession = payload.metadata.accession;
-      sequence = payload.metadata.sequence;
-      name = payload.metadata.name?.name;
+    let payload = null;
+    const { loading, ok } = this.props.data;
+    if (ok && !loading && !payload && this.props.data?.payload) {
+      payload = this.props.data?.payload;
+    }
+    if (!payload && !local) return null;
+    if (payload?.metadata) {
+      accession = payload.metadata?.accession;
+      sequence = payload.metadata?.sequence;
+      name = payload.metadata?.name?.name;
+    } else if (payload?.results) {
+      accession = payload.results?.[0]?.xref?.accession;
+      sequence = payload.results?.[0]?.xref?.sequence;
+      name = payload.results?.[0]?.xref?.name?.name;
     } else {
-      accession = payload.xref[0].identifier || '';
-      name = this.props.localTitle || payload.xref[0].name || '';
-      sequence = payload.sequence;
+      accession = local.xref[0].identifier || '';
+      name = this.props.localTitle || local.xref[0].name || '';
+      sequence = local.sequence;
     }
     return (
       <>

--- a/src/utils/processDescription/handlers/index.js
+++ b/src/utils/processDescription/handlers/index.js
@@ -593,7 +593,7 @@ export const resultTypeHandler /*: Handler */ = handlerConstructor({
   },
 });
 export const IPscanRegex =
-  /^(iprscan5-[SRI]\d{8}-\d{6}-\d{4}-\d+-\w{2,4}(-\d+)?|internal-[1-9]\d*-[1-9]\d*)|imported_file-.+-\d+$/;
+  /^(iprscan5-[SRI]\d{8}-\d{6}-\d{4}-\d+-\w{2,4}(-\d+)?|internal-[1-9]\d*-[1-9]\d*)|imported_file-.+(-\d+)$/;
 export const resultIPScanAccessionHandler /*: Handler */ = handlerConstructor({
   name: {
     value: 'resultIPScanAccessionHandler',

--- a/src/utils/processDescription/handlers/index.js
+++ b/src/utils/processDescription/handlers/index.js
@@ -592,7 +592,8 @@ export const resultTypeHandler /*: Handler */ = handlerConstructor({
     value: /^(interproscan|download)$/i,
   },
 });
-
+export const IPscanRegex =
+  /^(iprscan5-[SRI]\d{8}-\d{6}-\d{4}-\d+-\w{2,4}(-\d+)?|internal-[1-9]\d*-[1-9]\d*)|imported_file-.+-\d+$/;
 export const resultIPScanAccessionHandler /*: Handler */ = handlerConstructor({
   name: {
     value: 'resultIPScanAccessionHandler',
@@ -604,8 +605,7 @@ export const resultIPScanAccessionHandler /*: Handler */ = handlerConstructor({
     value: (value) => value,
   },
   regexp: {
-    value:
-      /^(iprscan5-[SRI]\d{8}-\d{6}-\d{4}-\d+-\w{2,4}|internal-[1-9]\d*-[1-9]\d*)|imported_file-.+-\d+$/,
+    value: IPscanRegex,
   },
 });
 


### PR DESCRIPTION
The purpose of this PR is to support the submission of multiple sequences to the InterProScan web service. 

Several changes were required in order to get this working:
1. Updates in the checks done in the textarea for the sequence
2. Updates in the "automatic clean" function to avoid deleting sequences and prevent 2 fasta headers without content
3. The results are now displayed on a "local-first" basis. Only if there is no data in IndexedDB, check the web service.
4. Each sequence on a job receives the ID of the job concatenated with a suffix `-n` where n is the position on the results file.
5. Multiple sequences are grouped in the job list, using the same logic as nucleotide files.
6. A selector of sequences in the same job was added at the top of the results page.
7.  Importing a job by its ipscan id should work with or without the suffix

Currently deployed in http://wp-np3-aa.ebi.ac.uk/future/ for testing purposes