### PR TITLE
External sources for the protein viewer

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -9,7 +9,8 @@ root:
   readthedocs: https://interpro-documentation.readthedocs.io/en/latest/
   alphafold: https://alphafold.ebi.ac.uk/
   repeatsDB: https://repeatsdb.bio.unipd.it/api/search
-
+  disprot: https://disprot.org/api/
+  
 title: InterPro
 
 github:

--- a/config.yml.example
+++ b/config.yml.example
@@ -8,6 +8,7 @@ root:
   wikipedia: https://en.wikipedia.org/w/api.php
   readthedocs: https://interpro-documentation.readthedocs.io/en/latest/
   alphafold: https://alphafold.ebi.ac.uk/
+  repeatsDB: https://repeatsdb.bio.unipd.it/api/search
 
 title: InterPro
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -4,7 +4,7 @@ root:
   API: https://www.ebi.ac.uk/interpro/api/
   EBIsearch: https://www.ebi.ac.uk/ebisearch/ws/rest/interpro
   IPScan: https://www.ebi.ac.uk/Tools/services/rest/iprscan5/
-  genome3d: https://www.genome3d.eu/api/v1/
+  genome3d: https://www.genome3d.net/api/v1/
   wikipedia: https://en.wikipedia.org/w/api.php
   readthedocs: https://interpro-documentation.readthedocs.io/en/latest/
   alphafold: https://alphafold.ebi.ac.uk/

--- a/src/components/Genome3D/index.ts
+++ b/src/components/Genome3D/index.ts
@@ -74,7 +74,7 @@ export const formatGenome3dIntoProtVistaPanels = ({
   status,
   payload,
 }: RequestedData<Genome3DProteinPayload>) => {
-  const panelsData: ProteinViewerDataObject<MinimalFeature> = {};
+  const panelsData: MinimalFeature[] = [];
   if (!loading && status === HTTP_OK && payload?.data?.annotations?.length) {
     const models = _getProtvistaTracksData({
       annotations: payload.data.annotations,
@@ -86,8 +86,7 @@ export const formatGenome3dIntoProtVistaPanels = ({
       type: 'Model',
       protein: payload.data.uniprot_acc,
     });
-    if (models)
-      panelsData['predicted_3D_structures_(Provided_by_genome3D)'] = models;
+    if (models) panelsData.push(...models);
     const domains = _getProtvistaTracksData({
       annotations: payload.data.annotations,
       condition: ({ metadata }) =>
@@ -98,8 +97,7 @@ export const formatGenome3dIntoProtVistaPanels = ({
       type: 'Domain',
       protein: payload.data.uniprot_acc,
     });
-    if (domains)
-      panelsData['predicted_domains_(Provided_by_genome3D)'] = domains;
+    if (domains) panelsData.push(...domains);
   }
   return panelsData;
 };

--- a/src/components/Menu/SideMenu/ServerStatus/index.js
+++ b/src/components/Menu/SideMenu/ServerStatus/index.js
@@ -18,7 +18,7 @@ const mapEndpointToName = new Map([
   ['api', 'InterPro API'],
   ['ebi', 'EBI Search API'],
   ['ipScan', 'InterProScan API'],
-  ['genome3d', 'Genome3D'],
+  // ['genome3d', 'Genome3D'],
   ['wikipedia', 'Wikipedia API'],
   ['alphafold', 'AlphaFold API'],
 ]);

--- a/src/components/Menu/SideMenu/ServerStatus/index.js
+++ b/src/components/Menu/SideMenu/ServerStatus/index.js
@@ -18,7 +18,6 @@ const mapEndpointToName = new Map([
   ['api', 'InterPro API'],
   ['ebi', 'EBI Search API'],
   ['ipScan', 'InterProScan API'],
-  // ['genome3d', 'Genome3D'],
   ['wikipedia', 'Wikipedia API'],
   ['alphafold', 'AlphaFold API'],
 ]);

--- a/src/components/Protein/Summary/__snapshots__/test.js.snap
+++ b/src/components/Protein/Summary/__snapshots__/test.js.snap
@@ -221,7 +221,7 @@ exports[`<SummaryProtein /> should render 1`] = `
         <div
           className="medium-12 columns margin-bottom-large"
         >
-          <Memo(Connect(loadData(loadExternalSources(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(DomainOnProteinWithoutData))))))))))))))
+          <Memo(Connect(loadData(Connect(loadData(loadExternalSources(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(DomainOnProteinWithoutData))))))))))))))))
             mainData={
               {
                 "metadata": {

--- a/src/components/Protein/Summary/__snapshots__/test.js.snap
+++ b/src/components/Protein/Summary/__snapshots__/test.js.snap
@@ -221,7 +221,7 @@ exports[`<SummaryProtein /> should render 1`] = `
         <div
           className="medium-12 columns margin-bottom-large"
         >
-          <Memo(Connect(loadData(Connect(loadData(loadExternalSources(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(DomainOnProteinWithoutData))))))))))))))))
+          <Memo(Connect(loadData(Connect(loadData(Connect(loadData(loadExternalSources(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(Connect(loadData(DomainOnProteinWithoutData))))))))))))))))))
             mainData={
               {
                 "metadata": {

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -107,10 +107,13 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
   }
   if (entry.accession && entry.accession.startsWith('G3D:')) {
     return isPrinting ? (
-      <span> {entry.source_database} </span>
+      <span>
+        {' '}
+        Genome3D: [{entry.type}] {entry.source_database}{' '}
+      </span>
     ) : (
       <Genome3dLink id={entry.protein || ''}>
-        {entry.source_database}
+        Genome3D: [{entry.type}] {entry.source_database}
       </Genome3dLink>
     );
   }

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -109,7 +109,7 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
   if (entry.accession && entry.accession.startsWith('G3D:')) {
     return isPrinting ? (
       <span>
-        Genome3D: [{entry.type}] {entry.source_database}{' '}
+        Genome3D: {entry.source_database}{' '}
       </span>
     ) : (
       <Genome3dLink id={entry.protein || ''}>

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -30,7 +30,7 @@ const EXCEPTIONAL_TYPES = [
   'chain',
   'secondary_structure',
 ];
-const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:'];
+const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:'];
 
 export const isAnExceptionalLabel = (entry: ExtendedFeature): boolean => {
   return (
@@ -126,6 +126,15 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
         target="_blank"
       >
         RepeatsDB: [{entry.type}]
+      </Link>
+    );
+  }
+  if (entry.accession && entry.accession.startsWith('DISPROT:')) {
+    return isPrinting ? (
+      <span>DisProt: [{entry.type}]</span>
+    ) : (
+      <Link href={`https://disprot.org/${entry.protein}`} target="_blank">
+        DisProt: [{entry.type}]
       </Link>
     );
   }

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -119,13 +119,13 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
   }
   if (entry.accession && entry.accession.startsWith('REPEAT:')) {
     return isPrinting ? (
-      <span>RepeatsDB: [{entry.type}]</span>
+      <span>RepeatsDB consensus</span>
     ) : (
       <Link
         href={`https://repeatsdb.bio.unipd.it/protein/${entry.protein}`}
         target="_blank"
       >
-        RepeatsDB: [{entry.type}]
+        RepeatsDB consensus
       </Link>
     );
   }

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -30,12 +30,13 @@ const EXCEPTIONAL_TYPES = [
   'chain',
   'secondary_structure',
 ];
+const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:'];
 
 export const isAnExceptionalLabel = (entry: ExtendedFeature): boolean => {
   return (
     EXCEPTIONAL_TYPES.includes(entry.type || '') ||
     NOT_MEMBER_DBS.has(entry.source_database || '') ||
-    entry.accession.startsWith('G3D:')
+    EXCEPTIONAL_PREFIXES.some((prefix) => entry.accession.startsWith(prefix))
   );
 };
 
@@ -108,13 +109,24 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
   if (entry.accession && entry.accession.startsWith('G3D:')) {
     return isPrinting ? (
       <span>
-        {' '}
         Genome3D: [{entry.type}] {entry.source_database}{' '}
       </span>
     ) : (
       <Genome3dLink id={entry.protein || ''}>
         Genome3D: [{entry.type}] {entry.source_database}
       </Genome3dLink>
+    );
+  }
+  if (entry.accession && entry.accession.startsWith('REPEAT:')) {
+    return isPrinting ? (
+      <span>RepeatsDB: [{entry.type}]</span>
+    ) : (
+      <Link
+        href={`https://repeatsdb.bio.unipd.it/protein/${entry.protein}`}
+        target="_blank"
+      >
+        RepeatsDB: [{entry.type}]
+      </Link>
     );
   }
   return null;

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -131,10 +131,10 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
   }
   if (entry.accession && entry.accession.startsWith('DISPROT:')) {
     return isPrinting ? (
-      <span>DisProt: [{entry.type}]</span>
+      <span>DisProt consensus</span>
     ) : (
       <Link href={`https://disprot.org/${entry.protein}`} target="_blank">
-        DisProt: [{entry.type}]
+        DisProt consensus
       </Link>
     );
   }

--- a/src/components/ProteinViewer/Options/index.tsx
+++ b/src/components/ProteinViewer/Options/index.tsx
@@ -15,6 +15,7 @@ import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
 import { Exporter } from 'components/Table';
 import TooltipAndRTDLink from 'components/Help/TooltipAndRTDLink';
 import NightingaleSaver from 'components/Nightingale/Saver';
+import Loading from 'components/SimpleCommonComponents/Loading';
 
 import LabelBy from './LabelBy';
 
@@ -48,6 +49,7 @@ type Props = PropsWithChildren<{
   setExpandedAllTracks: (v: boolean) => void;
   tooltipEnabled: boolean;
   setTooltipEnabled: (v: boolean) => void;
+  loading: boolean;
 }>;
 
 const ProteinViewerOptions = ({
@@ -62,6 +64,7 @@ const ProteinViewerOptions = ({
   setExpandedAllTracks,
   tooltipEnabled,
   setTooltipEnabled,
+  loading = false,
 }: Props) => {
   const [expanded, setExpanded] = useState(true);
   const componentsDivId =
@@ -138,9 +141,10 @@ const ProteinViewerOptions = ({
   return (
     <>
       <div className={css('view-options-title')}>
-        {title || 'Domains on protein'}{' '}
+        {title || 'Domains on protein'}
         <TooltipAndRTDLink rtdPage="protein_viewer.html" />
       </div>
+      {loading && <Loading inline />}
       <div className={css('view-options')}>
         <div className={css('option-fullscreen', 'font-l', 'viewer-options')}>
           <FullScreenButton

--- a/src/components/ProteinViewer/Popup/DisProt/index.tsx
+++ b/src/components/ProteinViewer/Popup/DisProt/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Positions from '../Positions';
+
+export type DisProtDetail = {
+  feature: {
+    accession: string;
+    type: string;
+    protein: string;
+    locations: Array<
+      ProtVistaLocation & {
+        term_name: string;
+        ec_name: string;
+        released: string;
+      }
+    >;
+  };
+};
+type Props = {
+  detail: DisProtDetail;
+};
+
+const DisProtPopup = ({ detail }: Props) => {
+  const { locations, type, protein } = detail.feature;
+  return (
+    <section>
+      <h5>DisProt [{type}]</h5>
+
+      {locations.map(({ fragments, term_name, ec_name, released }, i) => (
+        <div key={i}>
+          {term_name && (
+            <div>
+              {term_name} - ({released})
+            </div>
+          )}
+          {ec_name && <div>{ec_name}</div>}
+          <Positions fragments={fragments} protein={protein} key={i} />
+        </div>
+      ))}
+    </section>
+  );
+};
+export default DisProtPopup;

--- a/src/components/ProteinViewer/Popup/DisProt/index.tsx
+++ b/src/components/ProteinViewer/Popup/DisProt/index.tsx
@@ -6,13 +6,7 @@ export type DisProtDetail = {
     accession: string;
     type: string;
     protein: string;
-    locations: Array<
-      ProtVistaLocation & {
-        term_name: string;
-        ec_name: string;
-        released: string;
-      }
-    >;
+    locations: Array<ProtVistaLocation>;
   };
 };
 type Props = {
@@ -23,16 +17,10 @@ const DisProtPopup = ({ detail }: Props) => {
   const { locations, type, protein } = detail.feature;
   return (
     <section>
-      <h5>DisProt [{type}]</h5>
+      <h5>DisProt: {type}</h5>
 
-      {locations.map(({ fragments, term_name, ec_name, released }, i) => (
+      {locations.map(({ fragments }, i) => (
         <div key={i}>
-          {term_name && (
-            <div>
-              {term_name} - ({released})
-            </div>
-          )}
-          {ec_name && <div>{ec_name}</div>}
           <Positions fragments={fragments} protein={protein} key={i} />
         </div>
       ))}

--- a/src/components/ProteinViewer/Popup/Entry/index.tsx
+++ b/src/components/ProteinViewer/Popup/Entry/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { goToCustomLocation } from 'actions/creators';
+import Positions from '../Positions';
 
 import cssBinder from 'styles/cssBinder';
-import ipro from 'styles/interpro-new.css';
+import ipro from 'styles/interpro-vf.css';
 import localCSS from './style.css';
 
 const css = cssBinder(ipro, localCSS);
@@ -25,7 +25,6 @@ export type EntryDetail = {
 type Props = {
   detail: EntryDetail;
   sourceDatabase: string;
-  goToCustomLocation: typeof goToCustomLocation;
   currentLocation: InterProLocation;
 };
 const getSecondaryStructureType = (locations: Array<ProtVistaLocation>) => {
@@ -42,7 +41,6 @@ const getSecondaryStructureType = (locations: Array<ProtVistaLocation>) => {
 const ProtVistaEntryPopup = ({
   detail,
   sourceDatabase,
-  goToCustomLocation,
   currentLocation,
 }: Props) => {
   const {
@@ -82,16 +80,6 @@ const ProtVistaEntryPopup = ({
     currentLocation?.description?.protein?.accession ||
     detail?.feature?.protein ||
     detail?.feature?.parent?.protein;
-  const handleClick = (start: number, end: number) => () => {
-    if (!protein) return;
-    goToCustomLocation({
-      description: {
-        main: { key: 'protein' },
-        protein: { accession: protein, db: 'UniProt', detail: 'sequence' },
-      },
-      hash: `${start}-${end}`,
-    });
-  };
   return (
     <section className={css('entry-popup')}>
       <h6>
@@ -140,21 +128,7 @@ const ProtVistaEntryPopup = ({
                   </ul>
                 </div>
               )}
-              <ul>
-                {(fragments || []).map(({ start, end }, i) => (
-                  <li key={i}>
-                    <button
-                      className={css('button', 'secondary', 'coordinates')}
-                      onClick={handleClick(start, end)}
-                      style={{
-                        cursor: protein ? 'pointer' : 'inherit',
-                      }}
-                    >
-                      {start} - {end}
-                    </button>
-                  </li>
-                ))}
-              </ul>
+              <Positions fragments={fragments} protein={protein} />
             </li>
           )
         )}

--- a/src/components/ProteinViewer/Popup/Entry/style.css
+++ b/src/components/ProteinViewer/Popup/Entry/style.css
@@ -36,7 +36,3 @@ div.subfamily ul li > header {
     margin-bottom: 0.3rem;
   }
 }
-button.coordinates {
-  padding: 0.3rem 0.7rem;
-  margin: 0;
-}

--- a/src/components/ProteinViewer/Popup/Genome3D/index.tsx
+++ b/src/components/ProteinViewer/Popup/Genome3D/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Positions from '../Positions';
 
 export type Genome3DDetail = {
   feature: {
@@ -6,6 +7,8 @@ export type Genome3DDetail = {
     type: string;
     source_database: string;
     confidence: string;
+    protein: string;
+    locations: ProtVistaLocation[];
   };
 };
 type Props = {
@@ -13,7 +16,13 @@ type Props = {
 };
 
 const Genome3DPopup = ({ detail }: Props) => {
-  const { accession, source_database: db, type } = detail.feature;
+  const {
+    accession,
+    source_database: db,
+    type,
+    locations,
+    protein,
+  } = detail.feature;
 
   return (
     <section>
@@ -21,6 +30,9 @@ const Genome3DPopup = ({ detail }: Props) => {
       <h6>{db}</h6>
 
       <div>{accession}</div>
+      {locations.map(({ fragments }, i) => (
+        <Positions fragments={fragments} protein={protein} key={i} />
+      ))}
     </section>
   );
 };

--- a/src/components/ProteinViewer/Popup/Genome3D/index.tsx
+++ b/src/components/ProteinViewer/Popup/Genome3D/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export type Genome3DDetail = {
+  feature: {
+    accession: string;
+    type: string;
+    source_database: string;
+    confidence: string;
+  };
+};
+type Props = {
+  detail: Genome3DDetail;
+};
+
+const Genome3DPopup = ({ detail }: Props) => {
+  const { accession, source_database: db, type } = detail.feature;
+
+  return (
+    <section>
+      <h5>Genome3D [{type}]</h5>
+      <h6>{db}</h6>
+
+      <div>{accession}</div>
+    </section>
+  );
+};
+export default Genome3DPopup;

--- a/src/components/ProteinViewer/Popup/Positions/index.tsx
+++ b/src/components/ProteinViewer/Popup/Positions/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { goToCustomLocation } from 'actions/creators';
+
+import cssBinder from 'styles/cssBinder';
+import ipro from 'styles/interpro-vf.css';
+import localCSS from './style.css';
+const css = cssBinder(ipro, localCSS);
+
+type Props = {
+  fragments?: Array<ProtVistaFragment>;
+  protein?: string;
+  goToCustomLocation: typeof goToCustomLocation;
+};
+const Positions = ({ fragments, protein, goToCustomLocation }: Props) => {
+  const handleClick = (start: number, end: number) => () => {
+    if (!protein) return;
+    goToCustomLocation({
+      description: {
+        main: { key: 'protein' },
+        protein: { accession: protein, db: 'UniProt', detail: 'sequence' },
+      },
+      hash: `${start}-${end}`,
+    });
+  };
+
+  return (
+    <ul>
+      {(fragments || []).map(({ start, end }, i) => (
+        <li key={i}>
+          <button
+            className={css('button', 'secondary', 'coordinates')}
+            onClick={handleClick(start, end)}
+            style={{
+              cursor: protein ? 'pointer' : 'inherit',
+            }}
+          >
+            {start} - {end}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};
+export default connect(null, { goToCustomLocation })(Positions);

--- a/src/components/ProteinViewer/Popup/Positions/style.css
+++ b/src/components/ProteinViewer/Popup/Positions/style.css
@@ -1,0 +1,4 @@
+button.coordinates {
+  padding: 0.3rem 0.7rem;
+  margin: 0;
+}

--- a/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
+++ b/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
@@ -6,12 +6,7 @@ export type RepeatsDBDetail = {
     accession: string;
     type: string;
     protein: string;
-    locations: Array<
-      ProtVistaLocation & {
-        period: string;
-        classification: string[];
-      }
-    >;
+    locations: Array<ProtVistaLocation>;
   };
 };
 type Props = {
@@ -22,20 +17,10 @@ const RepeatsDBPopup = ({ detail }: Props) => {
   const { locations, type, protein } = detail.feature;
   return (
     <section>
-      <h5>RepeatsDB [{type}]</h5>
+      <h5>RepeatsDB: consensus</h5>
 
-      {locations.map(({ fragments, period, classification }, i) => (
+      {locations.map(({ fragments }, i) => (
         <div key={i}>
-          {period && (
-            <div>
-              <b>Period:</b> {period}
-            </div>
-          )}
-          {classification.length && (
-            <div>
-              <b>Classification:</b> {classification.join(', ')}
-            </div>
-          )}
           <Positions fragments={fragments} protein={protein} key={i} />
         </div>
       ))}

--- a/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
+++ b/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export type RepeatsDBDetail = {
+  feature: {
+    accession: string;
+    type: string;
+    locations: ProtVistaLocation[];
+  };
+};
+type Props = {
+  detail: RepeatsDBDetail;
+};
+
+const RepeatsDBPopup = ({ detail }: Props) => {
+  const { locations, type } = detail.feature;
+  const period = locations[0]?.period as string;
+  const classification = (locations[0]?.classification || []) as string[];
+  return (
+    <section>
+      <h5>RepeatsDB [{type}]</h5>
+
+      {period && (
+        <div>
+          <b>Period:</b> {period}
+        </div>
+      )}
+      {classification.length && (
+        <div>
+          <b>Classification:</b> {classification.join(', ')}
+        </div>
+      )}
+    </section>
+  );
+};
+export default RepeatsDBPopup;

--- a/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
+++ b/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 const RepeatsDBPopup = ({ detail }: Props) => {
-  const { locations, type, protein } = detail.feature;
+  const { locations, protein } = detail.feature;
   return (
     <section>
       <h5>RepeatsDB: consensus</h5>

--- a/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
+++ b/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
+import Positions from '../Positions';
 
 export type RepeatsDBDetail = {
   feature: {
     accession: string;
     type: string;
-    locations: ProtVistaLocation[];
+    protein: string;
+    locations: Array<
+      ProtVistaLocation & {
+        period: string;
+        classification: string[];
+      }
+    >;
   };
 };
 type Props = {
@@ -12,23 +19,26 @@ type Props = {
 };
 
 const RepeatsDBPopup = ({ detail }: Props) => {
-  const { locations, type } = detail.feature;
-  const period = locations[0]?.period as string;
-  const classification = (locations[0]?.classification || []) as string[];
+  const { locations, type, protein } = detail.feature;
   return (
     <section>
       <h5>RepeatsDB [{type}]</h5>
 
-      {period && (
-        <div>
-          <b>Period:</b> {period}
+      {locations.map(({ fragments, period, classification }, i) => (
+        <div key={i}>
+          {period && (
+            <div>
+              <b>Period:</b> {period}
+            </div>
+          )}
+          {classification.length && (
+            <div>
+              <b>Classification:</b> {classification.join(', ')}
+            </div>
+          )}
+          <Positions fragments={fragments} protein={protein} key={i} />
         </div>
-      )}
-      {classification.length && (
-        <div>
-          <b>Classification:</b> {classification.join(', ')}
-        </div>
-      )}
+      ))}
     </section>
   );
 };

--- a/src/components/ProteinViewer/Popup/index.tsx
+++ b/src/components/ProteinViewer/Popup/index.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
-import { goToCustomLocation } from 'actions/creators';
-
 import ProtVistaConfidencePopup, { ConfidenceDetail } from './Confidence';
 import ProtVistaResiduePopup, { ResidueDetail } from './Residue';
 import ProtVistaEntryPopup, { EntryDetail } from './Entry';
 import ProtVistaConservationPopup, { ConservationDetail } from './Conservation';
 import Genome3DPopup, { Genome3DDetail } from './Genome3D';
 import RepeatsDBPopup, { RepeatsDBDetail } from './RepeatsDB';
+import DisProtPopup, { DisProtDetail } from './DisProt';
 
 export type PopupDetail = (
   | ConservationDetail
@@ -20,17 +19,11 @@ export type PopupDetail = (
 };
 type Props = {
   sourceDatabase: string;
-  goToCustomLocation: typeof goToCustomLocation;
   currentLocation: InterProLocation;
   detail: PopupDetail;
 };
 
-const ProtVistaPopup = ({
-  detail,
-  sourceDatabase,
-  currentLocation,
-  goToCustomLocation,
-}: Props) => {
+const ProtVistaPopup = ({ detail, sourceDatabase, currentLocation }: Props) => {
   // comes from the conservation track
   if (detail.type === 'conservation') {
     return <ProtVistaConservationPopup detail={detail as ConservationDetail} />;
@@ -65,13 +58,18 @@ const ProtVistaPopup = ({
     )
   )
     return <RepeatsDBPopup detail={detail as RepeatsDBDetail} />;
+  if (
+    ((detail as RepeatsDBDetail)?.feature?.accession || '').startsWith(
+      'DISPROT:'
+    )
+  )
+    return <DisProtPopup detail={detail as DisProtDetail} />;
 
   // comes from the Entry track
   return (
     <ProtVistaEntryPopup
       detail={detail as EntryDetail}
       sourceDatabase={sourceDatabase}
-      goToCustomLocation={goToCustomLocation}
       currentLocation={currentLocation}
     />
   );

--- a/src/components/ProteinViewer/Popup/index.tsx
+++ b/src/components/ProteinViewer/Popup/index.tsx
@@ -7,6 +7,7 @@ import ProtVistaResiduePopup, { ResidueDetail } from './Residue';
 import ProtVistaEntryPopup, { EntryDetail } from './Entry';
 import ProtVistaConservationPopup, { ConservationDetail } from './Conservation';
 import Genome3DPopup, { Genome3DDetail } from './Genome3D';
+import RepeatsDBPopup, { RepeatsDBDetail } from './RepeatsDB';
 
 export type PopupDetail = (
   | ConservationDetail
@@ -57,6 +58,13 @@ const ProtVistaPopup = ({
   }
   if (((detail as Genome3DDetail)?.feature?.accession || '').startsWith('G3D:'))
     return <Genome3DPopup detail={detail as Genome3DDetail} />;
+
+  if (
+    ((detail as RepeatsDBDetail)?.feature?.accession || '').startsWith(
+      'REPEAT:'
+    )
+  )
+    return <RepeatsDBPopup detail={detail as RepeatsDBDetail} />;
 
   // comes from the Entry track
   return (

--- a/src/components/ProteinViewer/Popup/index.tsx
+++ b/src/components/ProteinViewer/Popup/index.tsx
@@ -6,6 +6,7 @@ import ProtVistaConfidencePopup, { ConfidenceDetail } from './Confidence';
 import ProtVistaResiduePopup, { ResidueDetail } from './Residue';
 import ProtVistaEntryPopup, { EntryDetail } from './Entry';
 import ProtVistaConservationPopup, { ConservationDetail } from './Conservation';
+import Genome3DPopup, { Genome3DDetail } from './Genome3D';
 
 export type PopupDetail = (
   | ConservationDetail
@@ -54,6 +55,8 @@ const ProtVistaPopup = ({
     if (colouredTrack.classList.contains('confidence'))
       return <ProtVistaConfidencePopup detail={detail as ConfidenceDetail} />;
   }
+  if (((detail as Genome3DDetail)?.feature?.accession || '').startsWith('G3D:'))
+    return <Genome3DPopup detail={detail as Genome3DDetail} />;
 
   // comes from the Entry track
   return (

--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -51,6 +51,7 @@ const OTHER_TRACK_TYPES = [
   'residue',
   'Model',
   'Domain',
+  'consensus majority',
 ];
 const b2sh = new Map([
   ['N_TERMINAL_DISC', 'discontinuosStart'], // TODO fix spelling in this and nightingale
@@ -316,6 +317,7 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                         'residue',
                         'Model',
                         'Domain',
+                        'consensus majority',
                       ].includes(entry.type || '') && (
                         <NightingaleTrack
                           length={sequence.length}

--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -12,7 +12,6 @@ import { createSelector } from 'reselect';
 
 import useStateRef from 'utils/hooks/useStateRef';
 import { getTrackColor, EntryColorMode } from 'utils/entry-color';
-import { goToCustomLocation } from 'actions/creators';
 
 import { LineData } from '@nightingale-elements/nightingale-linegraph-track';
 
@@ -53,6 +52,8 @@ const OTHER_TRACK_TYPES = [
   'Domain',
   'consensus majority',
 ];
+const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:'];
+
 const b2sh = new Map([
   ['N_TERMINAL_DISC', 'discontinuosStart'], // TODO fix spelling in this and nightingale
   ['C_TERMINAL_DISC', 'discontinuosEnd'],
@@ -123,7 +124,6 @@ type Props = {
   closeTooltip: () => void;
   sequence: string;
   customLocation?: InterProLocation;
-  goToCustomLocation?: typeof goToCustomLocation;
   colorDomainsBy?: string;
   databases?: DBsInfo;
 };
@@ -136,7 +136,6 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
       isPrinting,
       highlightColor,
       customLocation,
-      goToCustomLocation,
       openTooltip,
       closeTooltip,
       colorDomainsBy,
@@ -174,14 +173,13 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                 ?.name ||
               detail.feature?.source_database ||
               '';
-            if (customLocation && goToCustomLocation)
+            if (customLocation)
               openTooltip(
                 detail.target,
                 <ProtVistaPopup
                   detail={detail as unknown as PopupDetail}
                   sourceDatabase={sourceDatabase}
                   currentLocation={customLocation}
-                  goToCustomLocation={goToCustomLocation}
                 />
               );
             break;
@@ -264,6 +262,9 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
         {entries &&
           entries.map((entry) => {
             const type = entry.type || '';
+            const isExternalSource = EXCEPTIONAL_PREFIXES.some((prefix) =>
+              entry.accession.startsWith(prefix)
+            );
 
             return (
               <React.Fragment key={entry.accession}>
@@ -272,7 +273,7 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                     hideCategory,
                   })}
                 >
-                  {OTHER_TRACK_TYPES.includes(type) ? (
+                  {OTHER_TRACK_TYPES.includes(type) || isExternalSource ? (
                     <div className={css('track', type.replace('_', '-'))}>
                       {entry.type === 'sequence_conservation' &&
                         (entry.warnings || []).length > 0 && (
@@ -312,13 +313,10 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                           use-ctrl-to-zoom
                         />
                       )}
-                      {[
-                        'secondary_structure',
-                        'residue',
-                        'Model',
-                        'Domain',
-                        'consensus majority',
-                      ].includes(entry.type || '') && (
+                      {(['secondary_structure', 'residue'].includes(
+                        entry.type || ''
+                      ) ||
+                        isExternalSource) && (
                         <NightingaleTrack
                           length={sequence.length}
                           margin-color="#fafafa"
@@ -368,6 +366,6 @@ const mapStateToProps = createSelector(
       (ui.colorDomainsBy as string) || EntryColorMode.DOMAIN_RELATIONSHIP,
   })
 );
-export default connect(mapStateToProps, { goToCustomLocation }, null, {
+export default connect(mapStateToProps, null, null, {
   forwardRef: true,
 })(TracksInCategory);

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -103,6 +103,7 @@ export const ProteinViewer = ({
   const [isPrinting, setPrinting] = useState(false);
   const [hideCategory, setHideCategory] = useState<CategoryVisibility>({
     'other residues': true,
+    'external sources': true,
   });
   const categoryRefs = useRef<ExpandedHandle[]>([]);
 

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -76,6 +76,7 @@ type Props = {
   showConservationButton?: boolean;
   handleConservationLoad?: () => void;
   conservationError?: string;
+  loading: boolean;
 };
 interface LoadedProps extends Props, LoadDataProps<RootAPIPayload, 'Base'> {}
 
@@ -99,6 +100,7 @@ export const ProteinViewer = ({
   handleConservationLoad,
   conservationError,
   dataBase,
+  loading = false,
 }: LoadedProps) => {
   const [isPrinting, setPrinting] = useState(false);
   const [hideCategory, setHideCategory] = useState<CategoryVisibility>({
@@ -192,6 +194,7 @@ export const ProteinViewer = ({
                 setExpandedAllTracks={setExpandedAllTracks}
                 tooltipEnabled={tooltipEnabled}
                 setTooltipEnabled={setTooltipEnabled}
+                loading={loading}
               />
             </div>
           </div>

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -57,6 +57,7 @@ type Props = PropsWithChildren<{
   conservationError?: string | null;
   showConservationButton?: boolean;
   handleConservationLoad?: () => void;
+  loading: boolean;
 }>;
 
 const DomainsOnProteinLoaded = ({
@@ -66,6 +67,7 @@ const DomainsOnProteinLoaded = ({
   conservationError,
   showConservationButton,
   handleConservationLoad,
+  loading,
   children,
 }: Props) => {
   const sortedData = Object.entries(dataMerged)
@@ -89,6 +91,7 @@ const DomainsOnProteinLoaded = ({
         showConservationButton={showConservationButton}
         handleConservationLoad={handleConservationLoad}
         conservationError={conservationError}
+        loading={loading}
       >
         {children}
       </ProteinViewer>

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
@@ -1,11 +1,11 @@
 const HTTP_OK = 200;
 
-const TYPES: {[key: string]: string} = {
+const TYPES: { [key: string]: string } = {
   F: 'Function region',
   S: 'Order state',
   D: 'Disorder state',
   T: 'Transition',
-  I: 'Transition with interaction'
+  I: 'Transition with interaction',
 };
 
 export const formatDisProt = ({
@@ -29,9 +29,6 @@ export const formatDisProt = ({
                 end: region.end,
               },
             ],
-            term_name: region.term_name,
-            ec_name: region.ec_name,
-            released: region.released,
           },
         ],
       } as MinimalFeature);

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
@@ -1,5 +1,13 @@
 const HTTP_OK = 200;
 
+const TYPES: {[key: string]: string} = {
+  F: 'Function region',
+  S: 'Order state',
+  D: 'Disorder state',
+  T: 'Transition',
+  I: 'Transition with interaction'
+};
+
 export const formatDisProt = ({
   loading,
   status,
@@ -7,12 +15,12 @@ export const formatDisProt = ({
 }: RequestedData<DisProtPayload>) => {
   const panelsData: MinimalFeature[] = [];
   if (!loading && status === HTTP_OK && payload) {
-    for (const region of payload.regions) {
+    for (const region of payload.disprot_consensus.full) {
       panelsData.push({
-        accession: `DISPROT:${region.region_id}`,
+        accession: 'DISPROT:',
         protein: payload.acc,
         source_database: 'DisProt',
-        type: region.term_namespace,
+        type: TYPES[region.type] || '',
         locations: [
           {
             fragments: [

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
@@ -1,0 +1,35 @@
+const HTTP_OK = 200;
+
+export const formatDisProt = ({
+  loading,
+  status,
+  payload,
+}: RequestedData<DisProtPayload>) => {
+  const panelsData: MinimalFeature[] = [];
+  if (!loading && status === HTTP_OK && payload) {
+    for (const region of payload.regions) {
+      panelsData.push({
+        accession: `DISPROT:${region.region_id}`,
+        protein: payload.acc,
+        source_database: 'DisProt',
+        type: region.term_namespace,
+        locations: [
+          {
+            fragments: [
+              {
+                start: region.start,
+                end: region.end,
+              },
+            ],
+            term_name: region.term_name,
+            ec_name: region.ec_name,
+            released: region.released,
+          },
+        ],
+      } as MinimalFeature);
+    }
+  }
+  return panelsData;
+};
+
+export default formatDisProt;

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/RepeatsDB/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/RepeatsDB/index.ts
@@ -13,7 +13,7 @@ export const formatRepeatsDB = ({
           accession: `REPEAT:${repeatDatum.uniprot_id}:${feature.start}-${feature.end}`,
           protein: repeatDatum.uniprot_id,
           source_database: 'RepeatsDB',
-          type: 'consensus majority',
+          type: 'Consensus',
           locations: [
             {
               fragments: [
@@ -22,8 +22,6 @@ export const formatRepeatsDB = ({
                   end: feature.end,
                 },
               ],
-              classification: feature.classification,
-              period: feature.period,
             },
           ],
         } as MinimalFeature);

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/RepeatsDB/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/RepeatsDB/index.ts
@@ -1,0 +1,36 @@
+const HTTP_OK = 200;
+
+export const formatRepeatsDB = ({
+  loading,
+  status,
+  payload,
+}: RequestedData<RepeatsDBPayload>) => {
+  const panelsData: MinimalFeature[] = [];
+  if (!loading && status === HTTP_OK && payload) {
+    for (const repeatDatum of payload || []) {
+      for (const feature of repeatDatum.repeatsdb_consensus_majority || []) {
+        panelsData.push({
+          accession: `REPEAT:${repeatDatum.uniprot_id}:${feature.start}-${feature.end}`,
+          protein: repeatDatum.uniprot_id,
+          source_database: 'RepeatsDB',
+          type: 'consensus majority',
+          locations: [
+            {
+              fragments: [
+                {
+                  start: feature.start,
+                  end: feature.end,
+                },
+              ],
+              classification: feature.classification,
+              period: feature.period,
+            },
+          ],
+        } as MinimalFeature);
+      }
+    }
+  }
+  return panelsData;
+};
+
+export default formatRepeatsDB;

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
@@ -8,7 +8,7 @@ import { formatGenome3dIntoProtVistaPanels } from 'components/Genome3D';
 
 export type ExtenalSourcesProps = {
   loading: boolean;
-  externalSourcesData: ProteinViewerDataObject<MinimalFeature>;
+  externalSourcesData: MinimalFeature[];
 };
 export function loadExternalSources<
   T extends ExtenalSourcesProps = ExtenalSourcesProps
@@ -25,13 +25,11 @@ export function loadExternalSources<
 
     const genome3dFormatted = dataGenome3D
       ? formatGenome3dIntoProtVistaPanels(dataGenome3D)
-      : {};
+      : [];
     // Fetch the props you want to inject. This could be done with context instead.
     const newProps = {
       loading: !!dataGenome3D?.loading,
-      externalSourcesData: {
-        ...genome3dFormatted,
-      },
+      externalSourcesData: [...genome3dFormatted],
     };
 
     // props comes afterwards so the can override the default ones.

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -127,8 +127,11 @@ const DomainOnProteinWithoutData = ({
     ...groups,
     unintegrated: unintegrated as Array<MinimalFeature>,
     other_features: other,
-    ...externalSourcesData,
   };
+
+  if (externalSourcesData.length) {
+    mergedData.external_sources = externalSourcesData;
+  }
 
   if (dataResidues && !dataResidues.loading && dataResidues.payload) {
     mergeResidues(mergedData, dataResidues.payload);

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -205,6 +205,12 @@ const DomainOnProteinWithoutData = ({
         mainData={mainData}
         dataMerged={mergedData}
         dataConfidence={dataConfidence}
+        loading={
+          data?.loading ||
+          dataFeatures?.loading ||
+          dataResidues?.loading ||
+          false
+        }
         // Disabling Conservation until hmmer is working
         // conservationError={conservation.error}
         // showConservationButton={showConservationButton}

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -103,6 +103,7 @@ type SettingsState = {
   api: ParsedURLServer;
   ipScan: ParsedURLServer;
   genome3d: ParsedURLServer;
+  repeatsDB: ParsedURLServer;
   wikipedia: ParsedURLServer;
   alphafold: ParsedURLServer;
 };
@@ -458,6 +459,7 @@ type ProtVistaLocation = {
   };
   description?: string;
   accession?: string;
+  [other: string]: unknown;
 };
 
 type ProteinViewerData<Feature = unknown> = Array<
@@ -502,6 +504,21 @@ type Genome3DProteinPayload = {
   };
   message: string;
 };
+type RepeatsDBAnnotation = {
+  start: number;
+  end: number;
+  classification: Array<string>;
+  period: number;
+};
+type RepeatsDBPayload = Array<{
+  uniprot_id: string;
+  uniprot_name: string;
+  uniprot_sequence: string;
+  repeatsdb_consensus_majority: Array<RepeatsDBAnnotation>;
+  reviewed_one: boolean;
+  reviewed_all: boolean;
+}>;
+
 type ExtraFeaturesPayload = Record<
   string,
   {

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -104,6 +104,7 @@ type SettingsState = {
   ipScan: ParsedURLServer;
   genome3d: ParsedURLServer;
   repeatsDB: ParsedURLServer;
+  disprot: ParsedURLServer;
   wikipedia: ParsedURLServer;
   alphafold: ParsedURLServer;
 };
@@ -518,6 +519,33 @@ type RepeatsDBPayload = Array<{
   reviewed_one: boolean;
   reviewed_all: boolean;
 }>;
+type DisprotRegion = {
+  region_id: string;
+  term_namespace: string;
+  term_name: string;
+  ec_name: string;
+  acc: string;
+  start: number;
+  end: number;
+  released: string;
+};
+type DisProtPayload = {
+  acc: string;
+  sequence: string;
+  taxonomy: Array<string>;
+  length: number;
+  features: unknown;
+  date: string;
+  disprot_id: string;
+  name: string;
+  genes: Array<unknown>;
+  number_ambiguous_regions: number;
+  number_obsolete_regions: number;
+  disorder_content: number;
+  regions_counter: number;
+  regions: Array<DisprotRegion>;
+  disprot_consensus: unknown;
+};
 
 type ExtraFeaturesPayload = Record<
   string,

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -529,6 +529,17 @@ type DisprotRegion = {
   end: number;
   released: string;
 };
+type DisprotConsensusRegion = {
+  start: number,
+  end: number,
+  type: string;
+};
+type DisprotConsensus = {
+  full: Array<DisprotConsensusRegion>,
+  'Structural state': Array<object>,
+  'Structural transition': Array<object>,
+  'Biological process': Array<object>,
+};
 type DisProtPayload = {
   acc: string;
   sequence: string;
@@ -544,7 +555,7 @@ type DisProtPayload = {
   disorder_content: number;
   regions_counter: number;
   regions: Array<DisprotRegion>;
-  disprot_consensus: unknown;
+  disprot_consensus: DisprotConsensus;
 };
 
 type ExtraFeaturesPayload = Record<

--- a/src/pages/Settings/index.js
+++ b/src/pages/Settings/index.js
@@ -600,6 +600,9 @@ const IPScanEndpointSettings = connect(getStatusForEndpoint('ipScan'))(
 const Genome3DEndpointSettings = connect(getStatusForEndpoint('genome3d'))(
   EndpointSettings,
 );
+const RepeatsDBEndpointSettings = connect(getStatusForEndpoint('repeatsDB'))(
+  EndpointSettings,
+);
 const WikipediaEndpointSettings = connect(getStatusForEndpoint('wikipedia'))(
   EndpointSettings,
 );
@@ -736,6 +739,7 @@ type SettingsProps = {
     ebi: Object,
     ipScan: Object,
     genome3d: Object,
+    repeatsDB: Object,
     wikipedia: Object,
     alphafold: Object,
   },
@@ -760,6 +764,7 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
       ebi: T.object.isRequired,
       ipScan: T.object.isRequired,
       genome3d: T.object.isRequired,
+      repeatsDB: T.object.isRequired,
       wikipedia: T.object.isRequired,
       alphafold: T.object.isRequired,
     }).isRequired,
@@ -810,6 +815,7 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
         ebi = {},
         ipScan = {},
         genome3d = {},
+        repeatsDB = {},
         wikipedia = {},
         alphafold = {},
       },
@@ -898,6 +904,13 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
                     Genome3D Settings{' '}
                     {!DEV && '(modification temporarily disabled)'}
                   </Genome3DEndpointSettings>
+                  <RepeatsDBEndpointSettings
+                    category="repeatsDB"
+                    endpointDetails={repeatsDB}
+                  >
+                    RepeatsDB Settings{' '}
+                    {!DEV && '(modification temporarily disabled)'}
+                  </RepeatsDBEndpointSettings>
                   <WikipediaEndpointSettings
                     category="wikipedia"
                     endpointDetails={wikipedia}

--- a/src/pages/Settings/index.js
+++ b/src/pages/Settings/index.js
@@ -597,12 +597,15 @@ const EBIEndpointSettings = connect(getStatusForEndpoint('ebi'))(
 const IPScanEndpointSettings = connect(getStatusForEndpoint('ipScan'))(
   EndpointSettings,
 );
-const Genome3DEndpointSettings = connect(getStatusForEndpoint('genome3d'))(
-  EndpointSettings,
-);
-const RepeatsDBEndpointSettings = connect(getStatusForEndpoint('repeatsDB'))(
-  EndpointSettings,
-);
+// const Genome3DEndpointSettings = connect(getStatusForEndpoint('genome3d'))(
+//   EndpointSettings,
+// );
+// const RepeatsDBEndpointSettings = connect(getStatusForEndpoint('repeatsDB'))(
+//   EndpointSettings,
+// );
+// const DisprotEndpointSettings = connect(getStatusForEndpoint('disprot'))(
+//   EndpointSettings,
+// );
 const WikipediaEndpointSettings = connect(getStatusForEndpoint('wikipedia'))(
   EndpointSettings,
 );
@@ -740,6 +743,7 @@ type SettingsProps = {
     ipScan: Object,
     genome3d: Object,
     repeatsDB: Object,
+    disprot: Object,
     wikipedia: Object,
     alphafold: Object,
   },
@@ -763,8 +767,9 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
       api: T.object.isRequired,
       ebi: T.object.isRequired,
       ipScan: T.object.isRequired,
-      genome3d: T.object.isRequired,
-      repeatsDB: T.object.isRequired,
+      // genome3d: T.object.isRequired,
+      // repeatsDB: T.object.isRequired,
+      // disprot: T.object.isRequired,
       wikipedia: T.object.isRequired,
       alphafold: T.object.isRequired,
     }).isRequired,
@@ -814,8 +819,9 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
         api = {},
         ebi = {},
         ipScan = {},
-        genome3d = {},
-        repeatsDB = {},
+        // genome3d = {},
+        // repeatsDB = {},
+        // disprot = {},
         wikipedia = {},
         alphafold = {},
       },
@@ -897,7 +903,7 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
                     InterProScan Settings{' '}
                     {!DEV && '(modification temporarily disabled)'}
                   </IPScanEndpointSettings>
-                  <Genome3DEndpointSettings
+                  {/* <Genome3DEndpointSettings
                     category="genome3d"
                     endpointDetails={genome3d}
                   >
@@ -911,6 +917,13 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
                     RepeatsDB Settings{' '}
                     {!DEV && '(modification temporarily disabled)'}
                   </RepeatsDBEndpointSettings>
+                  <DisprotEndpointSettings
+                    category="disprot"
+                    endpointDetails={disprot}
+                  >
+                    DisProt Settings{' '}
+                    {!DEV && '(modification temporarily disabled)'}
+                  </DisprotEndpointSettings> */}
                   <WikipediaEndpointSettings
                     category="wikipedia"
                     endpointDetails={wikipedia}

--- a/src/pages/Settings/index.js
+++ b/src/pages/Settings/index.js
@@ -597,15 +597,6 @@ const EBIEndpointSettings = connect(getStatusForEndpoint('ebi'))(
 const IPScanEndpointSettings = connect(getStatusForEndpoint('ipScan'))(
   EndpointSettings,
 );
-// const Genome3DEndpointSettings = connect(getStatusForEndpoint('genome3d'))(
-//   EndpointSettings,
-// );
-// const RepeatsDBEndpointSettings = connect(getStatusForEndpoint('repeatsDB'))(
-//   EndpointSettings,
-// );
-// const DisprotEndpointSettings = connect(getStatusForEndpoint('disprot'))(
-//   EndpointSettings,
-// );
 const WikipediaEndpointSettings = connect(getStatusForEndpoint('wikipedia'))(
   EndpointSettings,
 );
@@ -767,9 +758,6 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
       api: T.object.isRequired,
       ebi: T.object.isRequired,
       ipScan: T.object.isRequired,
-      // genome3d: T.object.isRequired,
-      // repeatsDB: T.object.isRequired,
-      // disprot: T.object.isRequired,
       wikipedia: T.object.isRequired,
       alphafold: T.object.isRequired,
     }).isRequired,
@@ -819,9 +807,6 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
         api = {},
         ebi = {},
         ipScan = {},
-        // genome3d = {},
-        // repeatsDB = {},
-        // disprot = {},
         wikipedia = {},
         alphafold = {},
       },
@@ -903,27 +888,6 @@ class Settings extends PureComponent /*:: <SettingsProps, SettingsState> */ {
                     InterProScan Settings{' '}
                     {!DEV && '(modification temporarily disabled)'}
                   </IPScanEndpointSettings>
-                  {/* <Genome3DEndpointSettings
-                    category="genome3d"
-                    endpointDetails={genome3d}
-                  >
-                    Genome3D Settings{' '}
-                    {!DEV && '(modification temporarily disabled)'}
-                  </Genome3DEndpointSettings>
-                  <RepeatsDBEndpointSettings
-                    category="repeatsDB"
-                    endpointDetails={repeatsDB}
-                  >
-                    RepeatsDB Settings{' '}
-                    {!DEV && '(modification temporarily disabled)'}
-                  </RepeatsDBEndpointSettings>
-                  <DisprotEndpointSettings
-                    category="disprot"
-                    endpointDetails={disprot}
-                  >
-                    DisProt Settings{' '}
-                    {!DEV && '(modification temporarily disabled)'}
-                  </DisprotEndpointSettings> */}
                   <WikipediaEndpointSettings
                     category="wikipedia"
                     endpointDetails={wikipedia}

--- a/src/reducers/settings/category/index.js
+++ b/src/reducers/settings/category/index.js
@@ -80,6 +80,13 @@ export const getDefaultSettingsFor = (category /*: Category */) => {
         port: config.root.repeatsDB.port || DEFAULT_HTTP_PORT,
         root: config.root.repeatsDB.pathname,
       };
+    case 'disprot':
+      return {
+        protocol: config.root.disprot.protocol,
+        hostname: config.root.disprot.hostname,
+        port: config.root.disprot.port || DEFAULT_HTTP_PORT,
+        root: config.root.disprot.pathname,
+      };
     case 'wikipedia':
       return {
         protocol: config.root.wikipedia.protocol,

--- a/src/reducers/settings/category/index.js
+++ b/src/reducers/settings/category/index.js
@@ -73,6 +73,13 @@ export const getDefaultSettingsFor = (category /*: Category */) => {
         port: config.root.genome3d.port || DEFAULT_HTTP_PORT,
         root: config.root.genome3d.pathname,
       };
+    case 'repeatsDB':
+      return {
+        protocol: config.root.repeatsDB.protocol,
+        hostname: config.root.repeatsDB.hostname,
+        port: config.root.repeatsDB.port || DEFAULT_HTTP_PORT,
+        root: config.root.repeatsDB.pathname,
+      };
     case 'wikipedia':
       return {
         protocol: config.root.wikipedia.protocol,

--- a/src/reducers/settings/index.js
+++ b/src/reducers/settings/index.js
@@ -11,6 +11,7 @@ export default combineReducers({
   api: category('api'),
   ipScan: category('ipScan'),
   genome3d: category('genome3d'),
+  repeatsDB: category('repeatsDB'),
   wikipedia: category('wikipedia'),
   alphafold: category('alphafold'),
 });

--- a/src/reducers/settings/index.js
+++ b/src/reducers/settings/index.js
@@ -12,6 +12,7 @@ export default combineReducers({
   ipScan: category('ipScan'),
   genome3d: category('genome3d'),
   repeatsDB: category('repeatsDB'),
+  disprot: category('disprot'),
   wikipedia: category('wikipedia'),
   alphafold: category('alphafold'),
 });

--- a/src/reducers/status/servers/index.js
+++ b/src/reducers/status/servers/index.js
@@ -12,7 +12,7 @@ export default (combineReducers({
   api: server('api'),
   ebi: server('ebi'),
   ipScan: server('ipScan'),
-  genome3d: server('genome3d'),
+  // genome3d: server('genome3d'),
   wikipedia: server('wikipedia'),
   alphafold: server('alphafold'),
 }) /*: (ServerStatuses | void, any) => ServerStatuses */);
@@ -30,6 +30,6 @@ const serverStatusSelectorFor = (server) =>
 export const apiServerStatus = serverStatusSelectorFor('api');
 export const ebiServerStatus = serverStatusSelectorFor('ebi');
 export const ipScanServerStatus = serverStatusSelectorFor('ipScan');
-export const genome3dServerStatus = serverStatusSelectorFor('genome3d');
+// export const genome3dServerStatus = serverStatusSelectorFor('genome3d');
 export const wikipediaServerStatus = serverStatusSelectorFor('wikipedia');
 export const alphaFoldServerStatus = serverStatusSelectorFor('alphafold');

--- a/src/reducers/status/servers/server/index.js
+++ b/src/reducers/status/servers/server/index.js
@@ -1,7 +1,7 @@
 // @flow
 import { SERVER_STATUS } from 'actions/types';
 
-/*:: type Server = 'api' | 'ebi' | 'ipScan' | 'genome3d' | 'wikipedia' | 'alphafold'; */
+/*:: type Server = 'api' | 'ebi' | 'ipScan' | 'genome3d' | 'wikipedia' | 'alphafold' | 'repeatsDB'; */
 /*:: export type ServerStatus = {|
   status: ?boolean,
   lastCheck: ?number,
@@ -10,18 +10,16 @@ import { SERVER_STATUS } from 'actions/types';
 /*:: import type { Action } from 'actions'; */
 
 // eslint-disable-next-line no-extra-parens
-export default (server /*: Server */) => ((
-  state = { status: null, lastCheck: null },
-  action,
-) => {
-  switch (action.type) {
-    case SERVER_STATUS:
-      if (action.server !== server) return state;
-      return {
-        status: action.status,
-        lastCheck: Date.now(),
-      };
-    default:
-      return state;
-  }
-} /*: (ServerStatus | void, any) => any */);
+export default (server /*: Server */) =>
+  (state = { status: null, lastCheck: null }, action) => {
+    switch (action.type) {
+      case SERVER_STATUS:
+        if (action.server !== server) return state;
+        return {
+          status: action.status,
+          lastCheck: Date.now(),
+        };
+      default:
+        return state;
+    }
+  };

--- a/src/reducers/status/servers/server/index.js
+++ b/src/reducers/status/servers/server/index.js
@@ -1,7 +1,7 @@
 // @flow
 import { SERVER_STATUS } from 'actions/types';
 
-/*:: type Server = 'api' | 'ebi' | 'ipScan' | 'genome3d' | 'wikipedia' | 'alphafold' | 'repeatsDB'; */
+/*:: type Server = 'api' | 'ebi' | 'ipScan' | 'genome3d' | 'wikipedia' | 'alphafold' | 'repeatsDB' | 'disprot'; */
 /*:: export type ServerStatus = {|
   status: ?boolean,
   lastCheck: ?number,

--- a/src/reducers/status/servers/test.js
+++ b/src/reducers/status/servers/test.js
@@ -3,7 +3,6 @@ import {
   apiServerStatus,
   ebiServerStatus,
   ipScanServerStatus,
-  genome3dServerStatus,
 } from '.';
 
 describe('selectors', () => {
@@ -25,8 +24,5 @@ describe('selectors', () => {
 
   test('ipScanServerStatus', () => {
     expect(ipScanServerStatus(state)).toBe(state.status.servers.ipScan);
-  });
-  test('genome3dServerStatus', () => {
-    expect(genome3dServerStatus(state)).toBe(state.status.servers.genome3d);
   });
 });

--- a/src/store/utils/get-initial-state/index.js
+++ b/src/store/utils/get-initial-state/index.js
@@ -65,6 +65,12 @@ export default (historyWrapper) => {
         port: config.root.repeatsDB.port || DEFAULT_HTTP_PORT,
         root: config.root.repeatsDB.pathname,
       };
+      settings.disprot = {
+        protocol: config.root.disprot.protocol,
+        hostname: config.root.disprot.hostname,
+        port: config.root.disprot.port || DEFAULT_HTTP_PORT,
+        root: config.root.disprot.pathname,
+      };
     }
   }
   let description = { other: ['NotFound'] };

--- a/src/store/utils/get-initial-state/index.js
+++ b/src/store/utils/get-initial-state/index.js
@@ -59,6 +59,12 @@ export default (historyWrapper) => {
         port: config.root.genome3d.port || DEFAULT_HTTP_PORT,
         root: config.root.genome3d.pathname,
       };
+      settings.repeatsDB = {
+        protocol: config.root.repeatsDB.protocol,
+        hostname: config.root.repeatsDB.hostname,
+        port: config.root.repeatsDB.port || DEFAULT_HTTP_PORT,
+        root: config.root.repeatsDB.pathname,
+      };
     }
   }
   let description = { other: ['NotFound'] };


### PR DESCRIPTION
The main feature added in this PR is the support of 2 new external sources to the `ProteinViewer` on the protein page:
*DisProt* and *RepeatsDB*.

The logic to display *Genome3D* annotations has been updated to follow the same strategy as the 2 DBs above. i.e. Making them part of the `ExternalSourcesHOC`.

All of the external sources are in a category that by default is close, and the label of each feature starts with its source, e.g. `DisProt:`. Popup components were created for each external source.

### Other changes

The server settings for genome 3d have been removed, also the status of it in the side menu has been removed.

The position of a feature in the popups was abstracted as a separate component to reuse it in the external sources popups.

**NOTE 1:** Please review first #489 

**NOTE 2:** Add this to your `config.yml` file:

```yml
  repeatsDB: https://repeatsdb.bio.unipd.it/api/search
  disprot: https://disprot.org/api/
```