### PR TITLE
Fix empty PIRSR site matches

### DIFF
--- a/src/components/IPScan/Summary/serializers.js
+++ b/src/components/IPScan/Summary/serializers.js
@@ -190,7 +190,8 @@ export const mergeData = (matches, sequenceLength) => {
       mergedData.other_features.push(mergedMatch);
     } else if (OTHER_RESIDUES_DBS.includes(mergedMatch.source_database)) {
       const residues = match2residues(mergedMatch);
-      mergedData.other_residues.push(residues[0]);
+      if (residues[0].locations.length !== 0)
+        mergedData.other_residues.push(residues[0]);
     } else {
       unintegrated[mergedMatch.accession] = mergedMatch;
     }

--- a/src/components/TimeAgo/__snapshots__/test.js.snap
+++ b/src/components/TimeAgo/__snapshots__/test.js.snap
@@ -5,6 +5,6 @@ exports[`<TimeAgo /> should render 1`] = `
   dateTime="17-06-1998 01:00:00"
   title="17/06/1998"
 >
-  24 years ago
+  25 years ago
 </time>
 `;


### PR DESCRIPTION
A user recently reported that their InterProScan results were not available in the website because a component crashed.

This is due to a PIRSR match that does not have any site annotations, which is not expected to happen. The job in question is https://www.ebi.ac.uk/interpro/result/InterProScan/iprscan5-R20230612-090754-0435-27808602-p1m/

Here's a snippet to find the PIRSR match:

```js
const response = await fetch('https://www.ebi.ac.uk/Tools/services/rest/iprscan5/result/iprscan5-R20230612-090754-0435-27808602-p1m/json');
const payload = await response.json();
const empty = payload.results[0].matches.filter((m,) => m.locations[0].sites !== undefined && m.locations[0].sites.length === 0);
```

This PR adds a check to the deserialization to ignore site matches without site annotations. Pointing to `master` because we should deploy the fix asap.