### PR TITLE
Structure sequence fix

### DIFF
--- a/src/components/EntryMenu/EntryMenuLink/style.css
+++ b/src/components/EntryMenu/EntryMenuLink/style.css
@@ -1,4 +1,4 @@
-@import '../../../styles/timing.css';
+@import "../../../styles/timing.css";
 
 :root {
   /*GAL*/
@@ -12,7 +12,7 @@ body {
     &:focus,
     &:hover,
     &:visited {
-      text-decoration: none;
+      text-decoration: none !important;
       font-size: 0.9rem; /* same size as submenu */
       padding: var(--menuitem-padding, 0.4rem);
       color: black;

--- a/src/components/File/TooltipContent/style.css
+++ b/src/components/File/TooltipContent/style.css
@@ -14,5 +14,7 @@
   &:focus {
     color: var(--colors-almost-white);
     box-shadow: none;
+    text-decoration: none !important;
+    border: 4px solid transparent !important;
   }
 }

--- a/src/components/ProteinViewer/grid.css
+++ b/src/components/ProteinViewer/grid.css
@@ -60,12 +60,18 @@
 
 .protvista-grid .track-label {
   grid-column: 2 / 3;
-  overflow-x: scroll;
+  overflow-x: auto;
   line-height: 1;
   white-space: nowrap;
   font-family: var(--fonts-system);
   padding-left: 0.5rem;
   scrollbar-color: lightgray transparent;
+}
+.protvista-grid .track-label::-webkit-scrollbar:horizontal {
+  background-color: transparent;
+}
+.protvista-grid .track-label::-webkit-scrollbar-thumb:horizontal {
+  background: lightgray;
 }
 .protvista-grid .track-label > a,
 .protvista-grid .track-label > a:focus,
@@ -87,9 +93,6 @@
 .protvista-grid .track-label .track-accession-child > a:visited {
   font-size: 90%;
   color: var(--colors-graydark);
-}
-.protvista-grid .track-label::-webkit-scrollbar {
-  background-color: transparent;
 }
 .protvista-grid .tracks-container {
   grid-column: 1 / 3;

--- a/src/components/Related/DomainEntriesOnStructure/GoToProtVistaMenu/index.tsx
+++ b/src/components/Related/DomainEntriesOnStructure/GoToProtVistaMenu/index.tsx
@@ -12,7 +12,7 @@ const GoToProtVistaMenu = ({ entries }: { entries: DataForProteinChain[] }) => (
   <DropDownButton label="Jump To" icon="&#xf124;">
     <ul>
       {entries.map((e, i) => {
-        const elementID = `protvista-${e.chain}-${e.protein.accession}`;
+        const elementID = `protvista-${e.chain}-${e.protein.accession || '0'}`;
         return (
           <li key={i}>
             <Link
@@ -22,7 +22,8 @@ const GoToProtVistaMenu = ({ entries }: { entries: DataForProteinChain[] }) => (
               })}
               onClick={() => scrollToElementByID(elementID)}
             >
-              Chain {e.chain} ({e.protein.accession})
+              Chain {e.chain}
+              {e.protein.accession !== null ? ` (${e.protein.accession})` : ''}
             </Link>
           </li>
         );

--- a/src/components/Related/DomainEntriesOnStructure/index.tsx
+++ b/src/components/Related/DomainEntriesOnStructure/index.tsx
@@ -169,9 +169,9 @@ const EntriesOnStructure = ({
   tagChimericStructures(merged);
   return (
     <>
-      {showChainMenu && merged.length > 1 && (
-        <GoToProtVistaMenu entries={merged} />
-      )}
+      {/*{showChainMenu && merged.length > 1 && (*/}
+      {/*  <GoToProtVistaMenu entries={merged} />*/}
+      {/*)}*/}
       <div className={css('row')}>
         {merged.map((e, i) => {
           const sequenceData = {

--- a/src/components/SimpleCommonComponents/DropDownButton/style.css
+++ b/src/components/SimpleCommonComponents/DropDownButton/style.css
@@ -1,6 +1,6 @@
-@import '../../../styles/timing.css';
-@import '../../../styles/colors.css';
-@import '../../../styles/z-index.css';
+@import "../../../styles/timing.css";
+@import "../../../styles/colors.css";
+@import "../../../styles/z-index.css";
 
 .dropdown-container {
   display: inline-flex;
@@ -27,7 +27,7 @@
     position: absolute;
     top: 100%;
     width: initial;
-    padding: 1rem 0.5rem;
+    padding: 1rem 1.5rem 1rem 0.5rem;
     transform: scaleY(0);
     transform-origin: top;
     transition: transform var(--timing-really-fast) ease-in-out;
@@ -60,6 +60,13 @@
         }
       }
     }
+  }
+}
+
+.dropdown-container.right-aligned {
+  & .dropdown-content {
+    left: auto;
+    right: 0;
   }
 }
 

--- a/src/components/SimpleCommonComponents/Tooltip/index.tsx
+++ b/src/components/SimpleCommonComponents/Tooltip/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@floating-ui/react';
 import useStateRef from 'utils/hooks/useStateRef';
 
-const TOOLTIP_DELAY = 300;
+const TOOLTIP_DELAY = 150;
 
 import cssBinder from 'styles/cssBinder';
 
@@ -35,7 +35,7 @@ const Tooltip = ({
   const arrowRef = useRef(null);
   const [_, setOverTooltip, overTooltipRef] = useStateRef(false);
   const intervalId = useRef<NodeJS.Timer | null>(null);
-  const [hide, setHide] = useState(true)
+  const [hide, setHide] = useState(true);
   const { refs, floatingStyles, context } = useFloating({
     middleware: [
       autoPlacement(),
@@ -81,15 +81,16 @@ const Tooltip = ({
           </div>
         )}
       </FloatingPortal>
-      <div {...rest} ref={refs.setReference}
+      <div
+        {...rest}
+        ref={refs.setReference}
         onMouseEnter={() => setHide(false)}
-        onMouseLeave={() => interactive ? scheduleHide() : setHide(true)}
-        style={useContext ? {} : { display: 'inline' }}>
+        onMouseLeave={() => (interactive ? scheduleHide() : setHide(true))}
+        style={useContext ? {} : { display: 'inline' }}
+      >
         {children}
       </div>
-
     </>
-
   );
 };
 

--- a/src/components/SimpleCommonComponents/Tooltip/style.css
+++ b/src/components/SimpleCommonComponents/Tooltip/style.css
@@ -8,6 +8,7 @@
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
   padding: 0.6rem;
   margin: 4px;
+  z-index: var(--z-index-tooltips);
 
   & h5 {
     text-transform: uppercase;

--- a/src/components/Structure/Summary/__snapshots__/test.js.snap
+++ b/src/components/Structure/Summary/__snapshots__/test.js.snap
@@ -84,11 +84,7 @@ exports[`<SummaryStructure /> should render 1`] = `
               Released
             </td>
             <td>
-              <TimeAgo
-                date={1998-04-08T00:00:00.000Z}
-                noUpdate={true}
-                title="08/04/1998"
-              />
+              8 April 1998
             </td>
           </tr>
         </tbody>

--- a/src/components/Structure/Summary/index.tsx
+++ b/src/components/Structure/Summary/index.tsx
@@ -11,10 +11,9 @@ import Link from 'components/generic/Link';
 import BaseLink from 'components/ExtLink/BaseLink';
 import ErrorBoundary from 'wrappers/ErrorBoundary';
 import Literature from 'components/Entry/Literature';
-import TimeAgo from 'components/TimeAgo';
 import ViewerOnDemand from 'components/Structure/ViewerAndEntries';
 import { formatExperimentType } from 'components/Structure/utils';
-import { formatShortDate } from 'utils/date';
+import { formatLongDate } from 'utils/date';
 
 import cssBinder from 'styles/cssBinder';
 
@@ -119,13 +118,7 @@ export const SummaryStructure = ({ data, dataMatches }: LoadedProps) => {
                 </tr>
                 <tr>
                   <td>Released</td>
-                  <td>
-                    <TimeAgo
-                      date={date}
-                      noUpdate
-                      title={formatShortDate(date)}
-                    />
-                  </td>
+                  <td>{formatLongDate(date)}</td>
                 </tr>
               </tbody>
             </table>

--- a/src/components/Table/Exporter/index.js
+++ b/src/components/Table/Exporter/index.js
@@ -57,6 +57,7 @@ class Exporter extends PureComponent /*:: <Props, State> */ {
           icon="&#x3d;"
           color={entryDB ? config.colors.get(entryDB) : backgroundColor}
           disabled={disabled}
+          extraClasses={'right-aligned'}
         >
           {children}
         </DropDownButton>

--- a/src/reducers/settings/category/index.js
+++ b/src/reducers/settings/category/index.js
@@ -33,7 +33,7 @@ export const getDefaultSettingsFor = (category /*: Category */) => {
         labelContent: {
           accession: true,
           name: false,
-          short: false,
+          short: true,
         },
         structureViewer: false,
         shouldHighlight: true,

--- a/src/reducers/settings/category/index.js
+++ b/src/reducers/settings/category/index.js
@@ -39,7 +39,7 @@ export const getDefaultSettingsFor = (category /*: Category */) => {
         shouldHighlight: true,
         idaAccessionDB: 'interpro',
         idaLabel: 'name',
-        isPIPEnabled: true,
+        isPIPEnabled: false,
       };
     case 'cache':
       return {


### PR DESCRIPTION
**"Jump To" button**

Hidden. I think there a downstream event listener that breaks the "Jump to" functionality by jumping back to the structure viewer, but I don't have the time to investigate more.

**Relative time**

Showing absolute time instead of relative time (e.g. `31 October 1993` instead of `29 years ago`).

**Performance**

Not done.
I tried to transform the "Jump To" button into a selector so we only show one protein viewer (for one chain) at a time. It works at first, but then there is an unexpected behavior when "cycling back" to the first selected chain (e.g. `A` selected -> switch to `B` -> switch back to `A`).

**Redundancy**

Not done. We need to be able to group chains together based on their sequence. Although this could be done directly in the client (we have the sequence for each chain), it's probably better to do that in the data warehouse.

**Missing secondary structures**

Fixed. Example : 

- missing on the live website: https://www.ebi.ac.uk/interpro/structure/PDB/6m58/
- present on local build at `/interpro/structure/PDB/6m58/`

**Export button**

* Tooltip behind dropdown panel: fixed
* Dropdown overflow viewport on small screens: fixed; the dropdown content is aligned with the right of the "Export" button

![Screenshot_2023-09-11_11-49-23](https://github.com/ProteinsWebTeam/interpro7-client/assets/2097501/08983042-2722-4461-9cf3-308b604b4e77)

**Other changes**

* Picture-In-Picture for structure viewer disabled by default
* Domain viewer labels: accession and short name used by default (currently, only the accession is used)