### PR TITLE
Removing Pfam links to pfam.xfam.org

### DIFF
--- a/src/components/Entry/Summary/index.js
+++ b/src/components/Entry/Summary/index.js
@@ -232,7 +232,9 @@ const _SidePanel = ({ metadata, dbInfo, api, addToast }) => {
         </Tooltip>
       </div>
       {metadata.integrated && <Integration intr={metadata.integrated} />}
-      {metadata.source_database.toLowerCase() !== 'interpro' && (
+      {!['interpro', 'pfam'].includes(
+        metadata.source_database.toLowerCase(),
+      ) && (
         <section>
           <h5>External Links</h5>
           <ul className={f('no-bullet')}>
@@ -246,18 +248,6 @@ const _SidePanel = ({ metadata, dbInfo, api, addToast }) => {
                 {(dbInfo && dbInfo.name) || metadata.source_database}
               </Link>
             </li>
-            {false && // TODO: reactivate that after change in the API
-              metadata.wikipedia && (
-                <li>
-                  <Link
-                    className={f('ext')}
-                    target="_blank"
-                    href={`https://en.wikipedia.org/wiki/${metadata.wikipedia}`}
-                  >
-                    Wikipedia article
-                  </Link>
-                </li>
-              )}
           </ul>
         </section>
       )}
@@ -554,12 +544,7 @@ const _wikipedia = ({ title, extract, thumbnail, data }) => {
                             {id.name}
                           </a>
                         </th>
-                        <td className={f('row-data')}>
-                          {/* TODO add external links*/}
-                          {/* <a rel="nofollow" className="external text" href="http://pfam.xfam.org/family?acc=PF02171">*/}
-                          {id.value}
-                          {/* </a>*/}
-                        </td>
+                        <td className={f('row-data')}>{id.value}</td>
                       </tr>
                     );
                   })}

--- a/src/components/Set/ClanViewer/index.js
+++ b/src/components/Set/ClanViewer/index.js
@@ -1,0 +1,267 @@
+// @flow
+import React, { PureComponent } from 'react';
+import T from 'prop-types';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+import { goToCustomLocation } from 'actions/creators';
+
+import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
+import { setDBs } from 'utils/processDescription/handlers';
+import { getTextForLabel } from 'utils/text';
+
+import ClanViewerViz from 'clanviewer';
+import 'clanviewer/build/main.css';
+import ZoomOverlay from 'components/ZoomOverlay';
+
+import { foundationPartial } from 'styles/foundation';
+import ebiGlobalStyles from 'ebi-framework/css/ebi-global.css';
+import style from '../Summary/style.css';
+import LabelBy from '../../ProtVista/Options/LabelBy';
+
+const f = foundationPartial(ebiGlobalStyles, style);
+
+/*::
+type Props = {
+  data: {
+    metadata: Object,
+  },
+  db: string,
+  goToCustomLocation: function,
+  loading: boolean,
+  label: {
+    accession: boolean,
+    name: boolean,
+    short: boolean,
+  },
+};
+
+type State = {
+  showClanViewer: boolean,
+  nodeHovered: null | {
+    accession:string,
+    name:string,
+    short_name:string,
+  }
+};
+ */
+const MAX_NUMBER_OF_NODES = 100;
+
+class ClanViewer extends PureComponent /*:: <Props, State> */ {
+  /*::
+    _ref: { current: null | React$ElementRef<'div'> };
+    _vis: typeof ClanViewerViz;
+    loaded: boolean;
+  */
+  static propTypes = {
+    data: T.shape({
+      metadata: T.object,
+    }).isRequired,
+    db: T.string.isRequired,
+    goToCustomLocation: T.func.isRequired,
+    loading: T.bool.isRequired,
+    label: T.shape({
+      accession: T.bool,
+      name: T.bool,
+      short: T.bool,
+    }),
+  };
+
+  constructor(props /*: Props */) {
+    super(props);
+
+    this._ref = React.createRef();
+    this.state = { showClanViewer: false, nodeHovered: null };
+    this.loaded = false;
+  }
+
+  componentDidMount() {
+    if (!this._ref.current || this._vis) return;
+    this._vis = new ClanViewerViz({
+      element: this._ref.current,
+      useCtrlToZoom: true,
+      height: 600,
+      nodeLabel: (node) => getTextForLabel(node, this.props.label),
+    });
+    if (
+      this.props?.data?.metadata?.relationships?.nodes &&
+      this.props.data.metadata.relationships.nodes.length <= MAX_NUMBER_OF_NODES
+    )
+      this.setState({ showClanViewer: true });
+    this._ref.current?.addEventListener('click', (evt /*: Event */) =>
+      this._handleClick(evt),
+    );
+    this.updateLocationIfAllDB();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.label !== this.props.label) this._refreshLabels();
+    if (
+      prevProps.data?.metadata?.accession !==
+      this.props?.data?.metadata?.accession
+    )
+      this.loaded = false;
+    this.repaint();
+    this.updateLocationIfAllDB();
+  }
+
+  componentWillUnmount() {
+    if (this._ref.current) {
+      this._ref.current?.removeEventListener('click', this._handleClick);
+    }
+    this._vis.clear();
+  }
+  updateLocationIfAllDB() {
+    if (
+      this.props.db === 'all' &&
+      this.props?.data?.metadata?.source_database
+    ) {
+      this.props.goToCustomLocation({
+        description: {
+          main: { key: 'set' },
+          set: {
+            db: this.props?.data?.metadata?.source_database,
+            accession: this.props?.data?.metadata?.accession,
+          },
+        },
+      });
+    }
+  }
+  repaint() {
+    if (
+      (this.state.showClanViewer ||
+        this.props.data.metadata.relationships.nodes.length <=
+          MAX_NUMBER_OF_NODES) &&
+      !this.loaded
+    ) {
+      const data = this.props.data.metadata.relationships;
+      this._vis.clear();
+      this._vis.paint(data, false);
+      this.loaded = true;
+      for (const node /*: HTMLElement */ of this._ref.current?.querySelectorAll(
+        'g.node',
+      ) || []) {
+        node.addEventListener('mouseenter', (evt /*: Event */) => {
+          this.setState({ nodeHovered: (evt.target /*: any */).__data__ });
+        });
+        node.addEventListener('mouseleave', () => {
+          this.setState({ nodeHovered: null });
+        });
+      }
+    }
+  }
+
+  _handleClick = (event /*: Event */) => {
+    const g = event
+      .composedPath()
+      .filter((e /*: any */) => e.nodeName === 'g')
+      .filter((e /*: any */) => e.classList.contains('node'))?.[0];
+    if (g) {
+      this.props.goToCustomLocation({
+        description: {
+          main: { key: 'entry' },
+          entry: {
+            db: this.props.db,
+            accession: (g /*: any */).dataset.accession,
+          },
+        },
+      });
+    }
+  };
+  _refreshLabels = () => {
+    this._vis.updatingLabels = true;
+    if (this._vis.tick) this._vis.tick();
+    this._vis.updatingLabels = false;
+  };
+  render() {
+    const metadata =
+      this.props.loading || !this.props.data.metadata
+        ? {
+            accession: '',
+            description: '',
+            id: '',
+            source_database: '',
+            authors: null,
+            literature: null,
+          }
+        : this.props.data.metadata;
+    let currentSet = null;
+    if (metadata.source_database) {
+      for (const db of setDBs) {
+        if (db.name === metadata.source_database) currentSet = db;
+      }
+      if (metadata.source_database === 'panther')
+        metadata.description = metadata.name.name;
+    }
+
+    return (
+      <div className={f('row')}>
+        {!this.state.showClanViewer &&
+          metadata.relationships &&
+          metadata.relationships.nodes &&
+          metadata.relationships.nodes.length > MAX_NUMBER_OF_NODES && (
+            <div
+              className={f('flex-card')}
+              style={{ width: '50%', padding: '1em' }}
+            >
+              <h3>ClanViewer</h3>
+              <section>
+                The selected clan has {metadata.relationships.nodes.length}{' '}
+                member entries. Displaying more than {MAX_NUMBER_OF_NODES} nodes
+                in this visualisation can affect the performance of your
+                browser.
+                <button
+                  className={f('button')}
+                  onClick={() => this.setState({ showClanViewer: true })}
+                >
+                  Visualise it
+                </button>
+              </section>
+            </div>
+          )}
+        <div>
+          <DropDownButton
+            label="Label Content"
+            extraClasses={f('protvista-menu')}
+          >
+            <LabelBy />
+          </DropDownButton>
+        </div>
+        <div className={f('clanviewer-container')}>
+          <ZoomOverlay elementId="clanViewerContainer" />
+          <div
+            ref={this._ref}
+            style={{ minHeight: 500 }}
+            id="clanViewerContainer"
+          />
+          <div
+            className={f('legends')}
+            style={{
+              opacity: this.state.nodeHovered ? 1 : 0,
+            }}
+          >
+            <ul className={f('no-bullet')}>
+              <li>
+                <b>Accession</b>: {this.state?.nodeHovered?.accession}
+              </li>
+              <li>
+                <b>Name</b>: {this.state?.nodeHovered?.name}
+              </li>
+              <li>
+                <b>Short name</b>: {this.state?.nodeHovered?.short_name}
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createSelector(
+  (state) => state.customLocation.description.set.db,
+  (state) => state.settings.ui,
+  (db, ui) => ({ db, label: ui.labelContent }),
+);
+
+export default connect(mapStateToProps, { goToCustomLocation })(ClanViewer);

--- a/src/components/Set/ClanViewer/index.js
+++ b/src/components/Set/ClanViewer/index.js
@@ -185,14 +185,6 @@ class ClanViewer extends PureComponent /*:: <Props, State> */ {
             literature: null,
           }
         : this.props.data.metadata;
-    let currentSet = null;
-    if (metadata.source_database) {
-      for (const db of setDBs) {
-        if (db.name === metadata.source_database) currentSet = db;
-      }
-      if (metadata.source_database === 'panther')
-        metadata.description = metadata.name.name;
-    }
 
     return (
       <div className={f('row')}>

--- a/src/components/Set/ClanViewer/index.js
+++ b/src/components/Set/ClanViewer/index.js
@@ -7,7 +7,6 @@ import { createSelector } from 'reselect';
 import { goToCustomLocation } from 'actions/creators';
 
 import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
-import { setDBs } from 'utils/processDescription/handlers';
 import { getTextForLabel } from 'utils/text';
 
 import ClanViewerViz from 'clanviewer';

--- a/src/components/Set/Summary/index.js
+++ b/src/components/Set/Summary/index.js
@@ -213,7 +213,7 @@ class SummarySet extends PureComponent /*:: <Props> */ {
                 </div>
               </div>
             ) : null}
-            <ClanViewer data={this.props.data} />
+            <ClanViewer data={this.props.data} loading={this.props.loading} />
           </div>
         </section>
       </div>

--- a/src/components/Set/Summary/index.js
+++ b/src/components/Set/Summary/index.js
@@ -4,19 +4,11 @@ import T from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { goToCustomLocation } from 'actions/creators';
-
 import Accession from 'components/Accession';
 import Description from 'components/Description';
-import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
 import { BaseLink } from 'components/ExtLink';
 import { setDBs } from 'utils/processDescription/handlers';
-import { getTextForLabel } from 'utils/text';
 import Literature from 'components/Entry/Literature';
-
-import ClanViewer from 'clanviewer';
-import 'clanviewer/build/main.css';
-import ZoomOverlay from 'components/ZoomOverlay';
 
 import loadable from 'higherOrder/loadable';
 import config from 'config';
@@ -25,7 +17,7 @@ import descriptionToPath from 'utils/processDescription/descriptionToPath';
 import { foundationPartial } from 'styles/foundation';
 import ebiGlobalStyles from 'ebi-framework/css/ebi-global.css';
 import style from './style.css';
-import LabelBy from '../../ProtVista/Options/LabelBy';
+import ClanViewer from '../ClanViewer';
 
 const f = foundationPartial(ebiGlobalStyles, style);
 
@@ -35,24 +27,9 @@ type Props = {
     metadata: Object,
   },
   db: string,
-  goToCustomLocation: function,
-  customLocation: Object,
   loading: boolean,
-  label: {
-    accession: boolean,
-    name: boolean,
-    short: boolean,
-  },
 };
 
-type State = {
-  showClanViewer: boolean,
-  nodeHovered: null | {
-    accession:string,
-    name:string,
-    short_name:string,
-  }
-};
  */
 const SchemaOrgData = loadable({
   loader: () => import(/* webpackChunkName: "schemaOrg" */ 'schema_org'),
@@ -138,136 +115,15 @@ SetAuthors.propTypes = {
   authors: T.arrayOf(T.string),
 };
 
-class SummarySet extends PureComponent /*:: <Props, State> */ {
-  /*::
-    _ref: { current: null | React$ElementRef<'div'> };
-    _vis: typeof ClanViewer;
-    loaded: boolean;
-  */
+class SummarySet extends PureComponent /*:: <Props> */ {
   static propTypes = {
     data: T.shape({
       metadata: T.object,
     }).isRequired,
     db: T.string.isRequired,
-    goToCustomLocation: T.func.isRequired,
-    customLocation: T.object.isRequired,
     loading: T.bool.isRequired,
-    label: T.shape({
-      accession: T.bool,
-      name: T.bool,
-      short: T.bool,
-    }),
   };
 
-  constructor(props /*: Props */) {
-    super(props);
-
-    this._ref = React.createRef();
-    this.state = { showClanViewer: false, nodeHovered: null };
-    this.loaded = false;
-  }
-
-  componentDidMount() {
-    if (!this._ref.current || this._vis) return;
-    this._vis = new ClanViewer({
-      element: this._ref.current,
-      useCtrlToZoom: true,
-      height: 600,
-      nodeLabel: (node) => getTextForLabel(node, this.props.label),
-    });
-    if (
-      this.props.data &&
-      this.props.data.metadata &&
-      this.props.data.metadata.relationships &&
-      this.props.data.metadata.relationships.nodes &&
-      this.props.data.metadata.relationships.nodes.length <= MAX_NUMBER_OF_NODES
-    )
-      this.setState({ showClanViewer: true });
-    this._ref.current?.addEventListener('click', (evt /*: Event */) =>
-      this._handleClick(evt),
-    );
-    this.updateLocationIfAllDB();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.label !== this.props.label) this._refreshLabels();
-    if (
-      prevProps.data?.metadata?.accession !==
-      this.props?.data?.metadata?.accession
-    )
-      this.loaded = false;
-    this.repaint();
-    this.updateLocationIfAllDB();
-  }
-
-  componentWillUnmount() {
-    if (this._ref.current) {
-      this._ref.current?.removeEventListener('click', this._handleClick);
-    }
-    this._vis.clear();
-  }
-  updateLocationIfAllDB() {
-    if (
-      this.props.db === 'all' &&
-      this.props?.data?.metadata?.source_database
-    ) {
-      this.props.goToCustomLocation({
-        description: {
-          main: { key: 'set' },
-          set: {
-            db: this.props?.data?.metadata?.source_database,
-            accession: this.props?.data?.metadata?.accession,
-          },
-        },
-      });
-    }
-  }
-  repaint() {
-    if (
-      (this.state.showClanViewer ||
-        this.props.data.metadata.relationships.nodes.length <=
-          MAX_NUMBER_OF_NODES) &&
-      !this.loaded
-    ) {
-      const data = this.props.data.metadata.relationships;
-      this._vis.clear();
-      this._vis.paint(data, false);
-      this.loaded = true;
-      for (const node /*: HTMLElement */ of this._ref.current?.querySelectorAll(
-        'g.node',
-      ) || []) {
-        node.addEventListener('mouseenter', (evt /*: Event */) => {
-          this.setState({ nodeHovered: (evt.target /*: any */).__data__ });
-        });
-        node.addEventListener('mouseleave', () => {
-          this.setState({ nodeHovered: null });
-        });
-      }
-    }
-  }
-
-  _handleClick = (event /*: Event */) => {
-    const g = event
-      .composedPath()
-      .filter((e /*: any */) => e.nodeName === 'g')
-      .filter((e /*: any */) => e.classList.contains('node'))?.[0];
-    if (g) {
-      this.props.goToCustomLocation({
-        description: {
-          main: { key: 'entry' },
-          entry: {
-            db: this.props.db,
-            accession: (g /*: any */).dataset.accession,
-          },
-        },
-      });
-    }
-  };
-  _refreshLabels = () => {
-    this._vis.updatingLabels = true;
-    if (this._vis.tick) this._vis.tick();
-    this._vis.updatingLabels = false;
-  };
   render() {
     const metadata =
       this.props.loading || !this.props.data.metadata
@@ -293,7 +149,13 @@ class SummarySet extends PureComponent /*:: <Props, State> */ {
       <div className={f('sections')}>
         <section>
           <div className={f('row')}>
-            <div className={f('medium-9', 'columns', 'margin-bottom-large')}>
+            <div
+              className={f(
+                currentSet?.url_template ? 'medium-9' : 'medium-12',
+                'columns',
+                'margin-bottom-large',
+              )}
+            >
               <table className={f('light', 'table-sum')}>
                 <tbody>
                   <tr>
@@ -330,7 +192,7 @@ class SummarySet extends PureComponent /*:: <Props, State> */ {
                   />
                 ))}
             </div>
-            {currentSet ? (
+            {currentSet?.url_template ? (
               <div className={f('medium-3', 'columns')}>
                 <div className={f('panel')}>
                   <h5>External Links</h5>
@@ -352,65 +214,7 @@ class SummarySet extends PureComponent /*:: <Props, State> */ {
                 </div>
               </div>
             ) : null}
-          </div>
-          <div className={f('row')}>
-            {!this.state.showClanViewer &&
-              metadata.relationships &&
-              metadata.relationships.nodes &&
-              metadata.relationships.nodes.length > MAX_NUMBER_OF_NODES && (
-                <div
-                  className={f('flex-card')}
-                  style={{ width: '50%', padding: '1em' }}
-                >
-                  <h3>ClanViewer</h3>
-                  <section>
-                    The selected clan has {metadata.relationships.nodes.length}{' '}
-                    member entries. Displaying more than {MAX_NUMBER_OF_NODES}{' '}
-                    nodes in this visualisation can affect the performance of
-                    your browser.
-                    <button
-                      className={f('button')}
-                      onClick={() => this.setState({ showClanViewer: true })}
-                    >
-                      Visualise it
-                    </button>
-                  </section>
-                </div>
-              )}
-            <div>
-              <DropDownButton
-                label="Label Content"
-                extraClasses={f('protvista-menu')}
-              >
-                <LabelBy />
-              </DropDownButton>
-            </div>
-            <div className={f('clanviewer-container')}>
-              <ZoomOverlay elementId="clanViewerContainer" />
-              <div
-                ref={this._ref}
-                style={{ minHeight: 500 }}
-                id="clanViewerContainer"
-              />
-              <div
-                className={f('legends')}
-                style={{
-                  opacity: this.state.nodeHovered ? 1 : 0,
-                }}
-              >
-                <ul className={f('no-bullet')}>
-                  <li>
-                    <b>Accession</b>: {this.state?.nodeHovered?.accession}
-                  </li>
-                  <li>
-                    <b>Name</b>: {this.state?.nodeHovered?.name}
-                  </li>
-                  <li>
-                    <b>Short name</b>: {this.state?.nodeHovered?.short_name}
-                  </li>
-                </ul>
-              </div>
-            </div>
+            <ClanViewer data={this.props.data} />
           </div>
         </section>
       </div>
@@ -420,8 +224,7 @@ class SummarySet extends PureComponent /*:: <Props, State> */ {
 
 const mapStateToProps = createSelector(
   (state) => state.customLocation.description.set.db,
-  (state) => state.settings.ui,
-  (db, ui) => ({ db, label: ui.labelContent }),
+  (db) => ({ db }),
 );
 
-export default connect(mapStateToProps, { goToCustomLocation })(SummarySet);
+export default connect(mapStateToProps)(SummarySet);

--- a/src/components/Set/Summary/index.js
+++ b/src/components/Set/Summary/index.js
@@ -36,7 +36,6 @@ const SchemaOrgData = loadable({
   loading: () => null,
 });
 
-const MAX_NUMBER_OF_NODES = 100;
 export const schemaProcessData = (
   {
     data: { accession, score },

--- a/src/components/SimpleCommonComponents/DropDownButton/style.css
+++ b/src/components/SimpleCommonComponents/DropDownButton/style.css
@@ -3,7 +3,7 @@
 @import '../../../styles/z-index.css';
 
 .dropdown-container {
-  display: flex;
+  display: inline-flex;
   margin: 0;
   position: relative;
 

--- a/src/components/home/ByMemberDatabase/__snapshots__/test.js.snap
+++ b/src/components/home/ByMemberDatabase/__snapshots__/test.js.snap
@@ -98,17 +98,6 @@ exports[`<ByMemberDatabase /> Member Databases types 1`] = `
             />
           </Tooltip>
         </div>
-        <Memo(Connect(Link))
-          href="//pfam.xfam.org/"
-          target="_blank"
-        >
-          <span
-            aria-label="link to external site"
-            className="small icon icon-common"
-            data-icon=""
-            role="link"
-          />
-        </Memo(Connect(Link))>
       </div>
       <hr
         className="md pfam"

--- a/src/components/home/ByMemberDatabase/index.js
+++ b/src/components/home/ByMemberDatabase/index.js
@@ -124,16 +124,17 @@ export class ByMemberDatabase extends PureComponent /*:: <Props> */ {
                       />
                     </Tooltip>
                   </div>
-                  {memberDbURL.get(canonical) && (
-                    <Link href={memberDbURL.get(canonical)} target="_blank">
-                      <span
-                        role="link"
-                        className={f('small', 'icon', 'icon-common')}
-                        data-icon="&#xf35d;"
-                        aria-label="link to external site"
-                      />
-                    </Link>
-                  )}
+                  {canonical.toLowerCase() !== 'pfam' &&
+                    memberDbURL.get(canonical) && (
+                      <Link href={memberDbURL.get(canonical)} target="_blank">
+                        <span
+                          role="link"
+                          className={f('small', 'icon', 'icon-common')}
+                          data-icon="&#xf35d;"
+                          aria-label="link to external site"
+                        />
+                      </Link>
+                    )}
                 </div>
                 <hr className={f('md', canonical)} />
                 <small>{version}</small>

--- a/src/pages/Entry/index.js
+++ b/src/pages/Entry/index.js
@@ -692,7 +692,8 @@ class List extends PureComponent /*:: <Props> */ {
                   const symbol = (
                     <MemberSymbol type={db} className={f('md-small')} />
                   );
-                  if (!externalLinkRenderer) return symbol;
+                  if (db.toLowerCase() === 'pfam' || !externalLinkRenderer)
+                    return symbol;
                   return (
                     <Tooltip
                       title={`link to ${accession} on the ${

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -201,8 +201,15 @@ const Announcement = () => (
           >
             https://pfam-legacy.xfam.org/
           </Link>{' '}
-          until January 2023, when it will be decommissioned. Please notice this
-          version will not receive any updates and will be kept under very low
+          until January 2023, when it will be decommissioned. Please notice{' '}
+          <Link
+            href="//pfam-legacy.xfam.org/"
+            className={f('ext')}
+            target="_blank"
+          >
+            pfam-legacy.xfam.org
+          </Link>{' '}
+          will not receive any updates and will be kept under very low
           maintenance. You can read more about the sunset period in our{' '}
           <Link
             href="//xfam.wordpress.com/2022/08/04/pfam-website-decommission/"

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -185,15 +185,15 @@ const Announcement = () => (
           className={f('small', 'icon', 'icon-common', 'icon-announcement')}
         />{' '}
         <p>
-          <strong>We are the new home for Pfam data</strong>
+          <strong>InterPro is the new home of Pfam</strong>
           <br />
-          Since October 5th, we are the official web for Pfam. The Pfam website
-          (
+          The Pfam website (
           <span href="//pfam.xfam.org" className={f('link', 'disabled')}>
             pfam.xfam.org
           </span>
-          ) is now retired.
-          <br />A legacy version of the Pfam website will be available at{' '}
+          ) was shut down on October 5th, but InterPro offers the same
+          functionality and data.
+          <br />A legacy version of Pfam will remain available at{' '}
           <Link
             href="//pfam-legacy.xfam.org/"
             className={f('ext')}
@@ -201,22 +201,14 @@ const Announcement = () => (
           >
             https://pfam-legacy.xfam.org/
           </Link>{' '}
-          until January 2023, when it will be decommissioned. Please notice{' '}
-          <Link
-            href="//pfam-legacy.xfam.org/"
-            className={f('ext')}
-            target="_blank"
-          >
-            pfam-legacy.xfam.org
-          </Link>{' '}
-          will not receive any updates and will be kept under very low
-          maintenance. You can read more about the sunset period in our{' '}
+          until January 2023, but will not receive any updates. You can read
+          more about our decision to shut down the Pfam website in{' '}
           <Link
             href="//xfam.wordpress.com/2022/08/04/pfam-website-decommission/"
             className={f('ext')}
             target="_blank"
           >
-            blog post
+            our blog post
           </Link>
           .
         </p>

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -170,7 +170,7 @@ const Announcement = () => (
   <div className={f('row')}>
     <div className={f('columns', 'large-12', 'margin-bottom-xlarge')}>
       <div
-        className={f('callout', 'warning')}
+        className={f('callout', 'info')}
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -185,26 +185,25 @@ const Announcement = () => (
           className={f('small', 'icon', 'icon-common', 'icon-announcement')}
         />{' '}
         <p>
-          <strong>Powering down the Pfam website</strong>
+          <strong>We are the new house for Pfam</strong>
           <br />
-          On October 5th, we will start redirecting the traffic from Pfam (
-          <Link href="//pfam.xfam.org" className={f('ext')} target="_blank">
+          Since October 5th, we are the official web for Pfam. The Pfam website
+          (
+          <span href="//pfam.xfam.org" className={f('link', 'disabled')}>
             pfam.xfam.org
-          </Link>
-          ) to InterPro (
+          </span>
+          ) is now retired.
+          <br />A legacy version of the Pfam website will be available at{' '}
           <Link
-            to={{
-              description: {},
-            }}
+            href="//pfam-legacy.xfam.org/"
+            className={f('ext')}
+            target="_blank"
           >
-            www.ebi.ac.uk/interpro
-          </Link>
-          ). The Pfam website will be available at{' '}
-          <span href="//legacy.pfam.xfam.org" className={f('link', 'disabled')}>
-            legacy.pfam.xfam.org
-          </span>{' '}
-          until January 2023, when it will be decommissioned. You can read more
-          about the sunset period in our{' '}
+            https://pfam-legacy.xfam.org/
+          </Link>{' '}
+          until January 2023, when it will be decommissioned. Please notice this
+          version will not receive any updates and will be kept under very low
+          maintenance. You can read more about the sunset period in our{' '}
           <Link
             href="//xfam.wordpress.com/2022/08/04/pfam-website-decommission/"
             className={f('ext')}

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -185,7 +185,7 @@ const Announcement = () => (
           className={f('small', 'icon', 'icon-common', 'icon-announcement')}
         />{' '}
         <p>
-          <strong>We are the new house for Pfam</strong>
+          <strong>We are the new home for Pfam data</strong>
           <br />
           Since October 5th, we are the official web for Pfam. The Pfam website
           (

--- a/src/utils/processDescription/handlers/index.js
+++ b/src/utils/processDescription/handlers/index.js
@@ -169,7 +169,6 @@ export const setDBs /*: Set<Object> */ = new Set([
     name: 'pfam',
     dbName: 'Pfam',
     re: /^[Cc][lL][0-9]{4}$/,
-    url_template: 'http://pfam.xfam.org/clan/{id}',
   },
   {
     name: 'cdd',

--- a/src/utils/url-patterns/index.js
+++ b/src/utils/url-patterns/index.js
@@ -50,7 +50,7 @@ export const memberDbURL = new Map([
   ['cdd', '//www.ncbi.nlm.nih.gov/cdd/'],
   ['hamap', '//hamap.expasy.org/'],
   ['panther', '//pantherdb.org/'],
-  ['pfam', '//pfam.xfam.org/'],
+  ['pfam', '//www.ebi.ac.uk/interpro/entry/pfam/'],
   ['pirsf', '//proteininformationresource.org/pirsf/'],
   ['profile', '//prosite.expasy.org/'],
   ['prosite', '//prosite.expasy.org/'],
@@ -65,7 +65,7 @@ export default (db /*: string */) => {
     ['cdd', '//www.ncbi.nlm.nih.gov/Structure/cdd/cddsrv.cgi?uid={}'],
     ['hamap', '//hamap.expasy.org/signature/{}'],
     ['panther', 'http://www.pantherdb.org/panther/family.do?clsAccession={}'],
-    ['pfam', '//pfam.xfam.org/family/{}'],
+    ['pfam', '//www.ebi.ac.uk/interpro/entry/pfam/{}'],
     ['pirsf', '//pir.georgetown.edu/cgi-bin/ipcSF?id={}'],
     [
       'prints',


### PR DESCRIPTION
All links to pfam.xfam.org have been updated to point to the InterPro website or remove the link.

The announcement on the home page is updated to indicate the Pfam website has been decommissioned and InterPro is the new home for that data.

While updating the links on the Set page, I did a small refactoring, splitting the ClanViewer in its own component for clarity.