### PR TITLE
Update icon used for reviewed proteins

### DIFF
--- a/src/components/AlphaFold/ProteinTable/index.tsx
+++ b/src/components/AlphaFold/ProteinTable/index.tsx
@@ -75,10 +75,10 @@ const ProteinTable = ({
               {row.source_database === 'reviewed' ? (
                 <>
                   {'\u00A0' /* non-breakable space */}
-                  <Tooltip title="Reviewed by UniProt curators (Swiss-Prot)">
+                  <Tooltip title="Reviewed by UniProtKB curators">
                     <span
                       className={f('icon', 'icon-common')}
-                      data-icon="&#xf00c;"
+                      data-icon="&#xf2f0;"
                       aria-label="reviewed"
                     />
                   </Tooltip>
@@ -173,7 +173,7 @@ export const getUrl = (includeSearch: boolean) =>
     (
       { protocol, hostname, port, root }: ParsedURLServer,
       description,
-      search
+      search,
     ) => {
       if (description.main.key === 'entry') {
         const _description = {
@@ -204,7 +204,7 @@ export const getUrl = (includeSearch: boolean) =>
       // return {
       //   accession: description[description.main.key].accession,
       // };
-    }
+    },
   );
 
 export const mapStateToPropsForModels = createSelector(
@@ -213,7 +213,7 @@ export const mapStateToPropsForModels = createSelector(
   (description, search) => ({
     description,
     search,
-  })
+  }),
 );
 
 export default loadData({

--- a/src/components/Matches/index.tsx
+++ b/src/components/Matches/index.tsx
@@ -366,10 +366,10 @@ const Matches = ({
                 </Link>
               )}
               {primary === 'protein' && sourceDatabase === 'reviewed' ? (
-                <Tooltip title="Reviewed by UniProt curators (Swiss-Prot)">
+                <Tooltip title="Reviewed by UniProtKB curators">
                   <span
                     className={css('icon', 'icon-common')}
-                    data-icon="&#xf00c;"
+                    data-icon="&#xf2f0;"
                     aria-label="reviewed"
                   />
                 </Tooltip>
@@ -474,16 +474,10 @@ const Matches = ({
         }
         renderer={(db: string) =>
           db === 'reviewed' ? (
-            <Tooltip
-              title={
-                db === 'reviewed'
-                  ? `${db} by curators (Swiss-Prot)`
-                  : 'Not reviewed by curators (TrEMBL)'
-              }
-            >
+            <Tooltip title="Reviewed by UniProtKB curators">
               <span
                 className={css('icon', 'icon-common')}
-                data-icon="&#xf00c;"
+                data-icon="&#xf2f0;"
                 aria-label="reviewed"
               />
             </Tooltip>

--- a/src/components/Protein/Card/index.tsx
+++ b/src/components/Protein/Card/index.tsx
@@ -29,10 +29,10 @@ const ProteinCard = ({ data, search, entryDB }: Props) => {
       title={
         <>
           {data.metadata.source_database === 'reviewed' ? (
-            <Tooltip title="Reviewed by UniProt curators (Swiss-Prot)">
+            <Tooltip title="Reviewed by UniProtKB curators">
               <span
                 className={css('icon', 'icon-common')}
-                data-icon="&#xf00c;"
+                data-icon="&#xf2f0;"
                 aria-label="reviewed"
               />{' '}
             </Tooltip>

--- a/src/pages/Protein/index.js
+++ b/src/pages/Protein/index.js
@@ -274,10 +274,10 @@ class List extends PureComponent /*:: <ListProps> */ {
                   {row.source_database === 'reviewed' ? (
                     <>
                       {'\u00A0' /* non-breakable space */}
-                      <Tooltip title="Reviewed by UniProt curators (Swiss-Prot)">
+                      <Tooltip title="Reviewed by UniProtKB curators">
                         <span
                           className={f('icon', 'icon-common')}
-                          data-icon="&#xf00c;"
+                          data-icon="&#xf2f0;"
                           aria-label="reviewed"
                         />
                       </Tooltip>

--- a/src/subPages/SimilarProteins/Table/index.tsx
+++ b/src/subPages/SimilarProteins/Table/index.tsx
@@ -158,7 +158,7 @@ const SimilarProteinTable = ({
                 <Tooltip title="Reviewed by UniProtKB curators">
                   <span
                     className={css('icon', 'icon-common')}
-                    data-icon="&#xf00c;"
+                    data-icon="&#xf2f0;"
                     aria-label="reviewed"
                   />
                 </Tooltip>


### PR DESCRIPTION
Changing the icons we use next to the accession of reviewed UniProtKB entries and making the text in the tooltip more consistent.