### PR TITLE
Single domain track

### DIFF
--- a/src/components/ProteinViewer/Popup/RepresentativeDomain/index.tsx
+++ b/src/components/ProteinViewer/Popup/RepresentativeDomain/index.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import Positions from '../Positions';
+import Link from 'components/generic/Link';
+
+export type DomainDetails = {
+  feature: {
+    accession: string;
+    color: string;
+    integrated: string;
+    length: number;
+    protein: string;
+    short_name: string;
+    source_database: string;
+    locations: Array<ProtVistaLocation>;
+  };
+};
+type Props = {
+  detail: DomainDetails;
+};
+
+const DomainPopup = ({ detail }: Props) => {
+  const {
+    locations,
+    accession,
+    source_database,
+    integrated,
+    protein,
+    short_name,
+  } = detail.feature;
+  return (
+    <section>
+      <h5>
+        {source_database}:{' '}
+        <Link
+          to={{
+            description: {
+              main: { key: 'entry' },
+              entry: { db: source_database, accession },
+            },
+          }}
+        >
+          <span style={{ color: 'white' }}>{accession}</span>
+        </Link>
+      </h5>
+      {short_name ? <h6>{short_name}</h6> : null}
+      {integrated ? (
+        <h6>
+          Integrated:{' '}
+          <Link
+            to={{
+              description: {
+                main: { key: 'entry' },
+                entry: { db: 'interpro', accession: integrated },
+              },
+            }}
+          >
+            <span style={{ color: 'white' }}>{integrated}</span>
+          </Link>
+        </h6>
+      ) : null}
+
+      {locations.map(({ fragments }, i) => (
+        <div key={i}>
+          <Positions fragments={fragments} protein={protein} key={i} />
+        </div>
+      ))}
+    </section>
+  );
+};
+export default DomainPopup;

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -52,7 +52,16 @@ const RepresentativeDomainsTrack = ({
     setData(
       entries.map((entry) => ({
         ...entry,
-        color:  getTrackColor(colorDomainsBy===EntryColorMode.DOMAIN_RELATIONSHIP?({parent:{accession:entry.integrated}}):entry, colorDomainsBy),
+        color: getTrackColor(
+          colorDomainsBy === EntryColorMode.DOMAIN_RELATIONSHIP
+            ? {
+                parent: entry.integrated
+                  ? { accession: entry.integrated }
+                  : null,
+              }
+            : entry,
+          colorDomainsBy
+        ),
       }))
     );
   }, [entries, colorDomainsBy]);

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import NightingaleInterProTrack from 'components/Nightingale/InterProTrack';
+import LabelsInTrack from 'components/ProteinViewer/LabelsInTrack';
 import DomainPopup from 'components/ProteinViewer/Popup/RepresentativeDomain';
 import { getTrackColor, EntryColorMode } from 'utils/entry-color';
 
@@ -24,6 +25,7 @@ type Props = {
   colorDomainsBy?: keyof typeof EntryColorMode;
   openTooltip: (element: HTMLElement | undefined, content: ReactNode) => void;
   closeTooltip: () => void;
+  isPrinting: boolean;  
 };
 
 const RepresentativeDomainsTrack = ({
@@ -34,6 +36,7 @@ const RepresentativeDomainsTrack = ({
   colorDomainsBy,
   openTooltip,
   closeTooltip,
+  isPrinting,  
 }: Props) => {
   const [data, setData] = useState(entries);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -86,6 +89,14 @@ const RepresentativeDomainsTrack = ({
           use-ctrl-to-zoom
         />
       </div>
+      {entries.length === 1 ? (
+        <LabelsInTrack
+          entry={entries[0]}
+          hideCategory={hideCategory}
+          expandedTrack={true}
+          isPrinting={isPrinting}
+        />
+      ) : null}
     </>
   );
 };

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -1,0 +1,68 @@
+import React, { ReactNode, useRef, useEffect } from 'react';
+
+import NightingaleInterProTrack from 'components/Nightingale/InterProTrack';
+import DomainPopup from 'components/ProteinViewer/Popup/RepresentativeDomain';
+
+import { ExtendedFeature } from '..';
+
+import cssBinder from 'styles/cssBinder';
+
+import style from '../style.css';
+import grid from '../grid.css';
+
+const css = cssBinder(style, grid);
+
+type Props = {
+  entries: Array<ExtendedFeature>;
+  highlightColor: string;
+  hideCategory: boolean;
+  length: number;
+  openTooltip: (element: HTMLElement | undefined, content: ReactNode) => void;
+  closeTooltip: () => void;
+};
+
+const RepresentativeDomainsTrack = ({
+  entries,
+  highlightColor,
+  hideCategory,
+  length,
+  openTooltip,
+  closeTooltip,
+}: Props) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    containerRef?.current?.addEventListener('change', (event) => {
+      const detail = (event as CustomEvent)?.detail;
+      if (detail?.eventType === 'mouseover') {
+        openTooltip(detail.target, <DomainPopup detail={detail} />);
+      }
+      if (detail?.eventType === 'mouseout') {
+        closeTooltip();
+      }
+    });
+  }, [containerRef]);
+  return (
+    <>
+      <div
+        className={css('track', {
+          hideCategory,
+        })}
+        ref={containerRef}
+      >
+        <NightingaleInterProTrack
+          length={length}
+          data={entries}
+          margin-color="#fafafa"
+          id="Domains"
+          shape="roundRectangle"
+          highlight-event="onmouseover"
+          highlight-color={highlightColor}
+          show-label
+          label=".feature.short_name"
+          use-ctrl-to-zoom
+        />
+      </div>
+    </>
+  );
+};
+export default RepresentativeDomainsTrack;

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -52,7 +52,7 @@ const RepresentativeDomainsTrack = ({
     setData(
       entries.map((entry) => ({
         ...entry,
-        color: getTrackColor(entry, colorDomainsBy),
+        color:  getTrackColor(colorDomainsBy===EntryColorMode.DOMAIN_RELATIONSHIP?({parent:{accession:entry.integrated}}):entry, colorDomainsBy),
       }))
     );
   }, [entries, colorDomainsBy]);

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -1,7 +1,11 @@
-import React, { ReactNode, useRef, useEffect } from 'react';
+import React, { ReactNode, useRef, useEffect, useState } from 'react';
+
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
 
 import NightingaleInterProTrack from 'components/Nightingale/InterProTrack';
 import DomainPopup from 'components/ProteinViewer/Popup/RepresentativeDomain';
+import { getTrackColor, EntryColorMode } from 'utils/entry-color';
 
 import { ExtendedFeature } from '..';
 
@@ -17,6 +21,7 @@ type Props = {
   highlightColor: string;
   hideCategory: boolean;
   length: number;
+  colorDomainsBy?: keyof typeof EntryColorMode;
   openTooltip: (element: HTMLElement | undefined, content: ReactNode) => void;
   closeTooltip: () => void;
 };
@@ -26,9 +31,11 @@ const RepresentativeDomainsTrack = ({
   highlightColor,
   hideCategory,
   length,
+  colorDomainsBy,
   openTooltip,
   closeTooltip,
 }: Props) => {
+  const [data, setData] = useState(entries);
   const containerRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     containerRef?.current?.addEventListener('change', (event) => {
@@ -41,6 +48,14 @@ const RepresentativeDomainsTrack = ({
       }
     });
   }, [containerRef]);
+  useEffect(() => {
+    setData(
+      entries.map((entry) => ({
+        ...entry,
+        color: getTrackColor(entry, colorDomainsBy),
+      }))
+    );
+  }, [entries, colorDomainsBy]);
   return (
     <>
       <div
@@ -51,7 +66,7 @@ const RepresentativeDomainsTrack = ({
       >
         <NightingaleInterProTrack
           length={length}
-          data={entries}
+          data={data}
           margin-color="#fafafa"
           id="Domains"
           shape="roundRectangle"
@@ -65,4 +80,11 @@ const RepresentativeDomainsTrack = ({
     </>
   );
 };
-export default RepresentativeDomainsTrack;
+
+const mapStateToProps = createSelector(
+  (state: GlobalState) => state.settings.ui,
+  (ui) => ({
+    colorDomainsBy: ui.colorDomainsBy || EntryColorMode.DOMAIN_RELATIONSHIP,
+  })
+);
+export default connect(mapStateToProps)(RepresentativeDomainsTrack);

--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -24,8 +24,8 @@ import uniqueId from 'utils/cheap-unique-id';
 
 import cssBinder from 'styles/cssBinder';
 
-import style from '../../ProteinViewer/style.css';
-import grid from '../../ProteinViewer/grid.css';
+import style from '../style.css';
+import grid from '../grid.css';
 import { ExtendedFeature } from '..';
 import LabelsInTrack from '../LabelsInTrack';
 

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -32,6 +32,7 @@ import style from './style.css';
 import grid from './grid.css';
 import popper from './popper.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
+import RepresentativeDomainsTrack from './RepresentativeDomainsTrack';
 
 const css = cssBinder(style, grid, fonts, popper);
 
@@ -264,19 +265,30 @@ export const ProteinViewer = ({
                           <LabelComponent {...(component?.attributes || {})} />
                         </div>
                       )}{' '}
-                      <TracksInCategory
-                        entries={entries}
-                        sequence={protein.sequence}
-                        hideCategory={hideCategory[type]}
-                        highlightColor={highlightColor}
-                        openTooltip={openTooltip}
-                        closeTooltip={closeTooltip}
-                        isPrinting={isPrinting}
-                        ref={(ref: ExpandedHandle) =>
-                          categoryRefs.current.push(ref)
-                        }
-                        databases={dataBase?.payload?.databases}
-                      />
+                      {type === 'representative domains' ? (
+                        <RepresentativeDomainsTrack
+                          hideCategory={hideCategory[type]}
+                          highlightColor={highlightColor}
+                          entries={entries}
+                          length={protein.sequence.length}
+                          openTooltip={openTooltip}
+                          closeTooltip={closeTooltip}
+                        />
+                      ) : (
+                        <TracksInCategory
+                          entries={entries}
+                          sequence={protein.sequence}
+                          hideCategory={hideCategory[type]}
+                          highlightColor={highlightColor}
+                          openTooltip={openTooltip}
+                          closeTooltip={closeTooltip}
+                          isPrinting={isPrinting}
+                          ref={(ref: ExpandedHandle) =>
+                            categoryRefs.current.push(ref)
+                          }
+                          databases={dataBase?.payload?.databases}
+                        />
+                      )}
                     </div>
                   );
                 })}

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -67,6 +67,7 @@ export type ExtendedFeature = Feature & {
   location2residue?: unknown;
   chain?: string;
   protein?: string;
+  integrated?: string;
   children?: Array<ExtendedFeature>;
   warnings?: Array<string>;
 };

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -277,6 +277,7 @@ export const ProteinViewer = ({
                           length={protein.sequence.length}
                           openTooltip={openTooltip}
                           closeTooltip={closeTooltip}
+                          isPrinting={isPrinting}
                         />
                       ) : (
                         <TracksInCategory

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -34,6 +34,9 @@ import popper from './popper.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import RepresentativeDomainsTrack from './RepresentativeDomainsTrack';
 
+TracksInCategory.displayName = 'TracksInCategory';
+Header.displayName = 'TracksHeader';
+
 const css = cssBinder(style, grid, fonts, popper);
 
 const highlightColor = '#607D8B50';

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -41,12 +41,12 @@ const selectRepresentativeDomains = (domains: Record<string, unknown>[]) => {
       if (dom1 === dom2 || !dom1.keep || !dom2.keep) continue;
       const overlap =
         Math.min(dom1.end, dom2.end) - Math.max(dom1.start, dom2.start) + 1;
-      if (overlap) {
+      if (overlap > 0) {
         if (overlap > 0.7 * dom1.length && overlap > 0.7 * dom2.length) {
-          if (dom1.length < dom2.length) dom1.keep = false;
-          if (dom1.length === dom2.length) {
-            if (dom2.source_database === 'pfam') dom1.keep = false;
-          }
+          if (dom1.length < dom2.length ||
+               (dom1.length === dom2.length && dom2.source_database === 'pfam')) {
+            dom1.keep = false;
+}
         } else if (overlap > 0.7 * dom1.length && overlap < 0.7 * dom2.length) {
           dom1.keep = false;
         }

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -35,7 +35,6 @@ const selectRepresentativeDomains = (domains: Record<string, unknown>[]) => {
       }
     }
   }
-  // const sortedDomains = flatDomains.sort((a, b) => b.length - a.length);
   for (const dom1 of flatDomains) {
     for (const dom2 of flatDomains) {
       if (dom1 === dom2 || !dom1.keep || !dom2.keep) continue;
@@ -43,10 +42,12 @@ const selectRepresentativeDomains = (domains: Record<string, unknown>[]) => {
         Math.min(dom1.end, dom2.end) - Math.max(dom1.start, dom2.start) + 1;
       if (overlap > 0) {
         if (overlap > 0.7 * dom1.length && overlap > 0.7 * dom2.length) {
-          if (dom1.length < dom2.length ||
-               (dom1.length === dom2.length && dom2.source_database === 'pfam')) {
+          if (
+            dom1.length < dom2.length ||
+            (dom1.length === dom2.length && dom2.source_database === 'pfam')
+          ) {
             dom1.keep = false;
-}
+          }
         } else if (overlap > 0.7 * dom1.length && overlap < 0.7 * dom2.length) {
           dom1.keep = false;
         }

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -17,19 +17,20 @@ const dbs4SingleDomain = [
 const selectRepresentativeDomains = (domains: Record<string, unknown>[]) => {
   const flatDomains = [];
   for (const domain of domains) {
-    const { accession, short_name, source_database, integrated } = domain;
+    const { accession, short_name, name, source_database, integrated } = domain;
     for (const location of domain.entry_protein_locations as Array<ProtVistaLocation>) {
       for (const fragment of location.fragments) {
         const { start, end } = fragment;
         flatDomains.push({
           accession,
           short_name,
+          name,
           source_database,
           integrated,
           start,
           end,
           color: getTrackColor({ source_database }, EntryColorMode.MEMBER_DB),
-          length: end - start,
+          length: end - start + 1,
           keep: true,
         });
       }

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -1,7 +1,60 @@
 import { createSelector } from 'reselect';
 import { toPlural } from 'utils/pages/toPlural';
 import { NOT_MEMBER_DBS } from 'menuConfig';
+import { getTrackColor, EntryColorMode } from 'utils/entry-color';
 
+const dbs4SingleDomain = [
+  'pfam',
+  'smart',
+  'pirsf',
+  'ncbifam',
+  'hamap',
+  'sfld',
+  'cdd',
+  'profile',
+];
+
+const selectRepresentativeDomains = (domains: Record<string, unknown>[]) => {
+  const flatDomains = [];
+  for (const domain of domains) {
+    const { accession, short_name, source_database, integrated } = domain;
+    for (const location of domain.entry_protein_locations as Array<ProtVistaLocation>) {
+      for (const fragment of location.fragments) {
+        const { start, end } = fragment;
+        flatDomains.push({
+          accession,
+          short_name,
+          source_database,
+          integrated,
+          start,
+          end,
+          color: getTrackColor({ source_database }, EntryColorMode.MEMBER_DB),
+          length: end - start,
+          keep: true,
+        });
+      }
+    }
+  }
+  // const sortedDomains = flatDomains.sort((a, b) => b.length - a.length);
+  for (const dom1 of flatDomains) {
+    for (const dom2 of flatDomains) {
+      if (dom1 === dom2 || !dom1.keep || !dom2.keep) continue;
+      const overlap =
+        Math.min(dom1.end, dom2.end) - Math.max(dom1.start, dom2.start) + 1;
+      if (overlap) {
+        if (overlap > 0.7 * dom1.length && overlap > 0.7 * dom2.length) {
+          if (dom1.length < dom2.length) dom1.keep = false;
+          if (dom1.length === dom2.length) {
+            if (dom2.source_database === 'pfam') dom1.keep = false;
+          }
+        } else if (overlap > 0.7 * dom1.length && overlap < 0.7 * dom2.length) {
+          dom1.keep = false;
+        }
+      }
+    }
+  }
+  return flatDomains.filter(({ keep }) => keep);
+};
 export const processData = createSelector(
   (data: Data) => data?.data?.payload?.results || [],
   (data: Data) => data.endpoint,
@@ -22,6 +75,16 @@ export const processData = createSelector(
       (entry) =>
         (entry as unknown as Metadata).source_database.toLowerCase() ===
         'interpro'
+    );
+
+    const representativeDomains = selectRepresentativeDomains(
+      results.filter(
+        (entry) =>
+          dbs4SingleDomain.includes(
+            (entry as unknown as Metadata).source_database.toLowerCase()
+          ) &&
+          (entry as unknown as EntryMetadata)?.type?.toLowerCase() !== 'family'
+      )
     );
     const interproMap = new Map(
       interpro.map((ipro) => [
@@ -53,6 +116,7 @@ export const processData = createSelector(
     return {
       interpro,
       unintegrated,
+      representativeDomains,
       other: [],
     };
   }

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -10,6 +10,7 @@ const ProteinViewer = loadable({
 
 const UNDERSCORE = /_/g;
 const FIRST_IN_ORDER = [
+  'representative_domains',
   'family',
   'domain',
   'homologous_superfamily',

--- a/src/components/Related/DomainsOnProtein/mergeResidues.ts
+++ b/src/components/Related/DomainsOnProtein/mergeResidues.ts
@@ -50,7 +50,8 @@ const mergeResidues = (
   const residues: Record<string, ResidueEntry> =
     mergePIRSFRResidues(residuesPayload);
 
-  Object.values(data).forEach(
+  const { representative_domains: _, ...otherGroups } = data;
+  Object.values(otherGroups).forEach(
     (
       group /*: Array<{accession:string, residues: Array<Object>, children: any}> */
     ) =>

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -114,7 +114,7 @@ type SettingsState = {
 };
 type UISettings = {
   lowGraphics: boolean;
-  colorDomainsBy: string;
+  colorDomainsBy: 'ACCESSION' | 'MEMBER_DB' | 'DOMAIN_RELATIONSHIP';
   labelContent: LabelUISettings;
   structureViewer: boolean;
   shouldHighlight: boolean;

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -294,18 +294,16 @@ type ProteinEntryPayload = {
   metadata: ProteinMetadata;
   entries: Array<{
     accession: string;
-    entry_protein_locations: [
-      {
-        fragments: Array<{
-          start: number;
-          end: number;
-          'dc-status'?: string;
-        }>;
-        model: string | null;
-        score: number | null;
-        subfamily: { accession: string };
-      }
-    ];
+    entry_protein_locations: Array<{
+      fragments: Array<{
+        start: number;
+        end: number;
+        'dc-status'?: string;
+      }>;
+      model: string | null;
+      score: number | null;
+      subfamily: { accession: string };
+    }>;
     protein_length: number;
     source_database: string;
     entry_type: string;
@@ -550,15 +548,15 @@ type DisprotRegion = {
   released: string;
 };
 type DisprotConsensusRegion = {
-  start: number,
-  end: number,
+  start: number;
+  end: number;
   type: string;
 };
 type DisprotConsensus = {
-  full: Array<DisprotConsensusRegion>,
-  'Structural state': Array<object>,
-  'Structural transition': Array<object>,
-  'Biological process': Array<object>,
+  full: Array<DisprotConsensusRegion>;
+  'Structural state': Array<object>;
+  'Structural transition': Array<object>;
+  'Biological process': Array<object>;
 };
 type DisProtPayload = {
   acc: string;


### PR DESCRIPTION
Adds a new category in the protein viewer: **Representative Domains**

Uses a similar algorithm to the one provided by @typhainepl in [the demo](https://github.com/ProteinsWebTeam/pronto/blob/c296c6a987e6d0d999b9dbfd90266f955d6efd17/pronto/api/single_dom.py).

Doesn't have a label on the right, any suggestions for it are welcome, but I thought that given the title of the category, a label wasn't necessary.
