### PR TITLE
Removed signatures

### DIFF
--- a/src/components/Entry/RemovedEntrySummary/index.js
+++ b/src/components/Entry/RemovedEntrySummary/index.js
@@ -17,7 +17,7 @@ const RemovedEntrySummary = ({
   type,
   name,
   short_name,
-  date,
+  deletion_date,
   history,
   dbInfo,
 }) => {
@@ -39,6 +39,10 @@ const RemovedEntrySummary = ({
         : [],
     is_removed: true,
   };
+  const date = new Date(deletion_date).toLocaleDateString('en-GB', {
+    month: 'long',
+    year: 'numeric',
+  });
   const message = `${metadata.accession} has been retired in ${date}.`;
   return (
     <div className={f('row')}>
@@ -62,7 +66,7 @@ RemovedEntrySummary.propTypes = {
   type: T.string,
   name: T.string,
   short_name: T.string,
-  date: T.string,
+  deletion_date: T.string,
   history: T.shape({
     names: T.arrayOf(T.string),
     short_names: T.arrayOf(T.string),

--- a/src/components/Entry/RemovedEntrySummary/index.js
+++ b/src/components/Entry/RemovedEntrySummary/index.js
@@ -36,7 +36,7 @@ const RemovedEntrySummary = ({
     description:
       formerNames.length !== 0
         ? ['Former names:', `<ul>${formerNames.map(listWrap).join('')}</ul>`]
-        : null,
+        : [],
   };
   const message = `${metadata.accession} has been retired in ${date}.`;
   return (

--- a/src/components/Entry/RemovedEntrySummary/index.js
+++ b/src/components/Entry/RemovedEntrySummary/index.js
@@ -43,7 +43,7 @@ const RemovedEntrySummary = ({
     month: 'long',
     year: 'numeric',
   });
-  const message = `${metadata.accession} has been retired in ${date}.`;
+  const message = `${metadata.accession} is obsolete since ${date}.`;
   return (
     <div className={f('row')}>
       <div className={f('medium-12', 'large-12', 'columns')}>

--- a/src/components/Entry/RemovedEntrySummary/index.js
+++ b/src/components/Entry/RemovedEntrySummary/index.js
@@ -11,28 +11,41 @@ import ebiGlobalStyles from 'ebi-framework/css/ebi-global.css';
 
 const f = foundationPartial(ebiGlobalStyles, fonts);
 
-const RemovedEntrySummary = ({ detail, accession, date, history, dbInfo }) => {
+const RemovedEntrySummary = ({
+  accession,
+  source_database,
+  type,
+  name,
+  short_name,
+  date,
+  history,
+  dbInfo,
+}) => {
+  const allNames = (history?.names || []).concat(history?.short_names || []);
+  const formerNames = allNames.filter((n) => n !== name && n !== short_name);
+  const listWrap = (n) => `<li>${n}</li>`;
   const metadata = {
     accession: accession.toUpperCase(),
-    name: { name: history?.names?.[0] || '???' },
-    source_database: 'Removed',
-    type: 'unknown',
+    name: {
+      name: name,
+      short: short_name,
+    },
+    source_database: source_database,
+    type: type,
     member_databases: history?.signatures,
-    description: [
-      `<b>Removed</b>: ${date}`,
-      '<b>Used names</b>:',
-      ...(history?.names || []).map((n) => ` * ${n}`),
-    ],
+    description:
+      formerNames.length !== 0
+        ? ['Former names:', `<ul>${formerNames.map(listWrap).join('')}</ul>`]
+        : null,
   };
-  const regex = /ipr[0-9]{6}/gi;
-  const detailF = (detail || '').replace(regex, accession.toUpperCase());
+  const message = `${metadata.accession} has been retired in ${date}.`;
   return (
     <div className={f('row')}>
       <div className={f('medium-12', 'large-12', 'columns')}>
-        <EdgeCase text={detailF} status={410} shouldRedirect={false} />
+        <EdgeCase text={message} status={410} shouldRedirect={false} />
         <Title metadata={metadata} mainType="entry" />
         <SummaryEntry
-          data={{ metadata: { ...metadata, source_database: 'interpro' } }}
+          data={{ metadata: metadata }}
           loading={false}
           dbInfo={dbInfo}
         />
@@ -42,12 +55,16 @@ const RemovedEntrySummary = ({ detail, accession, date, history, dbInfo }) => {
 };
 
 RemovedEntrySummary.propTypes = {
-  detail: T.string,
   accession: T.string,
+  source_database: T.string,
+  type: T.string,
+  name: T.string,
+  short_name: T.string,
   date: T.string,
   history: T.shape({
-    signatures: T.arrayOf(T.object),
     names: T.arrayOf(T.string),
+    short_names: T.arrayOf(T.string),
+    signatures: T.object,
   }),
   dbInfo: T.object,
 };

--- a/src/components/Entry/RemovedEntrySummary/index.js
+++ b/src/components/Entry/RemovedEntrySummary/index.js
@@ -35,7 +35,7 @@ const RemovedEntrySummary = ({
     member_databases: history?.signatures,
     description:
       formerNames.length !== 0
-        ? ['Former names:', `<ul>${formerNames.map(listWrap).join('')}</ul>`]
+        ? [`<ul>${formerNames.map(listWrap).join('')}</ul>`]
         : [],
     is_removed: true,
   };
@@ -47,6 +47,7 @@ const RemovedEntrySummary = ({
         <Title metadata={metadata} mainType="entry" />
         <SummaryEntry
           data={{ metadata: metadata }}
+          headerText={'Former names'}
           loading={false}
           dbInfo={dbInfo}
         />

--- a/src/components/Entry/RemovedEntrySummary/index.js
+++ b/src/components/Entry/RemovedEntrySummary/index.js
@@ -37,6 +37,7 @@ const RemovedEntrySummary = ({
       formerNames.length !== 0
         ? ['Former names:', `<ul>${formerNames.map(listWrap).join('')}</ul>`]
         : [],
+    is_removed: true,
   };
   const message = `${metadata.accession} has been retired in ${date}.`;
   return (

--- a/src/components/Entry/Summary/SidePanel/index.tsx
+++ b/src/components/Entry/Summary/SidePanel/index.tsx
@@ -96,80 +96,87 @@ const SidePanel = ({
       {['interpro', 'pfam'].includes(
         // Only receiving new annotations for pfam and interpro
         metadata.source_database.toLowerCase()
-      ) && (
-        <div>
-          <Tooltip
-            title={
-              'You may suggest updates to the annotation of this entry using this form. Suggestions will be sent to ' +
-              'our curators for review and, if acceptable, will be included in the next public release of InterPro. It is ' +
-              'helpful if you can include literature references supporting your annotation suggestion.'
-            }
-          >
-            <DropDownButton
-              label="Add your annotation"
-              icon="&#xf303;"
-              extraClasses={css('annotation')}
+      ) &&
+        !metadata.is_removed && (
+          <div>
+            <Tooltip
+              title={
+                'You may suggest updates to the annotation of this entry using this form. Suggestions will be sent to ' +
+                'our curators for review and, if acceptable, will be included in the next public release of InterPro. It is ' +
+                'helpful if you can include literature references supporting your annotation suggestion.'
+              }
             >
-              <form
-                onSubmit={handleSubmit}
-                className={css('vf-stack', 'vf-stack--200')}
+              <DropDownButton
+                label="Add your annotation"
+                icon="&#xf303;"
+                extraClasses={css('annotation')}
               >
-                <label
-                  className={css('vf-form__label', 'vf-form__label--required')}
-                  htmlFor="message"
+                <form
+                  onSubmit={handleSubmit}
+                  className={css('vf-stack', 'vf-stack--200')}
                 >
-                  Your annotation
-                </label>
-                <textarea
-                  id="message"
-                  name="message"
-                  value={message}
-                  onChange={handleFields}
-                  className={css('vf-form__textarea')}
-                  rows={5}
-                  required
-                />
-                <label
-                  className={css('vf-form__label', 'vf-form__label--required')}
-                  htmlFor="from_email"
-                >
-                  Email address
-                </label>
-                <input
-                  id="from_email"
-                  name="from_email"
-                  type="email"
-                  value={email}
-                  onChange={handleFields}
-                  className={css('vf-form__input')}
-                  required
-                />
-                <div className={css('flex-space-evenly')}>
-                  <button
+                  <label
                     className={css(
-                      'vf-button',
-                      'vf-button--primary',
-                      'vf-button--sm'
+                      'vf-form__label',
+                      'vf-form__label--required'
                     )}
+                    htmlFor="message"
                   >
-                    Submit
-                  </button>
-                  <button
+                    Your annotation
+                  </label>
+                  <textarea
+                    id="message"
+                    name="message"
+                    value={message}
+                    onChange={handleFields}
+                    className={css('vf-form__textarea')}
+                    rows={5}
+                    required
+                  />
+                  <label
                     className={css(
-                      'vf-button',
-                      'vf-button--secondary',
-                      'vf-button--sm'
+                      'vf-form__label',
+                      'vf-form__label--required'
                     )}
-                    onClick={clearFields}
+                    htmlFor="from_email"
                   >
-                    Clear
-                  </button>
-                </div>
-              </form>
-            </DropDownButton>
-          </Tooltip>
-        </div>
-      )}
+                    Email address
+                  </label>
+                  <input
+                    id="from_email"
+                    name="from_email"
+                    type="email"
+                    value={email}
+                    onChange={handleFields}
+                    className={css('vf-form__input')}
+                    required
+                  />
+                  <div className={css('flex-space-evenly')}>
+                    <button
+                      className={css(
+                        'vf-button',
+                        'vf-button--primary',
+                        'vf-button--sm'
+                      )}
+                    >
+                      Submit
+                    </button>
+                    <button
+                      className={css(
+                        'vf-button',
+                        'vf-button--secondary',
+                        'vf-button--sm'
+                      )}
+                      onClick={clearFields}
+                    >
+                      Clear
+                    </button>
+                  </div>
+                </form>
+              </DropDownButton>
+            </Tooltip>
+          </div>
+        )}
       {metadata.integrated && <Integration intr={metadata.integrated} />}
       {!['interpro', 'pfam', 'antifam'].includes(
         metadata.source_database.toLowerCase()

--- a/src/components/Entry/Summary/index.tsx
+++ b/src/components/Entry/Summary/index.tsx
@@ -72,12 +72,14 @@ type SummaryEntryProps = {
   data: {
     metadata: EntryMetadata;
   };
+  headerText?: string;
   loading: boolean;
   dbInfo: DBInfo;
 };
 
 const SummaryEntry = ({
   data: { metadata },
+  headerText = 'Description',
   dbInfo,
   loading,
 }: SummaryEntryProps) => {
@@ -113,7 +115,7 @@ const SummaryEntry = ({
               // doesn't work for some HAMAP as they have enpty <P> tag
               (metadata.description || []).length ? (
                 <>
-                  <h4>Description</h4>
+                  <h4>{headerText}</h4>
                   <Description
                     textBlocks={metadata.description}
                     literature={included as Array<[string, Reference]>}

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -299,6 +299,7 @@ interface EntryMetadata extends Metadata {
     accession: string;
     name: string;
   };
+  is_removed?: boolean;
 }
 
 type SourceOrganism = {

--- a/src/pages/endpoint-page.js
+++ b/src/pages/endpoint-page.js
@@ -104,8 +104,7 @@ class Summary extends PureComponent {
   render() {
     const {
       data: { status, loading, payload },
-      // dataOrganism: { loading: loadingOrg, payload: payloadOrg },
-      dataBase,
+      dataBase: { payload: payloadDB, loading: loadingDB },
       customLocation,
       subPagesForEndpoint,
     } = this.props;
@@ -114,15 +113,24 @@ class Summary extends PureComponent {
         main: { key: endpoint },
       },
     } = customLocation;
-    const databases = dataBase?.payload?.databases;
-    if (status === STATUS_GONE) {
-      return <RemovedEntrySummary {...payload} dbInfo={databases} />;
-    }
-    const edgeCaseText = edgeCases.get(status);
-    if (edgeCaseText) return <EdgeCase text={edgeCaseText} status={status} />;
+
     if (loading || (!locationhasDetailOrFilter(customLocation) && !payload)) {
       return <Loading />;
     }
+
+    const db =
+      (!loadingDB &&
+        payloadDB &&
+        payloadDB.databases &&
+        payloadDB.databases[customLocation.description.entry.db]) ||
+      {};
+
+    if (status === STATUS_GONE) {
+      return <RemovedEntrySummary {...payload} dbInfo={db} />;
+    }
+    const edgeCaseText = edgeCases.get(status);
+    if (edgeCaseText) return <EdgeCase text={edgeCaseText} status={status} />;
+
     return (
       <>
         {payload?.metadata?.accession && (


### PR DESCRIPTION
Show basic information for deleted signatures and refactor the information displayed for deleted InterPro entries:

- update error message on top
- show the type and source of the deleted entry
- show the short name, if any
- for signatures, show the member database
- show past names and short names, if any

## API

You do not need to have a local API: you can use `http://wp-np3-af.ebi.ac.uk/interpro/api/` in `config.yml`.

## Examples

* `/entry/pfam/PF00256/`
* `/entry/ncbifam/TIGR00108/`
* `/entry/cdd/CD00020/`
* `/entry/InterPro/IPR000005/`

## Screenshot

### Live website:

![image](https://github.com/ProteinsWebTeam/interpro7-client/assets/2097501/b3f076ad-cae2-4dd4-a1f8-d324d1dfe771)

### After changes:

![image](https://github.com/ProteinsWebTeam/interpro7-client/assets/2097501/5930362a-3591-4150-b4c9-9b710ce6f576)
