### PR TITLE
confidence track

### DIFF
--- a/src/components/AlphaFold/Model/index.js
+++ b/src/components/AlphaFold/Model/index.js
@@ -18,6 +18,7 @@ import { foundationPartial } from 'styles/foundation';
 import ipro from 'styles/interpro-new.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import style from './style.css';
+import { noop } from 'lodash-es';
 
 const f = foundationPartial(style, ipro, fonts);
 
@@ -55,6 +56,7 @@ const AlphaFoldModel = (
     modelUrl,
     data,
     selections,
+    onModelCifChange = noop,
   } /*: {
   proteinAcc: string,
   hasMultipleProteins: boolean,
@@ -63,9 +65,11 @@ const AlphaFoldModel = (
   modelUrl: string,
   data: FetchOutput,
   selections: Object[],
+  onModelCifChange: (x:string|null)=>void|null,
 } */,
 ) => {
   const [shouldResetViewer, setShouldResetViewer] = useState(false);
+  const [modelCif, setModelCif] = useState(null);
   useEffect(() => {
     if (shouldResetViewer) {
       requestAnimationFrame(() => setShouldResetViewer(false));
@@ -74,6 +78,9 @@ const AlphaFoldModel = (
   useEffect(() => {
     if (!selections) setShouldResetViewer(true);
   }, [selections]);
+  useEffect(() => {
+    onModelCifChange(modelCif);
+  }, [modelCif]);
 
   if (data?.loading) return <Loading />;
   if ((data?.payload || []).length === 0) {
@@ -90,6 +97,7 @@ const AlphaFoldModel = (
     modelId === null
       ? models.slice(0, 1)
       : models.filter((x) => x.entryId === modelId);
+  if (modelCif !== modelInfo.cifUrl) setModelCif(modelInfo.cifUrl);
   const elementId = 'new-structure-model-viewer';
   return (
     <div>
@@ -238,6 +246,7 @@ AlphaFoldModel.propTypes = {
   modelUrl: T.string,
   data: T.object,
   selections: T.arrayOf(T.object),
+  onModelCifChange: T.func,
 };
 
 const getModelInfoUrl = (isUrlToApi) =>

--- a/src/components/AlphaFold/ProteinTable/index.js
+++ b/src/components/AlphaFold/ProteinTable/index.js
@@ -191,10 +191,11 @@ export const getUrl = (includeSearch /*: boolean */) =>
           query: query,
         });
       }
-
-      return {
-        accession: description[description.main.key].accession,
-      };
+      return null;
+      // This below was to support the idea of multiple models for the same protein, which is unnecessary at the moment
+      // return {
+      //   accession: description[description.main.key].accession,
+      // };
     },
   );
 

--- a/src/components/ExtLink/index.js
+++ b/src/components/ExtLink/index.js
@@ -173,6 +173,11 @@ export const UniProtLink = patternLinkWrapper(
 );
 UniProtLink.displayName = 'UniProtLink';
 
+export const AlphafoldLink = patternLinkWrapper(
+  'https://alphafold.ebi.ac.uk/entry/{id}',
+);
+AlphafoldLink.displayName = 'AlphafoldLink';
+
 export const Genome3dLink = patternLinkWrapper(
   'http://www.genome3d.net/uniprot/id/{id}/annotations',
 );

--- a/src/components/ProtVista/Popup/ColorScale/index.js
+++ b/src/components/ProtVista/Popup/ColorScale/index.js
@@ -25,21 +25,30 @@ const ColorScale = (
     width = COLOR_SCALE_WIDTH,
     height = COLOR_SCALE_HEIGHT,
   } /*: ColorScaleType */,
-) => (
-  <div className={f('color-scale')}>
-    <span>{domain[0]}</span>
-    <svg height={height} width={width}>
-      <defs>
-        <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" style={{ stopColor: range[0] }} />
-          <stop offset="100%" style={{ stopColor: range[1] }} />
-        </linearGradient>
-      </defs>
-      <rect width="100%" height={height} fill="url(#grad1)" />
-    </svg>
-    <span>{domain[1]}</span>
-  </div>
-);
+) => {
+  const maxDomain = domain.slice(-1)[0];
+  return (
+    <div className={f('color-scale')}>
+      <div className={f('legend', 'left')}>{domain[0]}</div>
+      <svg height={height} width={width}>
+        <defs>
+          <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" style={{ stopColor: range[0] }} />
+            {domain.slice(1).map((d, i) => (
+              <stop
+                key={i}
+                offset={`${(100 * d) / maxDomain}%`}
+                style={{ stopColor: range[i + 1] }}
+              />
+            ))}
+          </linearGradient>
+        </defs>
+        <rect width="100%" height={height} fill="url(#grad1)" />
+      </svg>
+      <div className={f('legend', 'right')}>{maxDomain}</div>
+    </div>
+  );
+};
 ColorScale.propTypes = {
   domain: T.arrayOf(T.number),
   range: T.arrayOf(T.string),

--- a/src/components/ProtVista/Popup/Confidence/index.js
+++ b/src/components/ProtVista/Popup/Confidence/index.js
@@ -3,19 +3,25 @@ import React from 'react';
 import T from 'prop-types';
 
 import ColorScale from '../ColorScale';
+
+const levels = {
+  H: 'Very high',
+  M: 'Confident',
+  L: 'Low',
+  D: 'Very Low',
+};
 /*::
   import type {PopupDetail} from '../index.js';
 */
-const HydroPopup = ({ detail } /*: {detail: PopupDetail} */) => {
+const ConfidencePopup = ({ detail } /*: {detail: PopupDetail} */) => {
   const element = detail?.target?.closest('protvista-coloured-sequence');
   if (!element) return null;
+  const aa = detail.feature.aa || '';
   return (
     <section>
-      <h6>
-        Residue {detail.feature.start}: {detail.feature.aa}
-      </h6>
+      <h6>Residue {detail.feature.start}</h6>
       <div>
-        <b>Hydrophobicity:</b> {detail.feature.value}
+        <b>{aa ? levels[aa] : '-'}</b>
         <br />
         <br />
         <ColorScale {...(element /*: any */).colorScale} />
@@ -24,11 +30,11 @@ const HydroPopup = ({ detail } /*: {detail: PopupDetail} */) => {
     </section>
   );
 };
-HydroPopup.propTypes = {
+ConfidencePopup.propTypes = {
   detail: T.shape({
     feature: T.object,
     target: T.any,
   }),
 };
 
-export default HydroPopup;
+export default ConfidencePopup;

--- a/src/components/ProtVista/Popup/Entry/index.js
+++ b/src/components/ProtVista/Popup/Entry/index.js
@@ -78,7 +78,7 @@ const ProtVistaEntryPopup = (
     goToCustomLocation(newLocation);
   };
   return (
-    <section>
+    <section className={f('entry-popup')}>
       <h6>
         {accession.startsWith('residue:')
           ? accession.split('residue:')[1]?.replace('PIRSF', 'PIRSR')
@@ -86,7 +86,7 @@ const ProtVistaEntryPopup = (
         {description && <p>[{description}]</p>}
       </h6>
 
-      {name && <h4>{name}</h4>}
+      {name && <h4 className={f('title')}>{name}</h4>}
 
       <div className={f('pop-wrapper')}>
         <div>

--- a/src/components/ProtVista/Popup/Entry/style.css
+++ b/src/components/ProtVista/Popup/Entry/style.css
@@ -23,3 +23,6 @@ div.subfamily ul li > header {
   min-width: 7rem;
   padding-left: 1rem;
 }
+.entry-popup .title {
+  max-width: 20ch;
+}

--- a/src/components/ProtVista/Popup/index.js
+++ b/src/components/ProtVista/Popup/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import T from 'prop-types';
 
 import ProtVistaHydroPopup from './Hydro';
+import ProtVistaConfidencePopup from './Confidence';
 import ProtVistaResiduePopup from './Residue';
 import ProtVistaEntryPopup from './Entry';
 import ProtVistaConservationPopup from './Conservation';
@@ -79,9 +80,13 @@ const ProtVistaPopup = (
     );
   }
 
+  const colouredTrack = detail?.target?.closest('protvista-coloured-sequence');
   // comes from the hydrophobicity track
-  if (detail?.target?.closest('protvista-coloured-sequence')) {
-    return <ProtVistaHydroPopup detail={detail} />;
+  if (colouredTrack) {
+    if (colouredTrack.classList.contains('hydro'))
+      return <ProtVistaHydroPopup detail={detail} />;
+    if (colouredTrack.classList.contains('confidence'))
+      return <ProtVistaConfidencePopup detail={detail} />;
   }
 
   // comes from the Entry track

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -723,6 +723,7 @@ export class ProtVista extends Component /*:: <Props, State> */ {
                   class="hydro"
                 />
               </div>
+              <div className={f('track-label')}>Hydrophobicity</div>
 
               {data &&
                 data

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -11,7 +11,7 @@ import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 
 import Link from 'components/generic/Link';
 import Loading from 'components/SimpleCommonComponents/Loading';
-import { Genome3dLink } from 'components/ExtLink';
+import { Genome3dLink, AlphafoldLink } from 'components/ExtLink';
 import { FunFamLink } from 'subPages/Subfamilies';
 
 import ProtVistaManager from 'protvista-manager';
@@ -267,22 +267,21 @@ export class ProtVista extends Component /*:: <Props, State> */ {
 
     for (const type of data) {
       for (const d of type[1]) {
-        const tmp =
-          d.type === 'sequence_conservation'
-            ? d.data
-            : (d.entry_protein_locations || d.locations).map((loc) => ({
-                accession: d.accession,
-                name: d.name,
-                source_database: d.source_database,
-                locations: [loc],
-                color: getTrackColor(d, this.props.colorDomainsBy),
-                entry_type: d.entry_type,
-                type: d.type || 'entry',
-                residues: d.residues && JSON.parse(JSON.stringify(d.residues)),
-                chain: d.chain,
-                protein: d.protein,
-                confidence: loc.confidence,
-              }));
+        const tmp = ['sequence_conservation', 'confidence'].includes(d.type)
+          ? d.data
+          : (d.entry_protein_locations || d.locations).map((loc) => ({
+              accession: d.accession,
+              name: d.name,
+              source_database: d.source_database,
+              locations: [loc],
+              color: getTrackColor(d, this.props.colorDomainsBy),
+              entry_type: d.entry_type,
+              type: d.type || 'entry',
+              residues: d.residues && JSON.parse(JSON.stringify(d.residues)),
+              chain: d.chain,
+              protein: d.protein,
+              confidence: loc.confidence,
+            }));
         const children = d.children
           ? d.children.map((child) => ({
               accession: child.accession,
@@ -311,7 +310,9 @@ export class ProtVista extends Component /*:: <Props, State> */ {
             }))
           : null;
         if (tmp.length > 0) {
-          const isNewElement = !this.web_tracks[d.accession]._data;
+          const isNewElement =
+            !this.web_tracks[d.accession]._data &&
+            !this.web_tracks[d.accession].sequence;
           this.web_tracks[d.accession].data = tmp;
           if (this.props.fixedHighlight)
             this.web_tracks[d.accession].fixedHighlight =
@@ -388,7 +389,7 @@ export class ProtVista extends Component /*:: <Props, State> */ {
                 detail.target,
                 this._popperRef.current,
                 {
-                  placement: this._isPopperTop ? 'top' : 'bottom',
+                  // placement: this._isPopperTop ? 'top' : 'bottom',
                   applyStyle: { enabled: false },
                 },
               );
@@ -467,13 +468,13 @@ export class ProtVista extends Component /*:: <Props, State> */ {
     );
   }
 
-  renderLabels(entry) {
-    const { expandedTrack, isPrinting } = this.state;
+  renderExceptionalLabels(entry) {
     const { dataDB, id } = this.props;
     let databases = {};
     if (dataDB.payload) {
       databases = dataDB.payload.databases;
     }
+
     if (entry.source_database === 'mobidblt')
       return <Link href={`https://mobidb.org/${id}`}>{entry.accession}</Link>;
     if (entry.source_database === 'funfam') {
@@ -493,6 +494,13 @@ export class ProtVista extends Component /*:: <Props, State> */ {
         >
           N: {entry.accession}
         </Link>
+      );
+    }
+    if (entry.source_database === 'alphafold') {
+      return (
+        <AlphafoldLink id={entry.protein} className={f('ext')}>
+          pLDDT
+        </AlphafoldLink>
       );
     }
     if (entry.type === 'residue')
@@ -520,70 +528,77 @@ export class ProtVista extends Component /*:: <Props, State> */ {
       );
     }
     if (entry.accession && entry.accession.startsWith('G3D:')) {
-      // entry.accession = G3D:{entry.source_database}-PREDICTED... entry.source_database is what had to be shown
       return (
         <Genome3dLink id={entry.protein}>{entry.source_database}</Genome3dLink>
       );
     }
+    return null;
+  }
+
+  renderLabels(entry) {
+    const { expandedTrack, isPrinting } = this.state;
+
     const key /*: string */ =
       entry.source_database === 'pdb' ? 'structure' : 'entry';
     return (
-      <>
-        {isPrinting ? (
-          <b>{this.renderSwitch(this.props.label, entry)}</b>
-        ) : (
-          <Link
-            to={{
-              description: {
-                main: {
-                  key,
+      this.renderExceptionalLabels(entry) || (
+        <>
+          {isPrinting ? (
+            <b>{this.renderSwitch(this.props.label, entry)}</b>
+          ) : (
+            <Link
+              to={{
+                description: {
+                  main: {
+                    key,
+                  },
+                  [key]: {
+                    db: entry.source_database,
+                    accession: entry.accession.startsWith('residue:')
+                      ? entry.accession.split('residue:')[1]
+                      : entry.accession,
+                  },
                 },
-                [key]: {
-                  db: entry.source_database,
-                  accession: entry.accession.startsWith('residue:')
-                    ? entry.accession.split('residue:')[1]
-                    : entry.accession,
-                },
-              },
-            }}
+              }}
+            >
+              {this.renderSwitch(this.props.label, entry)}
+            </Link>
+          )}
+          <div
+            className={f({
+              hide: !expandedTrack[entry.accession],
+            })}
           >
-            {this.renderSwitch(this.props.label, entry)}
-          </Link>
-        )}
-        <div
-          className={f({
-            hide: !expandedTrack[entry.accession],
-          })}
-        >
-          {this.renderResidueLabels(entry)}
-          {entry.children &&
-            entry.children.map((d) => (
-              <div
-                key={`main_${d.accession}`}
-                className={f('track-accession-child')}
-              >
-                {isPrinting ? (
-                  this.renderSwitch(this.props.label, d)
-                ) : (
-                  <Link
-                    to={{
-                      description: {
-                        main: { key: 'entry' },
-                        entry: {
-                          db: d.source_database,
-                          accession: d.accession,
+            {this.renderResidueLabels(entry)}
+            {entry.children &&
+              entry.children.map((d) => (
+                <div
+                  key={`main_${d.accession}`}
+                  className={f('track-accession-child')}
+                >
+                  {isPrinting ? (
+                    this.renderSwitch(this.props.label, d)
+                  ) : (
+                    <Link
+                      to={{
+                        description: {
+                          main: { key: 'entry' },
+                          entry: {
+                            db: d.source_database,
+                            accession: d.accession,
+                          },
                         },
-                      },
-                    }}
-                  >
-                    {this.renderSwitch(this.props.label, d)}
-                  </Link>
-                )}
-                {this.renderResidueLabels(d)}
-              </div>
-            ))}
-        </div>
-      </>
+                      }}
+                    >
+                      {this.renderSwitch(this.props.label, d)}
+                    </Link>
+                  )}
+                  {this.renderResidueLabels(d)}
+                </div>
+              ))}
+          </div>
+        </>
+      )
     );
   }
 
@@ -705,6 +720,7 @@ export class ProtVista extends Component /*:: <Props, State> */ {
                   color_range="#0000FF:-3,#ffdd00:3"
                   highlight-event="onmouseover"
                   use-ctrl-to-zoom
+                  class="hydro"
                 />
               </div>
 
@@ -764,6 +780,7 @@ export class ProtVista extends Component /*:: <Props, State> */ {
                               >
                                 {entry.type === 'secondary_structure' ||
                                 entry.type === 'sequence_conservation' ||
+                                entry.type === 'confidence' ||
                                 entry.type === 'residue' ? (
                                   <div
                                     className={f(
@@ -811,6 +828,23 @@ export class ProtVista extends Component /*:: <Props, State> */ {
                                           (this.web_tracks[entry.accession] = e)
                                         }
                                         highlight-event="onmouseover"
+                                        use-ctrl-to-zoom
+                                      />
+                                    )}
+                                    {entry.type === 'confidence' && (
+                                      <protvista-coloured-sequence
+                                        ref={(e) =>
+                                          (this.web_tracks[entry.accession] = e)
+                                        }
+                                        id={`track_${entry.accession}`}
+                                        length={length}
+                                        displaystart="1"
+                                        displayend={length}
+                                        scale="H:90,M:70,L:50,D:0"
+                                        height="12"
+                                        color_range="#ff7d45:0,#ffdb13:50,#65cbf3:70,#0053d6:90,#0053d6:100"
+                                        highlight-event="onmouseover"
+                                        class="confidence"
                                         use-ctrl-to-zoom
                                       />
                                     )}

--- a/src/components/ProtVista/style.css
+++ b/src/components/ProtVista/style.css
@@ -161,3 +161,18 @@ g:global(.child-location-group.clg-5) path {
   display: inline;
   margin-right: 0.25rem;
 }
+
+.color-scale {
+  display: inline-flex;
+  & .legend {
+    padding: 0 0.5rem;
+    vertical-align: top;
+    width: 3rem;
+    &.left {
+      text-align: right;
+    }
+    &.right {
+      text-align: left;
+    }
+  }
+}

--- a/src/subPages/AlphaFoldModelSubPage/index.js
+++ b/src/subPages/AlphaFoldModelSubPage/index.js
@@ -25,6 +25,7 @@ const AlphaFoldModelSubPage = ({ data, description }) => {
   const [selectionsInModel, setSelectionsInModel] = useState(null);
   const [proteinAcc, setProteinAcc] = useState('');
   const [modelId, setModelId] = useState(null);
+  const [confidenceURL, setConfidenceURL] = useState(null);
   const handleProteinChange = (value) => {
     setProteinAcc(value);
     setModelId(null);
@@ -54,6 +55,12 @@ const AlphaFoldModelSubPage = ({ data, description }) => {
           onModelChange={handleModelChange}
           modelId={modelId}
           selections={selectionsInModel}
+          onModelCifChange={(cif) => {
+            const newURL = cif?.length
+              ? cif.replace('-model', '-confidence').replace('.cif', '.json')
+              : null;
+            if (newURL !== confidenceURL) setConfidenceURL(newURL);
+          }}
         />
       )}
       {mainType === 'entry' ? (
@@ -68,6 +75,7 @@ const AlphaFoldModelSubPage = ({ data, description }) => {
             onChangeSelection={(selection) => {
               setSelectionsInModel(selection);
             }}
+            confidenceURL={confidenceURL}
           />
         </div>
       )}


### PR DESCRIPTION
Alphafold provides a JSON that has the lPDDT score per amino acid, for example for the [Q8I3H7 model](https://alphafold.ebi.ac.uk/files/AF-Q8I3H7-F1-confidence_v3.json). 

We are now retrieving this file when displaying the protein viewer at the side of an alphafold model in order to generate a track that shows this information in the context of the protein sequence.

This PR uses the nightingale coloured track, defining the sequence for it as the categories retrieved on the file (`"D" |  "L" | "M" | "H"`) and defining the attributes of the track as:

```html
<protvista-coloured-sequence
  scale="H:90,M:70,L:50,D:0"
  color_range="#ff7d45:0,#ffdb13:50,#65cbf3:70,#0053d6:90,#0053d6:100"

  ...

/>
```

Other changes included in this PR:
* The Color Scale in the PopUps now support scales with multiple points as the one in the AlphaFold track
* Adjusting the style of the legends on the Scale popups
* The `width` of the title on the popups is now limited to `20ch` to avoid popups that take up the whole screen.
* Adding label for hydrophobicity track
