### PR TITLE
Confidence track in the protein page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,7 @@ const rules = {
   // Enforce one true comma style
   'comma-style': [1, 'last'],
   // Specify the maximum cyclomatic complexity allowed in a program
-  complexity: [1, 16],
+  complexity: [1, 18],
   // Disallow padding inside computed properties
   'computed-property-spacing': [1, 'never'],
   // Require return statements to either always or never specify values

--- a/src/components/AlphaFold/Model/index.js
+++ b/src/components/AlphaFold/Model/index.js
@@ -18,7 +18,6 @@ import { foundationPartial } from 'styles/foundation';
 import ipro from 'styles/interpro-new.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import style from './style.css';
-import { noop } from 'lodash-es';
 
 const f = foundationPartial(style, ipro, fonts);
 
@@ -56,7 +55,6 @@ const AlphaFoldModel = (
     modelUrl,
     data,
     selections,
-    onModelCifChange = noop,
   } /*: {
   proteinAcc: string,
   hasMultipleProteins: boolean,
@@ -65,11 +63,9 @@ const AlphaFoldModel = (
   modelUrl: string,
   data: FetchOutput,
   selections: Object[],
-  onModelCifChange: (x:string|null)=>void|null,
 } */,
 ) => {
   const [shouldResetViewer, setShouldResetViewer] = useState(false);
-  const [modelCif, setModelCif] = useState(null);
   useEffect(() => {
     if (shouldResetViewer) {
       requestAnimationFrame(() => setShouldResetViewer(false));
@@ -78,9 +74,6 @@ const AlphaFoldModel = (
   useEffect(() => {
     if (!selections) setShouldResetViewer(true);
   }, [selections]);
-  useEffect(() => {
-    onModelCifChange(modelCif);
-  }, [modelCif]);
 
   if (data?.loading) return <Loading />;
   if ((data?.payload || []).length === 0) {
@@ -97,7 +90,6 @@ const AlphaFoldModel = (
     modelId === null
       ? models.slice(0, 1)
       : models.filter((x) => x.entryId === modelId);
-  if (modelCif !== modelInfo.cifUrl) setModelCif(modelInfo.cifUrl);
   const elementId = 'new-structure-model-viewer';
   return (
     <div>
@@ -246,7 +238,6 @@ AlphaFoldModel.propTypes = {
   modelUrl: T.string,
   data: T.object,
   selections: T.arrayOf(T.object),
-  onModelCifChange: T.func,
 };
 
 const getModelInfoUrl = (isUrlToApi) =>

--- a/src/components/AlphaFold/selectors.js
+++ b/src/components/AlphaFold/selectors.js
@@ -1,0 +1,27 @@
+// @flow
+import { createSelector } from 'reselect';
+import { format } from 'url';
+
+export const getAlphaFoldPredictionURL = createSelector(
+  (state) => state.settings.alphafold,
+  (state) => state.customLocation.description.protein.accession,
+  ({ protocol, hostname, port, root, query }, accession) => {
+    return format({
+      protocol,
+      hostname,
+      port,
+      pathname: `${root}api/prediction/${accession}`,
+      query: query,
+    });
+  },
+);
+export const getConfidenceURLFromPayload = (namespace) =>
+  createSelector(
+    (_, props) => props[`data${namespace}`],
+    (dataPrediction) => {
+      const cifURL = dataPrediction?.payload?.[0]?.cifUrl;
+      return cifURL?.length
+        ? cifURL.replace('-model', '-confidence').replace('.cif', '.json')
+        : null;
+    },
+  );

--- a/src/components/EntryMenu/EntryMenuLink/AlphaFoldMenuLink.js
+++ b/src/components/EntryMenu/EntryMenuLink/AlphaFoldMenuLink.js
@@ -3,10 +3,9 @@ import React from 'react';
 import T from 'prop-types';
 
 import loadData from 'higherOrder/loadData';
-import { createSelector } from 'reselect';
-import { format } from 'url';
 
 import { EntryMenuLinkWithoutData } from '.';
+import { getAlphaFoldPredictionURL } from 'components/AlphaFold/selectors';
 
 const AlphaFoldMenuLink = (
   {
@@ -37,17 +36,4 @@ AlphaFoldMenuLink.propTypes = {
   collapsed: T.bool,
 };
 
-const getAlphaFoldURL = createSelector(
-  (state) => state.settings.alphafold,
-  (state) => state.customLocation.description.protein.accession,
-  ({ protocol, hostname, port, root, query }, accession) => {
-    return format({
-      protocol,
-      hostname,
-      port,
-      pathname: `${root}api/prediction/${accession}`,
-      query: query,
-    });
-  },
-);
-export default loadData(getAlphaFoldURL)(AlphaFoldMenuLink);
+export default loadData(getAlphaFoldPredictionURL)(AlphaFoldMenuLink);

--- a/src/components/ProtVista/Popup/Entry/index.js
+++ b/src/components/ProtVista/Popup/Entry/index.js
@@ -70,12 +70,19 @@ const ProtVistaEntryPopup = (
       };
     });
   }
+  const protein =
+    currentLocation?.description?.protein?.accession ||
+    detail?.feature?.protein ||
+    detail?.feature?.parent?.protein;
   const handleClick = (start, end) => () => {
-    const newLocation = cloneDeep(currentLocation);
-    newLocation.description[newLocation.description.main.key].detail =
-      'sequence';
-    newLocation.hash = `${start}-${end}`;
-    goToCustomLocation(newLocation);
+    if (!protein) return;
+    goToCustomLocation({
+      description: {
+        main: { key: 'protein' },
+        protein: { accession: protein, db: 'UniProt', detail: 'sequence' },
+      },
+      hash: `${start}-${end}`,
+    });
   };
   return (
     <section className={f('entry-popup')}>
@@ -129,6 +136,9 @@ const ProtVistaEntryPopup = (
                     <button
                       className={f('button', 'secondary')}
                       onClick={handleClick(start, end)}
+                      style={{
+                        cursor: protein ? 'pointer' : 'inherit',
+                      }}
                     >
                       {start} - {end}
                     </button>

--- a/src/components/ProtVista/Popup/Entry/index.js
+++ b/src/components/ProtVista/Popup/Entry/index.js
@@ -2,8 +2,6 @@
 import React from 'react';
 import T from 'prop-types';
 
-import { cloneDeep } from 'lodash-es';
-
 import { foundationPartial } from 'styles/foundation';
 import ipro from 'styles/interpro-new.css';
 import localCSS from './style.css';

--- a/src/components/ProtVista/Popup/index.js
+++ b/src/components/ProtVista/Popup/index.js
@@ -34,6 +34,8 @@ import ProtVistaConservationPopup from './Conservation';
       entry: string,
       confidence: number,
       start?: number,
+      protein?: string,
+      parent?:{protein?: string},
       aa?: string,
       value?: number,
       currentResidue?: {

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -211,13 +211,10 @@ export class ProtVista extends Component /*:: <Props, State> */ {
   async componentDidMount() {
     await loadProtVistaWebComponents();
     const { data, protein } = this.props;
-    if (this._webProteinRef.current && this._hydroRef.current) {
+    if (this._webProteinRef.current) {
       const proteinE = this._webProteinRef.current;
-      const hydroE = this._hydroRef.current;
       proteinE.data = protein;
-      hydroE.data = protein;
       this.updateTracksWithData(data);
-      hydroE.addEventListener('change', this._handleTrackChange);
       if (this._popperContentRef.current) {
         const popperE = this._popperContentRef.current;
         popperE.addEventListener('mouseover', () =>
@@ -227,6 +224,11 @@ export class ProtVista extends Component /*:: <Props, State> */ {
           this.setState({ overPopup: false }),
         );
       }
+    }
+    if (this._hydroRef.current) {
+      const hydroE = this._hydroRef.current;
+      hydroE.data = protein;
+      hydroE.addEventListener('change', this._handleTrackChange);
     }
   }
 
@@ -398,6 +400,7 @@ export class ProtVista extends Component /*:: <Props, State> */ {
                   modifiers: {
                     preventOverflow: {
                       boundariesElement: this._protvistaRef?.current || window,
+                      priority: ['left', 'right'],
                     },
                   },
                 },

--- a/src/components/ProtVista/index.js
+++ b/src/components/ProtVista/index.js
@@ -119,6 +119,7 @@ const getUIDFromEntry = (entry) =>
   id: string,
   showOptions: boolean,
   showConservationButton: boolean,
+  showHydrophobicity: boolean,
   handleConservationLoad: function,
   goToCustomLocation: function,
   customLocation: Object,
@@ -166,6 +167,7 @@ export class ProtVista extends Component /*:: <Props, State> */ {
     id: T.string,
     showOptions: T.bool,
     showConservationButton: T.bool,
+    showHydrophobicity: T.bool,
     handleConservationLoad: T.func,
     goToCustomLocation: T.func,
     customLocation: T.object,
@@ -658,6 +660,7 @@ export class ProtVista extends Component /*:: <Props, State> */ {
       showConservationButton,
       children,
       showOptions = true,
+      showHydrophobicity = false,
     } = this.props;
 
     if (!(length && data)) return <Loading />;
@@ -723,22 +726,25 @@ export class ProtVista extends Component /*:: <Props, State> */ {
                   use-ctrl-to-zoom
                 />
               </div>
-              <div className={f('track')}>
-                <protvista-coloured-sequence
-                  ref={this._hydroRef}
-                  length={length}
-                  displaystart="1"
-                  displayend={length}
-                  scale="hydrophobicity-scale"
-                  height="10"
-                  color_range="#0000FF:-3,#ffdd00:3"
-                  highlight-event="onmouseover"
-                  use-ctrl-to-zoom
-                  class="hydro"
-                />
-              </div>
-              <div className={f('track-label')}>Hydrophobicity</div>
-
+              {showHydrophobicity && (
+                <>
+                  <div className={f('track')}>
+                    <protvista-coloured-sequence
+                      ref={this._hydroRef}
+                      length={length}
+                      displaystart="1"
+                      displayend={length}
+                      scale="hydrophobicity-scale"
+                      height="10"
+                      color_range="#0000FF:-3,#ffdd00:3"
+                      highlight-event="onmouseover"
+                      use-ctrl-to-zoom
+                      class="hydro"
+                    />
+                  </div>
+                  <div className={f('track-label')}>Hydrophobicity</div>
+                </>
+              )}
               {data &&
                 data
                   .filter(([_, tracks]) => tracks && tracks.length)

--- a/src/components/Protein/Summary/__snapshots__/test.js.snap
+++ b/src/components/Protein/Summary/__snapshots__/test.js.snap
@@ -217,7 +217,7 @@ exports[`<SummaryProtein /> should render 1`] = `
         <div
           className="medium-12 columns margin-bottom-large"
         >
-          <Memo(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(DomainOnProteinWithoutData)))))))))
+          <Memo(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(DomainOnProteinWithoutData)))))))))))))
             mainData={
               {
                 "metadata": {

--- a/src/subPages/AlphaFoldModelSubPage/index.js
+++ b/src/subPages/AlphaFoldModelSubPage/index.js
@@ -25,7 +25,6 @@ const AlphaFoldModelSubPage = ({ data, description }) => {
   const [selectionsInModel, setSelectionsInModel] = useState(null);
   const [proteinAcc, setProteinAcc] = useState('');
   const [modelId, setModelId] = useState(null);
-  const [confidenceURL, setConfidenceURL] = useState(null);
   const handleProteinChange = (value) => {
     setProteinAcc(value);
     setModelId(null);
@@ -55,12 +54,6 @@ const AlphaFoldModelSubPage = ({ data, description }) => {
           onModelChange={handleModelChange}
           modelId={modelId}
           selections={selectionsInModel}
-          onModelCifChange={(cif) => {
-            const newURL = cif?.length
-              ? cif.replace('-model', '-confidence').replace('.cif', '.json')
-              : null;
-            if (newURL !== confidenceURL) setConfidenceURL(newURL);
-          }}
         />
       )}
       {mainType === 'entry' ? (
@@ -75,7 +68,6 @@ const AlphaFoldModelSubPage = ({ data, description }) => {
             onChangeSelection={(selection) => {
               setSelectionsInModel(selection);
             }}
-            confidenceURL={confidenceURL}
           />
         </div>
       )}


### PR DESCRIPTION
Adds the AlphaFold confidence track in the protein viewer of the protein page
Removes the hydrophobicity track.

Refactor the way we get the data for the confidence track so it can be reused.