### PR TITLE
set subpages without counters

### DIFF
--- a/src/higherOrder/loadData/defaults/index.js
+++ b/src/higherOrder/loadData/defaults/index.js
@@ -176,7 +176,7 @@ export const getReversedUrl = createSelector(
       },
     });
     if (description.main.key === 'set' && description?.entry?.isFilter) {
-      url = url.replace('counters', 'counters,short_name');
+      url = url.replace('counters', 'short_name');
     }
     if (description.main.key === 'entry' && newMain === 'taxonomy') {
       url = url.replace('/entry/', '/protein/entry/');


### PR DESCRIPTION
Getting counters from the API is an expensive operation, especially on big lists.

Although this requires more investigation to be able to generalise it, it seems to me that for sets the counters in a page like https://www.ebi.ac.uk/interpro/set/pfam/CL0010/entry/pfam/#table are not necessary. I couldn't find any case where they are currently used.

The code change is minimal, but I'm afraid of any cases I miss, so I'd appreciate a check before merging!
