### PR TITLE
Add .gz suffix to download file name

### DIFF
--- a/src/subPages/Curation/index.js
+++ b/src/subPages/Curation/index.js
@@ -104,7 +104,9 @@ const CurationSubPage = ({ data }) => {
             <td>
               <Link
                 href={`${config.root.API.href}/entry/pfam/${payload?.metadata?.accession}?annotation=hmm`}
-                download={`${payload?.metadata?.accession || 'download'}.hmm`}
+                download={`${
+                  payload?.metadata?.accession || 'download'
+                }.hmm.gz`}
               >
                 <span
                   className={f('icon', 'icon-common', 'icon-download')}


### PR DESCRIPTION
When downloading the HMM model, the extension is `.hmm` but the file is gzip-compressed, which puzzled some users. This PR adds the `.gz` suffix.