### PR TITLE
removing legacy bundle

### DIFF
--- a/src/index.template.html
+++ b/src/index.template.html
@@ -154,15 +154,6 @@
         }
       </style>
     </noscript>
-    <% if (!htmlWebpackPlugin.options.inject) { %> 
-      <%= htmlWebpackPlugin.faviconTags %> 
-    <% } %> 
-    <% for (const css of htmlWebpackPlugin.files.css) { 
-         if (css.indexOf(htmlWebpackPlugin.entry)!==-1 || (css.indexOf('.hydrate.')===-1 && css.indexOf('.index.')===-1)) { %>
-           <link rel="stylesheet" href="<%= css %>" />
-    <%   } 
-       }
-    %>
   </head>
   <body class="ebi-black-bar-loaded">
     <noscript>
@@ -175,6 +166,7 @@
       <div class="tmp-layout">
         <div class="tmp-ebi-header"></div>
         <div class="tmp-interpro-header"><h1>InterPro</h1></div>
+        <div id="error"></div>
         <p>Loading the InterPro website, please wait.</p>
         <div class="loading">
           <div></div>
@@ -184,61 +176,6 @@
       </div>
     </div>
     <div id="modal-root"></div>
-    <% if (!htmlWebpackPlugin.options.inject) { %> <% if (
-      htmlWebpackPlugin.files.moduleScripts &&
-      htmlWebpackPlugin.files.moduleScripts.length &&
-      htmlWebpackPlugin.files.legacyScripts &&
-      htmlWebpackPlugin.files.legacyScripts.length ) { %>
-        <script nomodule type="text/javascript">
-          // workaround for Safari 10.1 supporting module but ignoring nomodule
-          // From https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc
-          (function () {
-            var d = document;
-            var c = d.createElement('script');
-            if (!('noModule' in c) && 'onbeforeload' in c) {
-              var s = false;
-              d.addEventListener(
-                'beforeload',
-                function (e) {
-                  if (e.target === c) {
-                    s = true;
-                  } else if (!e.target.hasAttribute('nomodule') || !s) {
-                    return;
-                  }
-                  e.preventDefault();
-                },
-                true
-              );
-
-              c.type = 'module';
-              c.src = '.';
-              d.head.appendChild(c);
-              c.remove();
-            }
-          })();
-        </script>
-      <% 
-        }
-        // Adding js files for module entry point
-        for (const file of htmlWebpackPlugin.files.moduleScripts || []) {
-          if (file.indexOf(htmlWebpackPlugin.entry)!==-1){
-            %> <script async type="module" src="<%= file %>"></script> <%   
-          } 
-          if (file.indexOf('.hydrate.')===-1 && file.indexOf('.index.')===-1){
-            %> <script async type="module" src="<%= file %>"></script> <% 
-          } 
-        }
-        // Adding js files for legacy entry point
-        for (const file of htmlWebpackPlugin.files.legacyScripts || []) {
-          if (file.indexOf(htmlWebpackPlugin.entry)!==-1) {
-            %> <script nomodule defer type="text/javascript" src="<%= file %>"></script> <%   
-          }
-          if (file.indexOf('.hydrate.')===-1 && file.indexOf('.index.')===-1){
-            %> <script nomodule async src="<%= file %>"></script> <% 
-          } 
-        }
-      } %>
-    <% if (!htmlWebpackPlugin.options.inject) { %>
       <script>
         function forceRefreshIfNotloaded(){
           if (!document.getElementById('interpro-root')) {
@@ -249,9 +186,16 @@
             window.location.reload();
           }
         }
-      //If in 5 seconds it hasn't render the root of the page thne reload the page.
+      //If in 5 seconds it hasn't render the root of the page then reload the page.
       setTimeout(forceRefreshIfNotloaded, 30000);
+
+      window.addEventListener('load', function (event) {
+        if (!('noModule' in HTMLScriptElement.prototype)) {
+          document.getElementById('error').innerHTML =
+            "<b>⚠️ Error!</b> The version of this browser doesn't support some essential features used in InterPro";
+          console.error('No support for es-modules');
+        }
+      });
     </script>
-    <% } %>
   </body>
 </html>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -198,7 +198,7 @@
       window.addEventListener('load', function (event) {
         if (!('noModule' in HTMLScriptElement.prototype)) {
           document.getElementById('error').innerHTML =
-            "<b>⚠️ Error!</b> The version of this browser doesn't support some essential features used in InterPro.<br/><br/>Please upgrade your browser.";
+            "Sorry, your web browser does not support JavaScript modules, which are required for InterPro. Please upgrade your browser to a newer version, or switch to a different browser that supports JavaScript modules.";
           console.error('No support for es-modules');
         }
       });

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -192,7 +192,7 @@
             window.location.reload();
           }
         }
-      //If in 5 seconds it hasn't render the root of the page then reload the page.
+      //If in 30 seconds it hasn't render the root of the page then reload the page.
       setTimeout(forceRefreshIfNotloaded, 30000);
 
       window.addEventListener('load', function (event) {

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -50,6 +50,12 @@
         margin: 0;
         padding: 0;
       }
+      #error {
+        margin: 1em;
+        font-size: 1.3em;
+        padding: 1em;
+        background: lightsteelblue;
+      }
       .tmp-layout {
         display: flex;
         flex-direction: column;
@@ -192,7 +198,7 @@
       window.addEventListener('load', function (event) {
         if (!('noModule' in HTMLScriptElement.prototype)) {
           document.getElementById('error').innerHTML =
-            "<b>⚠️ Error!</b> The version of this browser doesn't support some essential features used in InterPro";
+            "<b>⚠️ Error!</b> The version of this browser doesn't support some essential features used in InterPro.<br/><br/>Please upgrade your browser.";
           console.error('No support for es-modules');
         }
       });

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -15,6 +15,8 @@ import GeneralWarning from 'components/home/GeneralWarning';
 import InterProGraphicAnim from 'components/home/InterProGraphicAnim';
 import { PrintedInterPro2022 } from 'components/Help/Publication';
 import Tip from 'components/Tip';
+import Toast from 'components/Toast/Toast';
+
 import Link from 'components/generic/Link';
 
 import { ToolCards } from 'components/home/Tools';
@@ -35,6 +37,7 @@ import fonts from 'EBI-Icon-fonts/fonts.css';
 import theme from 'styles/theme-interpro.css';
 import style from '../style.css';
 import local from './style.css';
+import toast from 'components/Toast/ToastDisplay/style.css';
 
 import loadData from 'higherOrder/loadData';
 import { getUrlForMeta } from 'higherOrder/loadData/defaults';
@@ -45,7 +48,15 @@ import wellcome from '../../images/thirdparty/funding/logo_wellcome.jpg';
 import bbsrc from '../../images/thirdparty/funding/logo_bbsrc.png';
 
 // Bind css with style object
-const f = foundationPartial(ebiGlobalStyles, fonts, ipro, theme, style, local);
+const f = foundationPartial(
+  ebiGlobalStyles,
+  fonts,
+  ipro,
+  theme,
+  style,
+  local,
+  toast,
+);
 
 const MAX_DELAY_FOR_TWITTER = 10000;
 
@@ -208,6 +219,17 @@ const Announcement = () => (
     </div>
   </div>
 );
+
+// eslint-disable-next-line
+function supportsES6() {
+  try {
+    // eslint-disable-next-line
+    new Function('(a = 0) => a');
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
 class Home extends PureComponent {
   static propTypes = {
     showSettingsToast: T.bool.isRequired,
@@ -225,6 +247,17 @@ class Home extends PureComponent {
             settingsName="showSettingsToast"
           />
         ) : null}
+        {'noModule' in HTMLScriptElement.prototype && supportsES6() ? null : (
+          <ul className={f('toast-display')}>
+            <Toast
+              title="⚠️ Unsuported Browser"
+              body="We have detected some missing features in your browser. You might experience some issues in our website. Please update your browser."
+              toastID="browser-error"
+              style={{ right: '2rem', bottom: '40vh' }}
+            />
+          </ul>
+        )}
+
         {this.props.showHelpToast ? (
           <Tip
             title="💡 Need help?"

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -251,7 +251,7 @@ class Home extends PureComponent {
           <ul className={f('toast-display')}>
             <Toast
               title="⚠️ Unsuported Browser"
-              body="We have detected some missing features in your browser. You might experience some issues in our website. Please update your browser."
+              body="We have detected that your web browser does not support JavaScript modules, which are required for the InterPro website to function properly. As a result, certain features may not work as expected. We recommend that you upgrade your browser to the latest version or switch to a supported browser such as Firefox, Chrome, or Edge."
               toastID="browser-error"
               style={{ right: '2rem', bottom: '40vh' }}
             />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,5 @@
   },
   "include": [
     "src/**/*",
-    // "node_modules/@nightingale-elements/*/src/*"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,6 @@
   },
   "include": [
     "src/**/*",
-    "node_modules/@nightingale-elements/*/src/*"
+    // "node_modules/@nightingale-elements/*/src/*"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,6 @@ const zlib = require('zlib');
 // Webpack plugins
 const HTMLWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-// custom plugins
-// const LegacyModuleSplitPlugin = require('./webpack-plugins/legacy-module-split-plugin');
 
 // CSS-related
 const postCSSImport = require('postcss-import');
@@ -72,8 +70,6 @@ const getHTMLWebpackPlugin = () =>
       };
     },
   });
-
-// const legacyModuleSplitPlugin = new LegacyModuleSplitPlugin();
 
 const miniCssExtractPlugin = new MiniCssExtractPlugin({
   filename: path.join('css', '[name].[fullhash:3].css'),
@@ -402,10 +398,6 @@ const getConfigFor = (env, mode) => {
             exclude: ['**/.*', '**/*.{map,br,gz}'],
           })
         : null,
-
-      // Custom plugin to split codebase into legacy/modern bundles,
-      // depends on HTMLWebpackPlugin
-      // legacyModuleSplitPlugin,
       // GZIP compression
       mode === 'production'
         ? new (getCompressionPlugin())({


### PR DESCRIPTION
Our webpack configuration was set up to create 2 bundles: 1 for modern browsers and 1 for legacy browsers that don't support es-modules.

Checking the stats of the last 7 days from the [livelogs](http://ves-ebi-2e.ebi.ac.uk/es/livelogs/#dashboard/temp/AYc32qFSLmmAsU_n8B8d), from 2356060 hits requesting `*.js` files from the interpro machines, only  4821 hits were requesting `*legacy*` files; for a total 0.2%.

This PR removes the `legacy` bundle, and adds warning messages to upgrade browsers for the affected cases. 

The particular change pushing in this direction is that Lit elements are highly dependent on classes, so adapting Nightingale components would require effort tuning the already complex webpack/babel/typescript setup. An effort that is hard to justify for such a small amount of requests.

**NOTE:** Probably better to review this one before #458 to be able to visualise the new components.