### PR TITLE
Granular counters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
         "postcss-loader": "7.3.4",
         "postcss-preset-env": "9.3.0",
         "prettier": "3.1.1",
+        "puppeteer": "22.0.0",
         "raw-loader": "4.0.2",
         "react-test-renderer": "18.2.0",
         "rimraf": "5.0.5",
@@ -33085,6 +33086,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/puppeteer": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.0.0.tgz",
+      "integrity": "sha512-zYVnjwJngnSB4dbkWp7DHFSIc3nqHvZzrdHyo9+ugV1nq1Lm8obOMcmCFaGfR3PJs0EmYNz+/skBeO45yvASCQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@puppeteer/browsers": "2.0.0",
+        "cosmiconfig": "9.0.0",
+        "puppeteer-core": "22.0.0"
+      },
+      "bin": {
+        "puppeteer": "lib/esm/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/puppeteer-core": {
       "version": "21.7.0",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.7.0.tgz",
@@ -33116,6 +33135,255 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
       "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==",
       "dev": true
+    },
+    "node_modules/puppeteer/node_modules/@puppeteer/browsers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.0.0.tgz",
+      "integrity": "sha512-3PS82/5+tnpEaUWonjAFFvlf35QHF15xqyGd34GBa5oP5EPVfFXRsbSxIGYf1M+vZlqBZ3oxT1kRg9OYhtt8ng==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/puppeteer/node_modules/chromium-bidi": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/puppeteer/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/puppeteer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/puppeteer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer/node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer/node_modules/puppeteer-core": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.0.0.tgz",
+      "integrity": "sha512-S3s91rLde0A86PWVeNY82h+P0fdS7CTiNWAicCVH/bIspRP4nS2PnO5j+VTFqCah0ZJizGzpVPAmxVYbLxTc9w==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "2.0.0",
+        "chromium-bidi": "0.5.8",
+        "cross-fetch": "4.0.0",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer/node_modules/tar-fs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      }
+    },
+    "node_modules/puppeteer/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/puppeteer/node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/puppeteer/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/puppeteer/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/puppeteer/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/pure-rand": {
       "version": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "postcss-loader": "7.3.4",
     "postcss-preset-env": "9.3.0",
     "prettier": "3.1.1",
+    "puppeteer": "22.0.0",
     "raw-loader": "4.0.2",
     "react-test-renderer": "18.2.0",
     "rimraf": "5.0.5",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,3 +8,34 @@ This directory contains the scripts run by npm when the appropriate argument is 
 4. `serve.js` Starts the server
 5. `test-init.js` Starts the functional tests
 
+### Browse with puppeteer
+
+Here we go again. I know we have done this before and dropped it because of the instability of it. But here is another attempt to get through all the filter combinations in the browse area in order to trigger all API requests and be able to have a list of essential URLs to use for the cache warmer, that is not based on the previous version of the cache. This is useful in case the filters change and there are new essential URLs.
+
+#### Usage
+
+Have an API running locally in debug mode.This among other things logs all the requests in a file located in ` ../requests.log` if you are i.n the directory of your API.I would recommend having the cache running and active because this script requires patience, and needs to be re-run multiple times. So running the cache will save you some time.
+
+The top of the file has some constants that you might want to play with, and once you happy with that just run:
+
+```
+node scripts/browse-with-puppetteer.js
+```
+
+My suggestion is to run by parts, by changing the value of the constant `SHOULD_RUN` at the top of the file. For instance just the Browse - By InterPro, and if it fails restart it multiple times until it finishes, it doesn't matter if a page is loaded again generating duplicates of the API request. at the end we can clean the API log file.
+
+The protein endpoint is the one with more filters, so more combinations to go through. Maybe in that one, you might want to split the run more, maybe just running a couple of DBs at the time. The easiest will be to comment out some DBs from the array at the top of the file.
+
+Once you complete it, and have a mandatory celebratory drink, you can run:
+
+```
+sort ../requests.log | uniq > your_file_of_esential_api_url.log
+```
+
+and then use it in the cache warming!
+
+##### Known Issues
+
+- Because of the way the sticky header of the website is implemented. there are ocassions where puppeteer scrolls into a component but endup under the header, and mistakingly clicks on the interpro logo, sending the page to Home. I have added some Scroll to top to cater for that, but if you notice happening, you could, press the back button in the browser and scroll the page to make the filter visible. If done quickly enough, this canjust let the script resume where it was.
+
+- When the table has very few items and the filter bar is longer than the table, the footer of elixir might endup over the last filter and instead of clicking an option it ends up opening the elixir page. The script should keep going as the page is open in a different tab, but that particular filter combination was never clicked.

--- a/scripts/browse-with-puppetteer.js
+++ b/scripts/browse-with-puppetteer.js
@@ -52,6 +52,21 @@ function delay(milliseconds) {
 }
 
 (async () => {
+  if (process.argv.length > 2) {
+    const shouldRun = new Set();
+    for (const argv of process.argv.slice(2)) {
+      const key = argv.substring(2).toLowerCase();
+      if (SHOULD_RUN[key] !== undefined)
+        shouldRun.add(key);
+      else {
+        console.error(`Error: invalid argument: ${argv}`);
+        process.exit(1);
+      }
+    }
+    for (const key of Object.keys(SHOULD_RUN)) {
+      SHOULD_RUN[key] = shouldRun.has(key);
+    }
+  }
   const browser = await puppeteer.launch({ headless: false });
   const page = await browser.newPage();
   page.setDefaultTimeout(TIMEOUT);

--- a/scripts/browse-with-puppetteer.js
+++ b/scripts/browse-with-puppetteer.js
@@ -1,0 +1,471 @@
+/**
+ * The idea of this script is to automatically go through all the filters
+ * in the browse area of the website. This in combination with a local API
+ * in debug mode, will capture all the API requests needed to be cached.
+ *
+ * The file can then be used in the cahche warming procedures instead of
+ * one generated from the previous release.
+ */
+
+const puppeteer = require('puppeteer'); // v20.7.4 or later
+
+const DELAY_ON_EACH_PAGE = 1000;
+const NUMBER_OF_RETRIES = 3;
+const TIMEOUT = 30000;
+
+const SHOULD_RUN = {
+  interpro: false,
+  dbs: false,
+  protein: true,
+  structure: false,
+  taxonomy: false,
+  proteome: false,
+  set: false,
+};
+
+const DBS = [
+  'all',
+  'interpro',
+  'antifam',
+  'cathgene3d',
+  'cdd',
+  'hamap',
+  'ncbifam',
+  'panther',
+  'pfam',
+  'pirsf',
+  'prints',
+  'profile',
+  'prosite',
+  'sfld',
+  'smart',
+  'ssf',
+];
+const MEMBER_DBS = DBS.filter((db) => !['all', 'interpro'].includes(db));
+
+const DBS_WITH_SETS = ['all', 'cdd', 'pfam', 'pirsf'];
+
+function delay(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: false });
+  const page = await browser.newPage();
+  page.setDefaultTimeout(TIMEOUT);
+
+  const locatorRaceClickWithRetries = async (locators, timeout = TIMEOUT) => {
+    for (let i = 0; i < NUMBER_OF_RETRIES; i++) {
+      try {
+        return await puppeteer.Locator.race(locators)
+          .setTimeout(timeout)
+          .click();
+      } catch (e) {
+        console.log(`Attempt Failed - ${i + 1}/${NUMBER_OF_RETRIES}`);
+      }
+    }
+  };
+
+  const clickCookieBanner = async () => {
+    const targetPage = page;
+    console.log('cookie banner');
+    await delay(6000);
+    await locatorRaceClickWithRetries([
+      targetPage.locator('::-p-text(I agree, dismiss this banner)'),
+    ]);
+  };
+  const clickBrowse = async () => {
+    const targetPage = page;
+    console.log('Menu browse click');
+    await locatorRaceClickWithRetries([
+      targetPage.locator('::-p-aria(▾ Browse)'),
+      targetPage.locator("[data-testid='menu-tab-browse'] > div > a"),
+      targetPage.locator(
+        '::-p-xpath(//*[@data-testid=\\"menu-tab-browse\\"]/div/a)'
+      ),
+      targetPage.locator(
+        ":scope >>> [data-testid='menu-tab-browse'] > div > a"
+      ),
+      targetPage.locator('::-p-text(▾ Browse)'),
+    ]);
+  };
+  const clickBrowseOption = async (option) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(`::-p-aria(${option}[role=\\"link\\"])`),
+      targetPage.locator(`::-p-text(${option})`),
+    ]);
+  };
+
+  const clickTableView = async (view) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(`::-p-aria(view your results in a ${view})`),
+      targetPage.locator(`[data-testid='view-${view}-button']`),
+      targetPage.locator(
+        `::-p-xpath(//*[@data-testid=\\"view-${view}-button\\"])`
+      ),
+      targetPage.locator(`:scope >>> [data-testid='view-${view}-button']`),
+    ]);
+  };
+  const clickMemberDB = async (db) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(`[data-testid='memberdb-filter-${db}']`),
+      targetPage.locator(
+        `::-p-xpath(//*[@data-testid=\\"memberdb-filter-${db}\\"])`
+      ),
+      targetPage.locator(`:scope >>> [data-testid='memberdb-filter-${db}']`),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+  const scrollToTop = async () => {
+    await page.evaluate(() => {
+      window.scrollTo(0, 0);
+    });
+  };
+
+  {
+    const targetPage = page;
+    await targetPage.setViewport({
+      width: 1141,
+      height: 803,
+    });
+  }
+  {
+    const targetPage = page;
+    const promises = [];
+    const startWaitingForEvents = () => {
+      promises.push(targetPage.waitForNavigation());
+    };
+    startWaitingForEvents();
+    await targetPage.goto('http://localhost:8080/interpro/');
+    await Promise.all(promises);
+  }
+  {
+    const targetPage = page;
+    await targetPage.keyboard.up('Meta');
+  }
+  await clickCookieBanner();
+  /**
+   * Browse By InterPro
+   * */
+
+  const interProTypes = [
+    'family',
+    'domain',
+    'homologous superfamily',
+    'repeat',
+    'conserved site',
+    'active site',
+    'binding site',
+    'ptm',
+  ];
+  const clickInterProType = async (entryType) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(`interpro-type[type="${entryType}"] >>>> text`),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+
+  const goOptions = ['All', 'F', 'P', 'C'];
+  const clickGoOption = async (goOption) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(
+        `input[type=radio][name=go_category][value=${goOption}]`
+      ),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+
+  const interproTableViews = ['table', 'grid'];
+
+  if (SHOULD_RUN.interpro) {
+    console.log('Browse By InterPro');
+
+    for (const view of interproTableViews) {
+      await clickBrowse();
+      await clickBrowseOption('By InterPro');
+      await clickTableView(view);
+      console.log(` > View: ${view}`);
+
+      for (const entryType of interProTypes) {
+        console.log(` > > Entry type: ${entryType}`);
+        await clickInterProType(entryType);
+        for (const go of goOptions) {
+          console.log(` > > > GO optiom: ${go}`);
+          await clickGoOption(go);
+        }
+      }
+    }
+  }
+
+  /**
+   * Browse By Member DB
+   * */
+  const memberDBTableViews = ['table', 'grid'];
+
+  const interproState = ['both', 'integrated', 'unintegrated'];
+  const clickInterproState = async (state) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(
+        `input[type=radio][name=interpro_state][value=${state}]`
+      ),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+
+  if (SHOULD_RUN.dbs) {
+    console.log('\n\nBrowse By Member DB');
+    for (const view of memberDBTableViews) {
+      await clickBrowse();
+      await clickBrowseOption('By Member DB');
+      await clickTableView(view);
+      console.log(` > View: ${view}`);
+      for (const db of MEMBER_DBS) {
+        await clickMemberDB(db);
+        console.log(` > > Member DB: ${db}`);
+        for (const state of interproState) {
+          console.log(` > > > InterPro State: ${state}`);
+          await clickInterproState(state);
+          // Entry type list is variable so needs to bre treated differently
+          await delay(DELAY_ON_EACH_PAGE * 2);
+          await scrollToTop();
+          const entryTypesInputs = await page.$$(
+            'div[data-testid="filterby-member_database_entry_type"] label input'
+          );
+          for (const input of entryTypesInputs) {
+            const value = await page.evaluate(
+              (el) => el.getAttribute('value'),
+              input
+            );
+            console.log(` > > > > Entry type: ${value}`);
+            input.click();
+            await delay(DELAY_ON_EACH_PAGE);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Browse By Protein
+   * */
+  const matchPresence = ['both', 'true', 'false'];
+  const clickMatchPresence = async (value) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(
+        `input[type=radio][name=match_presence_filter][value=${value}]`
+      ),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+  const curationStatus = ['uniprot', 'reviewed', 'unreviewed'];
+  const clickCurationStatus = async (status) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(
+        `input[type=radio][name=curated_filter][value=${status}]`
+      ),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+
+  const sequenceStatus = ['both', 'false', 'true'];
+  const clickSequenceStatus = async (status) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(
+        `input[type=radio][name=fragment_filter][value=${status}]`
+      ),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+
+  if (SHOULD_RUN.protein) {
+    console.log('\n\nBrowse By Protein');
+    const proteinTableViews = ['table', 'grid'];
+
+    for (const view of proteinTableViews) {
+      await clickBrowse();
+      await clickBrowseOption('By Protein');
+      await clickTableView(view);
+      console.log(` > View: ${view}`);
+      await delay(DELAY_ON_EACH_PAGE);
+      for (const db of DBS) {
+        console.log(` > > Member DB: ${db}`);
+        await clickMemberDB(db);
+
+        for (const presence of db === 'all' ? matchPresence : [false]) {
+          if (presence) {
+            console.log(` > >> Match Presence: ${presence}`);
+            await clickMatchPresence(presence);
+          }
+          for (const status of curationStatus) {
+            console.log(` > > > Curation Status: ${status}`);
+            await clickCurationStatus(status);
+            for (const seqStatus of sequenceStatus) {
+              console.log(` > > > > Sequence Status: ${seqStatus}`);
+              await clickSequenceStatus(seqStatus);
+              // Organisms list is variable so needs to bre treated differently
+              await delay(DELAY_ON_EACH_PAGE * 3);
+              await scrollToTop();
+              const orgInputs = await page.$$('.list-taxonomy label input');
+              for (const orgInput of orgInputs) {
+                const value = await page.evaluate(
+                  (el) => el.getAttribute('value'),
+                  orgInput
+                );
+                console.log(` > > > > > Organism: ${value}`);
+                orgInput.click();
+                await delay(DELAY_ON_EACH_PAGE);
+              }
+              // Reset to all
+              orgInputs?.[0]?.click();
+              await delay(DELAY_ON_EACH_PAGE);
+            }
+            // Reset to both
+            await clickSequenceStatus('both');
+            await scrollToTop();
+            await delay(DELAY_ON_EACH_PAGE);
+          }
+          // Reset to Uniprot
+          await clickCurationStatus('uniprot');
+          await scrollToTop();
+          await delay(DELAY_ON_EACH_PAGE);
+        }
+      }
+    }
+  }
+
+  /**
+   * Browse By Structure
+   * */
+  const experimentTypes = ['All', 'x-ray', 'em', 'nmr'];
+  const clickExperimentType = async (value) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(
+        `input[type=radio][name=experiment_type][value=${value}]`
+      ),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+  const resolutions = ['-1', '0', '1', '2'];
+  const clickResolution = async (value) => {
+    const targetPage = page;
+    await locatorRaceClickWithRetries([
+      targetPage.locator(
+        `input[type=radio][name=resolution][value="${value}"]`
+      ),
+    ]);
+    await delay(DELAY_ON_EACH_PAGE);
+  };
+
+  if (SHOULD_RUN.structure) {
+    console.log('\n\nBrowse By Structure');
+    const proteinTableViews = ['table', 'grid'];
+
+    for (const view of proteinTableViews) {
+      await clickBrowse();
+      await clickBrowseOption('By Structure');
+      await clickTableView(view);
+      console.log(` > View: ${view}`);
+      await delay(DELAY_ON_EACH_PAGE);
+      for (const db of DBS
+        // Filters in antifam are disabled
+        .filter((db) => db !== 'antifam')) {
+        console.log(` > > Member DB: ${db}`);
+        await clickMemberDB(db);
+
+        for (const expType of experimentTypes) {
+          console.log(` > > > Exp Type: ${expType}`);
+          await clickExperimentType(expType);
+          if (expType !== 'nmr') {
+            for (const res of resolutions) {
+              console.log(` > > > > Resolution: ${res}`);
+              await clickResolution(res);
+            }
+            await clickResolution('-1');
+          }
+        }
+        await clickExperimentType('All');
+      }
+    }
+  }
+
+  /**
+   * Browse By Taxonomy
+   * */
+
+  if (SHOULD_RUN.taxonomy) {
+    console.log('\n\nBrowse By Taxonomy');
+    const taxTableViews = ['table', 'grid', 'tree'];
+
+    for (const view of taxTableViews) {
+      await clickBrowse();
+      await clickBrowseOption('By Taxonomy');
+      await clickTableView(view);
+      console.log(` > View: ${view}`);
+      await delay(DELAY_ON_EACH_PAGE);
+      for (const db of DBS) {
+        console.log(` > > Member DB: ${db}`);
+        await clickMemberDB(db);
+        await delay(DELAY_ON_EACH_PAGE);
+      }
+    }
+  }
+
+  /**
+   * Browse By Proteome
+   * */
+
+  if (SHOULD_RUN.proteome) {
+    console.log('\n\nBrowse By Proteome');
+    const proteomeTableViews = ['table', 'grid'];
+
+    for (const view of proteomeTableViews) {
+      await clickBrowse();
+      await clickBrowseOption('By Proteome');
+      await clickTableView(view);
+      console.log(` > View: ${view}`);
+      await delay(DELAY_ON_EACH_PAGE * 2);
+    }
+  }
+
+  /**
+   * Browse By Sets
+   * */
+
+  if (SHOULD_RUN.set) {
+    console.log('\n\nBrowse By Sets');
+    const proteomeTableViews = ['table', 'grid'];
+
+    for (const view of proteomeTableViews) {
+      await clickBrowse();
+      await clickBrowseOption('By Clan/Set');
+      await clickTableView(view);
+      console.log(` > View: ${view}`);
+      await delay(DELAY_ON_EACH_PAGE);
+      for (const db of DBS_WITH_SETS) {
+        console.log(` > > Member DB: ${db}`);
+        await clickMemberDB(db);
+        await delay(DELAY_ON_EACH_PAGE);
+      }
+    }
+  }
+
+  // wait a bit before closing to give time to any pending URL requests
+  await delay(DELAY_ON_EACH_PAGE * 10);
+
+  await browser.close();
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/Matches/FileExporter/index.tsx
+++ b/src/components/Matches/FileExporter/index.tsx
@@ -59,6 +59,13 @@ const FileExporter = ({
   if (focused && +focused !== 1 && customLocationDescription.taxonomy) {
     customLocationDescription.taxonomy.accession = focused;
   }
+  /*
+   * Not a mistake: the filtering/secondary endpoint in the client (subpage)
+   * becomes the main endpoint when exporting data.
+   * e.g. InterPro entry IPR000001 > Proteins
+   *   client: `/entry/interpro/IPR000001/protein/uniprot`
+   *   export: `/api/protein/uniprot/entry/interpro/IPR000001/`
+   */
   const counters = getNeededCountersForSubpages(secondary, primary, true);
   const extraFields = `${counters}${search.extra_fields || ''}` || undefined;
   const newSearch = { ...search };

--- a/src/components/Matches/FileExporter/index.tsx
+++ b/src/components/Matches/FileExporter/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import File from 'components/File';
 import { SupportedExtensions } from 'components/File/FileButton';
+import { getNeededCountersForSubpages } from 'higherOrder/loadData/defaults/relatedCounters';
 
 const endpoint: Partial<
   Record<Endpoint, Partial<Record<Endpoint, string | undefined>>>
@@ -58,6 +59,10 @@ const FileExporter = ({
   if (focused && +focused !== 1 && customLocationDescription.taxonomy) {
     customLocationDescription.taxonomy.accession = focused;
   }
+  const counters = getNeededCountersForSubpages(secondary, primary, true);
+  const extraFields = `${counters}${search.extra_fields || ''}` || undefined;
+  const newSearch = { ...search };
+  if (extraFields) newSearch.extra_fields = extraFields;
   return (
     <File
       className={className}
@@ -67,12 +72,7 @@ const FileExporter = ({
       }.${fileType}`}
       count={count}
       customLocationDescription={customLocationDescription}
-      search={{
-        ...search,
-        extra_fields: `counters${
-          search.extra_fields ? `,${search.extra_fields}` : ''
-        }`,
-      }}
+      search={newSearch}
       endpoint={(endpoint?.[primary]?.[secondary] as string) || primary}
       minWidth={minWidth}
       label={label}

--- a/src/higherOrder/loadData/defaults/relatedCounters.ts
+++ b/src/higherOrder/loadData/defaults/relatedCounters.ts
@@ -1,0 +1,21 @@
+export const getNeededCountersForSubpages = (
+  mainEndpoint: Endpoint,
+  filterEndpoint: Endpoint,
+  forExporter = false,
+) => {
+  const counters = [];
+  if (forExporter) {
+    if (['taxonomy', 'proteome', 'set'].includes(filterEndpoint)) {
+      counters.push('protein');
+      counters.push('entry');
+    }
+  } else {
+    if (['entry', 'taxonomy', 'set'].includes(mainEndpoint)) {
+      if (['taxonomy', 'proteome'].includes(filterEndpoint)) {
+        counters.push('protein');
+      }
+    }
+  }
+  if (counters.length) return `counters:${counters.join('-')}`;
+  return '';
+};

--- a/src/higherOrder/loadData/defaults/test.js
+++ b/src/higherOrder/loadData/defaults/test.js
@@ -182,7 +182,7 @@ describe('getUrlForApi', () => {
       );
       expect(url).toEqual(
         expect.stringMatching(
-          /[?&]extra_fields=description,literature,counters(&|$)/,
+          /[?&]extra_fields=description,literature,counters(:([a-z]+-?)+)?(&|$)/,
         ),
       );
       expect(url).toEqual(expect.stringMatching(/[?&]page_size=10(&|$)/));
@@ -208,7 +208,7 @@ describe('getUrlForApi', () => {
       );
       expect(url).toEqual(
         expect.stringMatching(
-          /[?&]extra_fields=description,literature,counters(&|$)/,
+          /[?&]extra_fields=description,literature,counters(:([a-z]+-?)+)?(&|$)/,
         ),
       );
       expect(url).toEqual(expect.stringMatching(/[?&]page=2(&|$)/));
@@ -273,7 +273,9 @@ describe('getUrlForApi', () => {
         ),
       );
       expect(url).toEqual(
-        expect.stringMatching(/[?&]extra_fields=counters(&|$)/),
+        expect.stringMatching(
+          /[?&]extra_fields=counters((:|%3A)([a-z]+-?)+)?(&|$)/,
+        ),
       );
       expect(url).toEqual(expect.stringMatching(/[?&]page_size=10(&|$)/));
       expect(url.match(/&/g).length).toBe(1);
@@ -293,7 +295,9 @@ describe('getUrlForApi', () => {
         ),
       );
       expect(url).toEqual(
-        expect.stringMatching(/[?&]extra_fields=lineage,counters(&|$)/),
+        expect.stringMatching(
+          /[?&]extra_fields=lineage,counters(:([a-z]+-?)+)?(&|$)/,
+        ),
       );
       expect(url).toEqual(expect.stringMatching(/[?&]page_size=10(&|$)/));
       expect(url.match(/&/g).length).toBe(1);
@@ -320,7 +324,9 @@ describe('getUrlForApi', () => {
         ),
       );
       expect(url).toEqual(
-        expect.stringMatching(/[?&]extra_fields=counters(&|$)/),
+        expect.stringMatching(
+          /[?&]extra_fields=counters((:|%3A)([a-z]+-?)+)?(&|$)/,
+        ),
       );
       expect(url).toEqual(expect.stringMatching(/[?&]page_size=10(&|$)/));
       expect(url.match(/&/g).length).toBe(1);
@@ -340,7 +346,9 @@ describe('getUrlForApi', () => {
         ),
       );
       expect(url).toEqual(
-        expect.stringMatching(/[?&]extra_fields=counters(&|$)/),
+        expect.stringMatching(
+          /[?&]extra_fields=counters((:|%3A)([a-z]+-?)+)?(&|$)/,
+        ),
       );
       expect(url).toEqual(expect.stringMatching(/[?&]page_size=10(&|$)/));
       expect(url.match(/&/g).length).toBe(1);

--- a/src/pages/Proteome/index.js
+++ b/src/pages/Proteome/index.js
@@ -121,7 +121,7 @@ const AllProteomesDownload = (
     name={`proteomes.${fileType}`}
     count={count}
     customLocationDescription={description}
-    search={{ ...search, extra_fields: 'counters' }}
+    search={{ ...search, extra_fields: 'counters:entry-protein' }}
     endpoint={'proteome'}
   />
 );

--- a/src/pages/Set/index.js
+++ b/src/pages/Set/index.js
@@ -74,7 +74,7 @@ const AllSetDownload = (
     name={`sets.${fileType}`}
     count={count}
     customLocationDescription={description}
-    search={{ ...search, extra_fields: 'counters' }}
+    search={{ ...search, extra_fields: 'counters:entry-protein' }}
     endpoint={'set'}
   />
 );

--- a/src/pages/Taxonomy/index.js
+++ b/src/pages/Taxonomy/index.js
@@ -143,7 +143,7 @@ const AllTaxDownload = (
       name={`taxon.${fileType}`}
       count={count}
       customLocationDescription={newDescription}
-      search={{ ...search, extra_fields: 'counters' }}
+      search={{ ...search, extra_fields: 'counters:entry-protein' }}
       endpoint={'taxonomy'}
     />
   );


### PR DESCRIPTION
On this PR I went through all the usages of `extra_fields=counters` and started using the new feature to specify particular counters to be included to reduce response times.

Additionally, there is a new script that uses `puppeteer` to visit all the combinations of filters in the browse area, and that way a local API can generate the `request.log` with all the recent URLs and we can use that to generate the next release cache.
This becomes necessary as many URLs to be cached have changed to the new granular counters format.

Also while checking this, please have a look at this [commit in the deployment scripts repo](https://github.com/ProteinsWebTeam/InterPro7-extra/commit/a057aed4090cd390c337f9961da9c20442a91dbe) which is a modification to the script that gets the URL from the live machines, to alternatively support a path as an argument and use a file instead.

