### PR TITLE
Subfamilies

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -45,6 +45,7 @@ pages:
       - pathways
       - genome3d
       - curation
+      - subfamilies
   protein:
     subPages:
       - entry

--- a/src/components/ProtVista/Popup/Entry/index.js
+++ b/src/components/ProtVista/Popup/Entry/index.js
@@ -115,7 +115,7 @@ const ProtVistaEntryPopup = (
                   <header>Subfamily</header>
                   <ul>
                     <li>
-                      <header>Accession:</header> {subfamily.acc}
+                      <header>Accession:</header> {subfamily.accession}
                     </li>
                     <li>
                       <header>Name:</header> {subfamily.name}

--- a/src/components/ProtVista/Popup/Entry/index.js
+++ b/src/components/ProtVista/Popup/Entry/index.js
@@ -63,7 +63,11 @@ const ProtVistaEntryPopup = (
   if (highlightChild) {
     newLocations = highlightChild.split(',').map((loc) => {
       const [start, end] = loc.split(':');
-      return { fragments: [{ start, end }], model_acc: null };
+      return {
+        fragments: [{ start, end }],
+        model_acc: null,
+        subfamily: undefined,
+      };
     });
   }
   const handleClick = (start, end) => () => {
@@ -103,9 +107,22 @@ const ProtVistaEntryPopup = (
       </p>
       <ul>
         {(newLocations || locations || []).map(
-          ({ fragments, model_acc: model }, j) => (
+          ({ fragments, model_acc: model, subfamily }, j) => (
             <li key={j}>
               {model && model !== accession && <>Model: {model}</>}
+              {subfamily && (
+                <div className={f('subfamily')}>
+                  <header>Subfamily</header>
+                  <ul>
+                    <li>
+                      <header>Accession:</header> {subfamily.accession}
+                    </li>
+                    <li>
+                      <header>Name:</header> {subfamily.name}
+                    </li>
+                  </ul>
+                </div>
+              )}
               <ul>
                 {(fragments || []).map(({ start, end }, i) => (
                   <li key={i}>

--- a/src/components/ProtVista/Popup/Entry/index.js
+++ b/src/components/ProtVista/Popup/Entry/index.js
@@ -66,7 +66,7 @@ const ProtVistaEntryPopup = (
       return {
         fragments: [{ start, end }],
         model_acc: null,
-        subfamily: undefined,
+        subfamily: locations?.[0]?.subfamily,
       };
     });
   }
@@ -115,7 +115,7 @@ const ProtVistaEntryPopup = (
                   <header>Subfamily</header>
                   <ul>
                     <li>
-                      <header>Accession:</header> {subfamily.accession}
+                      <header>Accession:</header> {subfamily.acc}
                     </li>
                     <li>
                       <header>Name:</header> {subfamily.name}

--- a/src/components/ProtVista/Popup/index.js
+++ b/src/components/ProtVista/Popup/index.js
@@ -20,7 +20,7 @@ import ProtVistaConservationPopup from './Conservation';
     model_acc?: string,
     subfamily?: {
       name: string,
-      accession: string,
+      acc: string,
     },
   }
   export type PopupDetail = {

--- a/src/components/ProtVista/Popup/index.js
+++ b/src/components/ProtVista/Popup/index.js
@@ -20,7 +20,7 @@ import ProtVistaConservationPopup from './Conservation';
     model_acc?: string,
     subfamily?: {
       name: string,
-      acc: string,
+      accession: string,
     },
   }
   export type PopupDetail = {

--- a/src/components/ProtVista/Popup/index.js
+++ b/src/components/ProtVista/Popup/index.js
@@ -18,6 +18,10 @@ import ProtVistaConservationPopup from './Conservation';
     fragments: Array<ProtVistaFragment>,
     match?: string,
     model_acc?: string,
+    subfamily?: {
+      name: string,
+      accession: string,
+    },
   }
   export type PopupDetail = {
     feature: {

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -132,6 +132,7 @@ const loadProtVistaWebComponents = () => {
 export class ProtVista extends Component /*:: <Props, State> */ {
   /*::
     web_tracks: {};
+    reactRoot: any;
     popper: any;
     _isPopperTop: boolean;
     _timeoutID: ?IntervalID;
@@ -360,8 +361,10 @@ export class ProtVista extends Component /*:: <Props, State> */ {
               this.props?.dataDB?.payload?.databases,
             );
             if (this._popperContentRef.current) {
-              const root = createRoot(this._popperContentRef.current);
-              root.render(
+              if (!this.reactRoot)
+                this.reactRoot = createRoot(this._popperContentRef.current);
+
+              this.reactRoot.render(
                 <ProtVistaPopup
                   detail={detail}
                   sourceDatabase={sourceDatabase}

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -12,7 +12,7 @@ import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 import Link from 'components/generic/Link';
 import Loading from 'components/SimpleCommonComponents/Loading';
 import { Genome3dLink } from 'components/ExtLink';
-import { FunFamLink } from 'subpages/Subfamilies';
+import { FunFamLink } from 'subPages/Subfamilies';
 
 import ProtVistaManager from 'protvista-manager';
 import ProtVistaSequence from 'protvista-sequence';

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -12,6 +12,7 @@ import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 import Link from 'components/generic/Link';
 import Loading from 'components/SimpleCommonComponents/Loading';
 import { Genome3dLink } from 'components/ExtLink';
+import { FunFamLink } from 'subpages/Subfamilies';
 
 import ProtVistaManager from 'protvista-manager';
 import ProtVistaSequence from 'protvista-sequence';
@@ -471,6 +472,11 @@ export class ProtVista extends Component /*:: <Props, State> */ {
     }
     if (entry.source_database === 'mobidblt')
       return <Link href={`https://mobidb.org/${id}`}>{entry.accession}</Link>;
+    if (entry.source_database === 'funfam') {
+      return (
+        <FunFamLink accession={entry.accession}>{entry.accession}</FunFamLink>
+      );
+    }
     if (entry.type === 'residue')
       return <span>{entry.locations[0].description}</span>;
     if (

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -361,6 +361,7 @@ export class ProtVista extends Component /*:: <Props, State> */ {
               this.props?.dataDB?.payload?.databases,
             );
             if (this._popperContentRef.current) {
+              // eslint-disable-next-line max-depth
               if (!this.reactRoot)
                 this.reactRoot = createRoot(this._popperContentRef.current);
 

--- a/src/components/ProtVista/style.css
+++ b/src/components/ProtVista/style.css
@@ -487,12 +487,17 @@ div.subfamily {
   margin-bottom: 0.5rem;
   font-size: 0.8rem;
   background: #444;
+  text-align: left;
+  padding: 0.3rem;
 
   & > header {
     font-weight: bold;
+    margin-bottom: 0.5rem;
   }
   & ul li > header {
     font-weight: 600;
     display: inline-block;
+    min-width: 7rem;
+    padding-left: 1rem;
   }
 }

--- a/src/components/ProtVista/style.css
+++ b/src/components/ProtVista/style.css
@@ -482,3 +482,17 @@ protvista-zoom-tool {
     margin: 1px;
   }
 }
+
+div.subfamily {
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  background: #444;
+
+  & > header {
+    font-weight: bold;
+  }
+  & ul li > header {
+    font-weight: 600;
+    display: inline-block;
+  }
+}

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -344,6 +344,7 @@ export default class Table extends PureComponent /*:: <Props> */ {
           <div className={f('row')}>
             <div className={f('columns')}>
               <_TotalNb
+                {...this.props}
                 className={f('show-for-small-only')}
                 data={data}
                 actualSize={actualSize}

--- a/src/higherOrder/loadData/defaults/index.js
+++ b/src/higherOrder/loadData/defaults/index.js
@@ -201,6 +201,7 @@ export const getUrlForApi = (...parameters) =>
     .replace('/alphafold', '/')
     .replace('/domain_architecture', '/')
     .replace('/interactions', '/')
+    .replace('/subfamilies', '/')
     .replace('/pathways', '/')
     .replace('/sequence', '/')
     .replace('/genome3d', '/')

--- a/src/menuConfig.js
+++ b/src/menuConfig.js
@@ -530,6 +530,25 @@ export const singleEntity /*: Map<string, Object> */ = new Map([
     },
   ],
   [
+    'subfamilies',
+    {
+      to(customLocation) {
+        return {
+          description: {
+            ...getEmptyDescription(),
+            main: { key: 'entry' },
+            entry: {
+              ...customLocation.description.entry,
+              detail: 'subfamilies',
+            },
+          },
+        };
+      },
+      name: 'Subfamilies',
+      counter: 'subfamilies',
+    },
+  ],
+  [
     'genome3d',
     {
       to(customLocation) {

--- a/src/schema_org/processors.js
+++ b/src/schema_org/processors.js
@@ -175,7 +175,7 @@ export const endpoint2type = {
 };
 
 const cleanUpDescription = (description /*: string */) =>
-  (Array.isArray(description) ? description[0] : description)
+  ((Array.isArray(description) ? description[0] : description) || '')
     .replace(/\r/g, '')
     .replace(/\n/g, '')
     .replace(/<\/?[a-zA-Z]+>/g, '')

--- a/src/subPages/Subfamilies/index.js
+++ b/src/subPages/Subfamilies/index.js
@@ -1,56 +1,107 @@
 // @flow
 import React from 'react';
+import T from 'prop-types';
 import { dataPropType } from 'higherOrder/loadData/dataPropTypes';
 
-import FullyLoadedTable from 'components/Table/FullyLoadedTable';
+import { createSelector } from 'reselect';
+import { format } from 'url';
+import descriptionToPath from 'utils/processDescription/descriptionToPath';
+import loadData from 'higherOrder/loadData';
+
+import Table, { Column, PageSizeSelector } from 'components/Table';
 import Link from 'components/generic/Link';
 import Loading from 'components/SimpleCommonComponents/Loading';
 
 import f from 'styles/foundation';
 
 const SubfamiliesSubpage = (
-  { data } /*: {data: {loading: boolean, payload: ?Object}}*/,
+  { data, search } /*: {
+    data: {loading: boolean, ok: boolean, status: number, payload: ?Object, url: string},
+    search: Object,
+  }*/,
 ) => {
   if (data.loading) return <Loading />;
-  const _data = (data?.payload?.results || []).map(
-    ({ metadata: { accession, name } }) => ({
-      accession,
-      name,
-    }),
-  );
 
   return (
     <section>
-      {_data.length && (
-        <FullyLoadedTable
-          data={_data}
-          renderers={{
-            accession: (accession) => (
-              <Link
-                target="_blank"
-                className={f('ext')}
-                href={`http://www.pantherdb.org/panther/family.do?clsAccession=${accession.toUpperCase()}`}
-              >
-                {accession}
-              </Link>
-            ),
-            name: (name, { accession }) => (
-              <Link
-                target="_blank"
-                className={f('ext')}
-                href={`http://www.pantherdb.org/panther/family.do?clsAccession=${accession.toUpperCase()}`}
-              >
-                {name}
-              </Link>
-            ),
-          }}
-        />
-      )}
+      <Table
+        dataTable={data.payload?.results.map((e) => e.metadata) || []}
+        contentType="search"
+        loading={data.loading}
+        status={data.status}
+        ok={data.ok}
+        query={search}
+        actualSize={data.payload?.count || 0}
+        nextAPICall={data.payload?.next}
+        previousAPICall={data.payload?.previous}
+        currentAPICall={data.url}
+      >
+        <PageSizeSelector />
+        <Column
+          dataKey="accession"
+          renderer={(accession) => (
+            <Link
+              target="_blank"
+              className={f('ext')}
+              href={`http://www.pantherdb.org/panther/family.do?clsAccession=${accession.toUpperCase()}`}
+            >
+              {accession}
+            </Link>
+          )}
+        >
+          Accession
+        </Column>
+        <Column
+          dataKey="name"
+          renderer={(name, { accession }) => (
+            <Link
+              target="_blank"
+              className={f('ext')}
+              href={`http://www.pantherdb.org/panther/family.do?clsAccession=${accession.toUpperCase()}`}
+            >
+              {name}
+            </Link>
+          )}
+        >
+          Accession
+        </Column>
+      </Table>
     </section>
   );
 };
 SubfamiliesSubpage.propTypes = {
   data: dataPropType,
+  search: T.object,
 };
+const mapStateToUrl = createSelector(
+  (state) => state.settings.api,
+  (state) => state.customLocation.description?.entry?.accession,
+  (state) => state.customLocation.search,
+  ({ protocol, hostname, port, root }, accession, search) => {
+    const s = {
+      ...search,
+      subfamilies: '',
+    };
+    return format({
+      protocol,
+      hostname,
+      port,
+      pathname:
+        root +
+        descriptionToPath({
+          main: { key: 'entry' },
+          entry: { db: 'panther', accession },
+        }),
+      query: s,
+    });
+  },
+);
+export const mapStateToProps = createSelector(
+  (state) => state.customLocation.search,
+  (search) => ({ search }),
+);
 
-export default SubfamiliesSubpage;
+export default loadData({
+  getUrl: mapStateToUrl,
+  mapStateToProps,
+})(SubfamiliesSubpage);

--- a/src/subPages/Subfamilies/index.js
+++ b/src/subPages/Subfamilies/index.js
@@ -1,0 +1,56 @@
+// @flow
+import React from 'react';
+import { dataPropType } from 'higherOrder/loadData/dataPropTypes';
+
+import FullyLoadedTable from 'components/Table/FullyLoadedTable';
+import Link from 'components/generic/Link';
+import Loading from 'components/SimpleCommonComponents/Loading';
+
+import f from 'styles/foundation';
+
+const SubfamiliesSubpage = (
+  { data } /*: {data: {loading: boolean, payload: ?Object}}*/,
+) => {
+  if (data.loading) return <Loading />;
+  const _data = (data?.payload?.results || []).map(
+    ({ metadata: { accession, name } }) => ({
+      accession,
+      name,
+    }),
+  );
+
+  return (
+    <section>
+      {_data.length && (
+        <FullyLoadedTable
+          data={_data}
+          renderers={{
+            accession: (accession) => (
+              <Link
+                target="_blank"
+                className={f('ext')}
+                href={`http://www.pantherdb.org/panther/family.do?clsAccession=${accession.toUpperCase()}`}
+              >
+                {accession}
+              </Link>
+            ),
+            name: (name, { accession }) => (
+              <Link
+                target="_blank"
+                className={f('ext')}
+                href={`http://www.pantherdb.org/panther/family.do?clsAccession=${accession.toUpperCase()}`}
+              >
+                {name}
+              </Link>
+            ),
+          }}
+        />
+      )}
+    </section>
+  );
+};
+SubfamiliesSubpage.propTypes = {
+  data: dataPropType,
+};
+
+export default SubfamiliesSubpage;

--- a/src/subPages/index.js
+++ b/src/subPages/index.js
@@ -30,6 +30,10 @@ const InteractionsSubPage = loadable({
 const PathwaysSubPage = loadable({
   loader: () => import(/* webpackChunkName: "pathways-subpage" */ './Pathways'),
 });
+const SubfamiliesSubPage = loadable({
+  loader: () =>
+    import(/* webpackChunkName: "subfamilies-subpage" */ './Subfamilies'),
+});
 
 const HMMModel = loadable({
   loader: () =>
@@ -167,7 +171,7 @@ const getGenome3dURL = createSelector(
     });
   },
 );
-const getInterProModifierURL = (modifier) =>
+const getDBModifierURL = (db, modifier) =>
   createSelector(
     (state) => state.settings.api,
     (state) => state.customLocation.description.entry,
@@ -177,7 +181,7 @@ const getInterProModifierURL = (modifier) =>
       const _description = {
         main: { key: 'entry' },
         entry: {
-          db: 'interpro',
+          db,
           accession: entry.accession,
         },
       };
@@ -201,9 +205,16 @@ const subPages = new Map([
   ['domain_architecture', DomainArchitecture],
   [
     'interactions',
-    loadData(getInterProModifierURL('interactions'))(InteractionsSubPage),
+    loadData(getDBModifierURL('InterPro', 'interactions'))(InteractionsSubPage),
   ],
-  ['pathways', loadData(getInterProModifierURL('pathways'))(PathwaysSubPage)],
+  [
+    'pathways',
+    loadData(getDBModifierURL('InterPro', 'pathways'))(PathwaysSubPage),
+  ],
+  [
+    'subfamilies',
+    loadData(getDBModifierURL('panther', 'subfamilies'))(SubfamiliesSubPage),
+  ],
   ['rosettafold', RoseTTAFoldModel],
   ['alphafold', AlphaFoldModelSubPage],
   ['alignments', SetAlignments],

--- a/src/subPages/index.js
+++ b/src/subPages/index.js
@@ -211,10 +211,7 @@ const subPages = new Map([
     'pathways',
     loadData(getDBModifierURL('InterPro', 'pathways'))(PathwaysSubPage),
   ],
-  [
-    'subfamilies',
-    loadData(getDBModifierURL('panther', 'subfamilies'))(SubfamiliesSubPage),
-  ],
+  ['subfamilies', SubfamiliesSubPage],
   ['rosettafold', RoseTTAFoldModel],
   ['alphafold', AlphaFoldModelSubPage],
   ['alignments', SetAlignments],

--- a/src/utils/url/index.js
+++ b/src/utils/url/index.js
@@ -66,7 +66,9 @@ export const toCanonicalURL = (
       const regex = /(.+)=(.+)/;
       const matches = regex.exec(arg);
       if (matches) {
-        return `${matches[1]}=${encodeURIComponent(matches[2])}`;
+        return `${matches[1]}=${
+          matches[1] === 'cursor' ? matches[2] : encodeURIComponent(matches[2])
+        }`;
       }
       return arg;
     })


### PR DESCRIPTION
Adding a subpage for panther families to list the subfamilies related to it.

It also adds a section in the popups in the protein viewers where a panther family matches, indicating which subfamily is responsible for the match.

A small improvement in the way the protvista popups work was made to avoid the creation of multiple react roots and instead reuse the first one that was created.

**Note:** It requires the API change in https://github.com/ProteinsWebTeam/interpro7-api/pull/89