### PR TITLE
Release91 struct models

### DIFF
--- a/src/components/EntryMenu/EntryMenuLink/index.js
+++ b/src/components/EntryMenu/EntryMenuLink/index.js
@@ -204,12 +204,8 @@ export class EntryMenuLink extends PureComponent /*:: <Props> */ {
       if (whitelist.has(name)) value = NaN;
       // TODO: find a generic way to deal with this:
       if (
-        (name === 'Pathways' &&
-          payload.metadata.source_database.toLowerCase() !== 'interpro') ||
-        (name === 'AlphaFold' &&
-          !['interpro', 'pfam'].includes(
-            payload.metadata.source_database.toLowerCase(),
-          ))
+        name === 'Pathways' &&
+        payload.metadata.source_database.toLowerCase() !== 'interpro'
       ) {
         value = null;
       }

--- a/src/components/EntryMenu/EntryMenuLink/index.js
+++ b/src/components/EntryMenu/EntryMenuLink/index.js
@@ -204,8 +204,12 @@ export class EntryMenuLink extends PureComponent /*:: <Props> */ {
       if (whitelist.has(name)) value = NaN;
       // TODO: find a generic way to deal with this:
       if (
-        name === 'Pathways' &&
-        payload.metadata.source_database.toLowerCase() !== 'interpro'
+        (name === 'Pathways' &&
+          payload.metadata.source_database.toLowerCase() !== 'interpro') ||
+        (name === 'AlphaFold' &&
+          !['interpro', 'pfam'].includes(
+            payload.metadata.source_database.toLowerCase(),
+          ))
       ) {
         value = null;
       }

--- a/src/menuConfig.js
+++ b/src/menuConfig.js
@@ -429,7 +429,7 @@ export const singleEntity /*: Map<string, Object> */ = new Map([
         };
       },
       name: 'RoseTTAFold',
-      counter: 'structural_models.RoseTTAFold',
+      counter: 'structural_models.rosettafold',
     },
   ],
   [


### PR DESCRIPTION
This PR accommodates two data changes for the upcoming release:

- the counter for RoseTTAFold structures has been renamed from `RoseTTAFold` to `rosettafold`
- the number of proteins with an AlphaFold model is calculated for all entries, and not only InterPro/Pfam: 51c075f3c7ba039f566e2b5ba4f7e614bf6c1bd6 adds a condition to only display the menu link for InterPro/Pfam entries 