### PR TITLE
Representative domains everywhere

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,10 @@ overrides:
 - files: "*.css"
   options:
     singleQuote: false
-- files: "src/**/*.js"
+- files: 
+  - "src/**/*.js"
+  - "src/**/*.ts"
+  - "src/**/*.tsx"
   options:
     parser: typescript
     trailingComma: all

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -3,12 +3,15 @@ import { toPlural } from 'utils/pages/toPlural';
 import { NOT_MEMBER_DBS } from 'menuConfig';
 import { getTrackColor, EntryColorMode } from 'utils/entry-color';
 
-const selectRepresentativeDomains = (domains: Record<string, unknown>[]) => {
+export const selectRepresentativeDomains = (
+  domains: Record<string, unknown>[],
+  locationKey: string = 'entry_protein_locations',
+) => {
   const flatDomains = [];
   for (const domain of domains) {
     const { accession, short_name, name, source_database, integrated, chain } =
       domain;
-    for (const location of domain.entry_protein_locations as Array<ProtVistaLocation>) {
+    for (const location of domain[locationKey] as Array<ProtVistaLocation>) {
       for (const fragment of location.fragments) {
         const { start, end, representative } = fragment;
         if (representative) {

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -6,13 +6,15 @@ import { getTrackColor, EntryColorMode } from 'utils/entry-color';
 const selectRepresentativeDomains = (domains: Record<string, unknown>[]) => {
   const flatDomains = [];
   for (const domain of domains) {
-    const { accession, short_name, name, source_database, integrated } = domain;
+    const { accession, short_name, name, source_database, integrated, chain } =
+      domain;
     for (const location of domain.entry_protein_locations as Array<ProtVistaLocation>) {
       for (const fragment of location.fragments) {
         const { start, end, representative } = fragment;
         if (representative) {
           flatDomains.push({
             accession,
+            chain,
             short_name,
             name,
             source_database,
@@ -31,7 +33,7 @@ const selectRepresentativeDomains = (domains: Record<string, unknown>[]) => {
 };
 export const useProcessData = <M = Metadata>(
   results: EndpointWithMatchesPayload<M, MatchI>[] | undefined,
-  endpoint: Endpoint
+  endpoint: Endpoint,
 ) =>
   useMemo(() => {
     return processData(results || [], endpoint);
@@ -39,7 +41,7 @@ export const useProcessData = <M = Metadata>(
 
 const processData = <M = Metadata>(
   dataResults: EndpointWithMatchesPayload<M>[],
-  endpoint: Endpoint
+  endpoint: Endpoint,
 ) => {
   const results: Record<string, unknown>[] = [];
   for (const item of dataResults) {
@@ -50,13 +52,13 @@ const processData = <M = Metadata>(
         ...match,
         ...item.metadata,
         ...(item.extra_fields || {}),
-      }))
+      })),
     );
   }
   const interpro = results.filter(
     (entry) =>
       (entry as unknown as Metadata).source_database.toLowerCase() ===
-      'interpro'
+      'interpro',
   );
 
   const representativeDomains = selectRepresentativeDomains(results);
@@ -64,15 +66,15 @@ const processData = <M = Metadata>(
     interpro.map((ipro) => [
       `${ipro.accession}-${ipro.chain}-${ipro.protein}`,
       ipro,
-    ])
+    ]),
   );
   const integrated = results.filter((entry) => entry.integrated);
   const unintegrated = results.filter(
     (entry) =>
       interpro.concat(integrated).indexOf(entry) === -1 &&
       !NOT_MEMBER_DBS.has(
-        (entry as unknown as Metadata).source_database.toLowerCase()
-      )
+        (entry as unknown as Metadata).source_database.toLowerCase(),
+      ),
   );
   integrated.forEach((entry) => {
     const ipro: Record<string, unknown> & {
@@ -84,7 +86,7 @@ const processData = <M = Metadata>(
     if (ipro.children.indexOf(entry) === -1) ipro.children.push(entry);
   });
   integrated.sort((a, b) =>
-    a.chain ? (a.chain as string).localeCompare(b.chain as string) : -1
+    a.chain ? (a.chain as string).localeCompare(b.chain as string) : -1,
   );
   return {
     interpro,

--- a/src/components/Related/DomainEntriesOnStructure/__snapshots__/test.js.snap
+++ b/src/components/Related/DomainEntriesOnStructure/__snapshots__/test.js.snap
@@ -3,10 +3,10 @@
 exports[`<EntriesOnStructure /> should render 1`] = `
 <React.Fragment>
   <div
-    className="row"
+    className="vf-stack vf-stack--400"
   >
     <div
-      className="columns"
+      className="vf-stack"
     >
       <h4
         id="protvista-A-p00735"

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -33,14 +33,14 @@ const css = cssBinder(ipro);
 
 export const orderByAccession = (
   a: { accession: string },
-  b: { accession: string }
+  b: { accession: string },
 ) => (a.accession > b.accession ? 1 : -1);
 
 export const groupByEntryType = (
   interpro: Array<{
     accession: string;
     type: string;
-  }>
+  }>,
 ) => {
   const groups: Record<
     string,
@@ -60,7 +60,7 @@ export const groupByEntryType = (
 type Props = PropsWithChildren<{
   mainData: { metadata: ProteinMetadata };
   onMatchesLoaded?: (
-    results: EndpointWithMatchesPayload<EntryMetadata, MatchI>[]
+    results: EndpointWithMatchesPayload<EntryMetadata, MatchI>[],
   ) => void;
   onFamiliesFound?: (families: Record<string, unknown>[]) => void;
   title?: string;
@@ -111,7 +111,7 @@ const DomainOnProteinWithoutData = ({
         EndpointWithMatchesPayload<EntryMetadata, MatchI>
       >
     )?.results,
-    'protein'
+    'protein',
   );
   useEffect(() => {
     const payload = data?.payload as PayloadList<
@@ -146,10 +146,10 @@ const DomainOnProteinWithoutData = ({
   const { interpro, unintegrated, other, representativeDomains } =
     processedData;
   const groups = groupByEntryType(
-    interpro as Array<{ accession: string; type: string }>
+    interpro as Array<{ accession: string; type: string }>,
   );
   (unintegrated as Array<{ accession: string; type: string }>).sort(
-    orderByAccession
+    orderByAccession,
   );
   const mergedData: ProteinViewerDataObject<MinimalFeature> = {
     ...groups,
@@ -159,18 +159,6 @@ const DomainOnProteinWithoutData = ({
   if (representativeDomains?.length)
     mergedData.representative_domains =
       representativeDomains as MinimalFeature[];
-  // [
-  //     // {
-  //     //   accession: 'Representative Domains',
-  //     //   locations: representativeDomains.map((d) => ({
-  //     //     fragments: [{ start: d.start as number, end: d.end as number }],
-  //     //     accession: d.accession as string,
-  //     //     short_name: d.short_name,
-  //     //     source_database: d.source_database,
-  //     //   })),
-  //     // },
-  //     representativeDomains,
-  //   ];
 
   if (externalSourcesData.length) {
     mergedData.external_sources = externalSourcesData;
@@ -276,7 +264,7 @@ const getRelatedEntriesURL = createSelector(
         extra_fields: 'hierarchy,short_name',
       },
     });
-  }
+  },
 );
 
 const getExtraURL = (query: string) =>
@@ -285,7 +273,7 @@ const getExtraURL = (query: string) =>
     (state: GlobalState) => state.customLocation.description,
     (
       { protocol, hostname, port, root }: ParsedURLServer,
-      description: InterProDescription
+      description: InterProDescription,
     ) => {
       const url = format({
         protocol,
@@ -297,7 +285,7 @@ const getExtraURL = (query: string) =>
         },
       });
       return url;
-    }
+    },
   );
 
 export default loadExternalSources(
@@ -317,9 +305,9 @@ export default loadExternalSources(
           getUrl: getExtraURL('residues'),
           propNamespace: 'Residues',
         } as Params)(
-          loadData(getRelatedEntriesURL as Params)(DomainOnProteinWithoutData)
-        )
-      )
-    )
-  )
+          loadData(getRelatedEntriesURL as Params)(DomainOnProteinWithoutData),
+        ),
+      ),
+    ),
+  ),
 );

--- a/src/components/Structure/ViewerAndEntries/ProteinViewerForAlphafold/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/ProteinViewerForAlphafold/index.tsx
@@ -25,7 +25,7 @@ const ProteinViewer = loadable({
 export const addConfidenceTrack = (
   dataConfidence: RequestedData<AlphafoldConfidencePayload>,
   protein: string,
-  tracks: ProteinViewerData
+  tracks: ProteinViewerData,
 ) => {
   if (dataConfidence?.payload?.confidenceCategory?.length) {
     const confidenceTrack: [string, Array<unknown>] = [
@@ -124,12 +124,15 @@ const ProteinViewerForAlphafold = ({
     !processedData
   )
     return <Loading />;
-  const { interpro, unintegrated } = processedData;
+  const { interpro, unintegrated, representativeDomains } = processedData;
   const tracks: ProteinViewerData = [
     ['Entries', interpro.concat(unintegrated)],
   ];
   if (dataConfidence) addConfidenceTrack(dataConfidence, protein, tracks);
   if (!dataProtein.payload?.metadata) return null;
+  if (representativeDomains?.length) {
+    tracks.splice(1, 0, ['representative domains', representativeDomains]);
+  }
   return (
     <div ref={containerRef}>
       <ProteinViewer
@@ -156,7 +159,7 @@ const getProteinURL = createSelector(
       port,
       pathname: root + descriptionToPath(newDesc),
     });
-  }
+  },
 );
 const getInterproRelatedEntriesURL = createSelector(
   (state) => state.settings.api,
@@ -177,7 +180,7 @@ const getInterproRelatedEntriesURL = createSelector(
         extra_fields: 'short_name',
       },
     });
-  }
+  },
 );
 
 export default loadData<AlphafoldPayload, 'Prediction'>({
@@ -193,8 +196,8 @@ export default loadData<AlphafoldPayload, 'Prediction'>({
       propNamespace: 'Protein',
     } as Params)(
       loadData(getInterproRelatedEntriesURL as Params)(
-        ProteinViewerForAlphafold
-      )
-    )
-  )
+        ProteinViewerForAlphafold,
+      ),
+    ),
+  ),
 );

--- a/src/components/Structure/ViewerAndEntries/ProteinViewerForStructures/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/ProteinViewerForStructures/index.tsx
@@ -38,13 +38,14 @@ const ProteinViewerForStructure = ({
     }
   }
   if (!data.payload || !processedData) return null;
-  const { interpro, unintegrated } = processedData;
+  const { interpro, unintegrated, representativeDomains } = processedData;
   return (
     <div>
       <EntriesOnStructure
         structure={structure}
         entries={interpro.concat(unintegrated) as StructureLinkedObject[]}
         secondaryStructures={secondaryData}
+        representativeDomains={representativeDomains}
       />
     </div>
   );
@@ -67,7 +68,7 @@ export const getURLForMatches = createSelector(
         page_size: 200,
         extra_fields: 'short_name',
       },
-    })
+    }),
 );
 const getSecondaryStructureURL = createSelector(
   (state) => state.settings.api,
@@ -86,7 +87,7 @@ const getSecondaryStructureURL = createSelector(
         extra_fields: 'secondary_structures',
       },
     });
-  }
+  },
 );
 
 export default loadData<StructureWithSecondary, 'Secondary'>({
@@ -94,6 +95,6 @@ export default loadData<StructureWithSecondary, 'Secondary'>({
   getUrl: getSecondaryStructureURL,
 } as Params)(
   loadData<PayloadList<EndpointWithMatchesPayload<EntryMetadata>>>(
-    getURLForMatches
-  )(ProteinViewerForStructure)
+    getURLForMatches,
+  )(ProteinViewerForStructure),
 );


### PR DESCRIPTION
Adding the track for Representative domains in different sections of the website:

* Structures. Handling multiple chains, e.g. http://localhost:8000/interpro/structure/PDB/15c8/#table
* Alphafold. e.g. http://localhost:8000/interpro/protein/unreviewed/R7T3V2/alphafold/
* Isoforms. e.g. http://localhost:8000/interpro/protein/UniProt/P90897/?isoform=P90897-3

Note: There are a few minor style changes in some of the docs because I activated the settings we had for JS files for TS ones.