### PR TITLE
Fix endpoint page loading

### DIFF
--- a/src/pages/endpoint-page.js
+++ b/src/pages/endpoint-page.js
@@ -114,22 +114,31 @@ class Summary extends PureComponent {
       },
     } = customLocation;
 
-    if (loading || (!locationhasDetailOrFilter(customLocation) && !payload)) {
+    if (loading) {
       return <Loading />;
     }
 
-    const db =
-      (!loadingDB &&
-        payloadDB &&
-        payloadDB.databases &&
-        payloadDB.databases[customLocation.description.entry.db]) ||
-      {};
+    if (payload && status === STATUS_GONE) {
+      const db =
+        (!loadingDB &&
+          payloadDB &&
+          payloadDB.databases &&
+          payloadDB.databases[customLocation.description.entry.db]) ||
+        {};
 
-    if (status === STATUS_GONE) {
       return <RemovedEntrySummary {...payload} dbInfo={db} />;
     }
-    const edgeCaseText = edgeCases.get(status);
-    if (edgeCaseText) return <EdgeCase text={edgeCaseText} status={status} />;
+
+    if (edgeCases.has(status)) {
+      const edgeCaseText = edgeCases.get(status);
+      if (edgeCaseText) {
+        return <EdgeCase text={edgeCaseText} status={status} />;
+      }
+    }
+
+    if (!locationhasDetailOrFilter(customLocation) && !payload) {
+      return <Loading />;
+    }
 
     return (
       <>


### PR DESCRIPTION
`endpoint-page.js` implements the logic to display the overview summary of primary endpoints, show the basic information if an InterPro entry or member database signature has been removed, or show error messages (for instance if there is no data returned by the API).

I previously, re-ordered some of the conditions, but this caused an issue when open a entry page for a PANTHER subfamily (`204` returned by the API), but since `payload` is null the client kept showing a "loading" state.

This PR fixes the order of conditions to test to show data or redirect.