### PR TITLE
Protein viewer fixes

### DIFF
--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -217,6 +217,10 @@ export const ProteinViewer = ({
                 .filter(([_, tracks]) => tracks && tracks.length)
 
                 .map(([type, entries, component]) => {
+                  entries.forEach((entry: ExtendedFeature) => {
+                    entry.protein = protein.accession;
+                  });
+
                   const LabelComponent = component?.component;
                   return (
                     <div

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -102,7 +102,7 @@ const DomainOnProteinWithoutData = ({
   } | null>(null);
   useEffect(() => {
     const payload = data?.payload as PayloadList<EntryProteinPayload>;
-    if (data && !data.loading && payload?.results) {
+    if (data && !data.loading) {
       const { interpro, unintegrated, other } = processData({
         data: data as unknown as RequestedData<
           PayloadList<ExpectedPayload<ProteinMetadata>>
@@ -110,7 +110,7 @@ const DomainOnProteinWithoutData = ({
         endpoint: 'protein',
       });
       setProcessedData({ interpro, unintegrated, other });
-      onMatchesLoaded?.(payload.results);
+      onMatchesLoaded?.(payload?.results || []);
       onFamiliesFound?.(interpro.filter((entry) => entry.type === 'family'));
     }
   }, [data]);


### PR DESCRIPTION
Resolves two bugs found in the protein viewer:

* #502: allows the viewer to load even when no entry matches are found
* #503: fixes broken link to MobiDB (and other external resources where the protein accession is part of the URL)