### PR TITLE
LLM entries

### DIFF
--- a/src/components/Description/DescriptionFromIntegrated/index.tsx
+++ b/src/components/Description/DescriptionFromIntegrated/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createSelector } from 'reselect';
 import { format } from 'url';
 
@@ -59,6 +59,7 @@ type Props = {
   integrated: string | null;
   setIntegratedCitations?: (citations: string[]) => void;
   headerText?: string;
+  handleLLMParagraphs?: (hasLLM: boolean) => void;
 };
 
 interface IntegratedProps
@@ -69,12 +70,19 @@ const DescriptionFromIntegrated = ({
   integrated,
   data,
   setIntegratedCitations = (_: string[]) => null,
+  handleLLMParagraphs,
   headerText,
 }: IntegratedProps) => {
   const { loading, payload } = data || {};
+  const [hasLLM, setHasLLM] = useState(false);
   useEffect(() => {
     setIntegratedCitations(Object.keys(payload?.metadata?.literature || {}));
   }, [payload?.metadata?.literature]);
+  useEffect(() => {
+    const newHasLLM = hasLLMParagraphs(payload?.metadata.description || []);
+    setHasLLM(newHasLLM);
+    handleLLMParagraphs?.(newHasLLM);
+  }, [payload?.metadata.description]);
   if (!integrated) return null;
   if (loading) return <Loading />;
 
@@ -86,16 +94,12 @@ const DescriptionFromIntegrated = ({
       payload.metadata.literature,
       citations,
     );
-    const hasLLM = hasLLMParagraphs(payload.metadata.description || []);
 
     return (
       <>
         <h4>
           {headerText || 'Description'} <ImportedTag accession={integrated} />
         </h4>
-        {hasLLM ? (
-          <DescriptionLLM accession={payload.metadata.accession} />
-        ) : null}
         <Description
           textBlocks={payload.metadata.description}
           literature={included}

--- a/src/components/Description/DescriptionLLM/__snapshots__/test.js.snap
+++ b/src/components/Description/DescriptionLLM/__snapshots__/test.js.snap
@@ -5,7 +5,112 @@ exports[`<DescriptionLLM /> should render 1`] = `
   type="warning"
 >
   <div>
-    The description below includes sections that have been automatically generated using an AI language model. Please exercise discretion when interpreting the information provided.
+    <React.Fragment>
+      Some of the fields of this entry
+       
+      <React.Fragment>
+        (including sections of the 
+        <b>
+          description
+        </b>
+        )
+      </React.Fragment>
+       
+    </React.Fragment>
+    have been automatically generated using an AI language model. Please exercise discretion when interpreting the information provided.
+  </div>
+  <div
+    style={
+      {
+        "display": "flex",
+        "gap": "2em",
+        "paddingTop": "0.4em",
+      }
+    }
+  >
+    <Memo(Connect(Link))
+      href="https://interpro-documentation.readthedocs.io/en/latest/llm_descriptions.html"
+      target="_blank"
+    >
+      <span
+        className="small icon icon-common icon-book"
+      />
+       
+      Read more on description generation
+    </Memo(Connect(Link))>
+    <Memo(Connect(Link))
+      href="https://docs.google.com/forms/d/e/1FAIpQLSc9lPkgGOZBpnyLiHF87AbUYdAWyx_3YFTNNg4MGQEcqAK4jQ/viewform?usp=pp_url&entry.128814244=PTHR48251"
+      target="_blank"
+    >
+      <span
+        className="small icon icon-common icon-pencil-alt"
+      />
+       
+      Provide feedback
+    </Memo(Connect(Link))>
+  </div>
+</Callout>
+`;
+
+exports[`<DescriptionLLM /> should render 2`] = `
+<Callout
+  type="warning"
+>
+  <div>
+    <React.Fragment>
+      Some of the fields of this entry
+       
+       
+    </React.Fragment>
+    have been automatically generated using an AI language model. Please exercise discretion when interpreting the information provided.
+  </div>
+  <div
+    style={
+      {
+        "display": "flex",
+        "gap": "2em",
+        "paddingTop": "0.4em",
+      }
+    }
+  >
+    <Memo(Connect(Link))
+      href="https://interpro-documentation.readthedocs.io/en/latest/llm_descriptions.html"
+      target="_blank"
+    >
+      <span
+        className="small icon icon-common icon-book"
+      />
+       
+      Read more on description generation
+    </Memo(Connect(Link))>
+    <Memo(Connect(Link))
+      href="https://docs.google.com/forms/d/e/1FAIpQLSc9lPkgGOZBpnyLiHF87AbUYdAWyx_3YFTNNg4MGQEcqAK4jQ/viewform?usp=pp_url&entry.128814244=PTHR48251"
+      target="_blank"
+    >
+      <span
+        className="small icon icon-common icon-pencil-alt"
+      />
+       
+      Provide feedback
+    </Memo(Connect(Link))>
+  </div>
+</Callout>
+`;
+
+exports[`<DescriptionLLM /> should render 3`] = `
+<Callout
+  type="warning"
+>
+  <div>
+    <React.Fragment>
+      The 
+      <b>
+        description
+      </b>
+       below includes sections that
+       
+    </React.Fragment>
+    have been automatically generated using an AI language model. Please exercise discretion when interpreting the information provided.
   </div>
   <div
     style={

--- a/src/components/Description/DescriptionLLM/index.tsx
+++ b/src/components/Description/DescriptionLLM/index.tsx
@@ -13,17 +13,37 @@ const css = cssBinder(globalStyles, localStyles, fonts);
 
 type Props = {
   accession: string;
+  hasLLMParagraphs: boolean;
+  hasLLMMetadata: boolean;
 };
 
-const DescriptionLLM = ({ accession }: Props) => {
+const DescriptionLLM = ({
+  accession,
+  hasLLMParagraphs,
+  hasLLMMetadata,
+}: Props) => {
   if ((accession || '').length === 0) return null;
 
   return (
     <Callout type="warning">
       <div>
-        The description below includes sections that have been automatically
-        generated using an AI language model. Please exercise discretion when
-        interpreting the information provided.
+        {hasLLMMetadata && (
+          <>
+            Some of the fields of this entry{' '}
+            {hasLLMParagraphs && (
+              <>
+                (including sections of the <b>description</b>)
+              </>
+            )}{' '}
+          </>
+        )}
+        {hasLLMParagraphs && !hasLLMMetadata && (
+          <>
+            The <b>description</b> below includes sections that{' '}
+          </>
+        )}
+        have been automatically generated using an AI language model. Please
+        exercise discretion when interpreting the information provided.
       </div>
       <div
         style={{

--- a/src/components/Description/DescriptionLLM/test.js
+++ b/src/components/Description/DescriptionLLM/test.js
@@ -8,7 +8,29 @@ const accession = 'PTHR48251';
 
 describe('<DescriptionLLM />', () => {
   test('should render', () => {
-    renderer.render(<DescriptionLLM accession={accession} />);
+    renderer.render(
+      <DescriptionLLM
+        accession={accession}
+        hasLLMParagraphs={true}
+        hasLLMMetadata={true}
+      />,
+    );
+    expect(renderer.getRenderOutput()).toMatchSnapshot();
+    renderer.render(
+      <DescriptionLLM
+        accession={accession}
+        hasLLMParagraphs={false}
+        hasLLMMetadata={true}
+      />,
+    );
+    expect(renderer.getRenderOutput()).toMatchSnapshot();
+    renderer.render(
+      <DescriptionLLM
+        accession={accession}
+        hasLLMParagraphs={true}
+        hasLLMMetadata={false}
+      />,
+    );
     expect(renderer.getRenderOutput()).toMatchSnapshot();
   });
 });

--- a/src/components/Description/index.tsx
+++ b/src/components/Description/index.tsx
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 
 import { transformFormatted } from 'utils/text';
 
+import BadgeAI, { BadgeCurated } from 'components/Entry/BadgeAI';
 import Paragraph from './Paragraph';
 
 import cssBinder from 'styles/cssBinder';
@@ -72,18 +73,7 @@ class Description extends PureComponent<Props> {
                   key={`${i}_${j}`}
                 >
                   {showBadges &&
-                    (llm ? (
-                      <span className={css('vf-badge', 'vf-badge--tertiary')}>
-                        AI-generated
-                        <span className={css('details')}>
-                          {checked ? 'Reviewed' : 'Unreviewed'}
-                        </span>
-                      </span>
-                    ) : (
-                      <span className={css('vf-badge', 'vf-badge--tertiary')}>
-                        Expert-curated
-                      </span>
-                    ))}
+                    (llm ? <BadgeAI checked={checked} /> : <BadgeCurated />)}
                   <Paragraph
                     key={`${i}.${j}`}
                     p={text}

--- a/src/components/Description/style.css
+++ b/src/components/Description/style.css
@@ -34,20 +34,3 @@ a.text-high:focus {
 .description .content.llm:not(.checked) {
   border-left-color: #f0ad4e;
 }
-.vf-badge--tertiary {
-  background: #e8e8e8;
-  border-color: transparent;
-  border-radius: 0.3em;
-  color: rgba(0, 0, 0, 0.6);
-  font-size: 0.85em;
-  text-transform: none;
-  user-select: none;
-}
-.vf-badge--tertiary:hover,
-.vf-badge--tertiary:visited {
-  color: rgba(0, 0, 0, 0.6);
-}
-.vf-badge > .details {
-  margin-left: 1em;
-  opacity: 0.8;
-}

--- a/src/components/Entry/BadgeAI/index.tsx
+++ b/src/components/Entry/BadgeAI/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+type Props = {
+  checked: boolean;
+};
+import cssBinder from 'styles/cssBinder';
+
+import styles from './style.css';
+
+const css = cssBinder(styles);
+
+export const BadgeCurated = () => {
+  return (
+    <span className={css('vf-badge', 'vf-badge--tertiary')}>
+      Expert-curated
+    </span>
+  );
+};
+const BadgeAI = ({ checked }: Props) => {
+  return (
+    <span className={css('vf-badge', 'vf-badge--tertiary')}>
+      AI-generated
+      <span className={css('details')}>
+        {checked ? 'Reviewed' : 'Unreviewed'}
+      </span>
+    </span>
+  );
+};
+
+export default BadgeAI;

--- a/src/components/Entry/BadgeAI/style.css
+++ b/src/components/Entry/BadgeAI/style.css
@@ -1,0 +1,17 @@
+.vf-badge--tertiary {
+  background: #e8e8e8;
+  border-color: transparent;
+  border-radius: 0.3em;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.85em;
+  text-transform: none;
+  user-select: none;
+}
+.vf-badge--tertiary:hover,
+.vf-badge--tertiary:visited {
+  color: rgba(0, 0, 0, 0.6);
+}
+.vf-badge > .details {
+  margin-left: 1em;
+  opacity: 0.8;
+}

--- a/src/components/Entry/Summary/index.tsx
+++ b/src/components/Entry/Summary/index.tsx
@@ -24,6 +24,7 @@ import ipro from 'styles/interpro-vf.css';
 import summary from 'styles/summary.css';
 import local from './style.css';
 import InterProSubtitle from './InterProSubtitle';
+import BadgeAI from '../BadgeAI';
 
 const css = cssBinder(local, ipro, summary);
 
@@ -88,6 +89,7 @@ const SummaryEntry = ({
   loading,
 }: SummaryEntryProps) => {
   const [integratedCitations, setIntegratedCitations] = useState<string[]>([]);
+  const [hasIntegratedLLM, setHasIntegratedLLM] = useState(false);
   useEffect(() => {
     setIntegratedCitations([]);
   }, [metadata]);
@@ -109,13 +111,11 @@ const SummaryEntry = ({
     (a, b) => desc.indexOf(a[0]) - desc.indexOf(b[0]),
   );
 
-  const selectDescriptionComponent = () => {
+  const selectDescriptionComponent = (hasLLM: boolean) => {
     if ((metadata.description || []).length) {
-      const hasLLM = hasLLMParagraphs(metadata.description || []);
       return (
         <>
           <h4>{headerText || 'Description'}</h4>
-          {hasLLM ? <DescriptionLLM accession={metadata.accession} /> : null}
           <Description
             textBlocks={metadata.description}
             literature={included as Array<[string, Reference]>}
@@ -129,23 +129,36 @@ const SummaryEntry = ({
           integrated={metadata.integrated}
           setIntegratedCitations={setIntegratedCitations}
           headerText={headerText || 'Description'}
+          handleLLMParagraphs={setHasIntegratedLLM}
         />
       );
     }
     return null;
   };
-
+  const hasLLM = hasLLMParagraphs(metadata.description || []);
   return (
     <div className={css('vf-stack', 'vf-stack--400')}>
       <section className={css('vf-grid', 'summary-grid')}>
         <div className={css('vf-stack')}>
+          {metadata?.is_llm ? (
+            <BadgeAI checked={!!metadata?.is_reviewed_llm} />
+          ) : null}
           {metadata?.source_database?.toLowerCase() === 'interpro' ? (
             <InterProSubtitle metadata={metadata} />
           ) : (
             <MemberDBSubtitle metadata={metadata} dbInfo={dbInfo} />
           )}
+
+          {hasLLM || hasIntegratedLLM || metadata?.is_llm ? (
+            <DescriptionLLM
+              accession={metadata.accession}
+              hasLLMParagraphs={hasLLM || hasIntegratedLLM}
+              hasLLMMetadata={!!metadata?.is_llm}
+            />
+          ) : null}
+
           <section className={css('vf-stack')}>
-            {selectDescriptionComponent()}
+            {selectDescriptionComponent(hasLLM)}
           </section>
         </div>
         <div className={css('vf-stack')}>

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -324,6 +324,8 @@ interface EntryMetadata extends Metadata {
     name: string;
   };
   is_removed?: boolean;
+  is_llm?: boolean;
+  is_reviewed_llm?: boolean;
 }
 
 type SourceOrganism = {


### PR DESCRIPTION
This PR is a way to represent the LLM tagged entries.

Basically, I'm reusing the same styling as with LLM descriptions:
* The same type of badge is now displayed in the top of the summary of an entry tagged as LLM, including the `reviewed` or `unreviewed` part.
* I'm extending the Callout box, and changing the content depending if an LLM was used to generate the description, the entry details, or both.

To test this PR I deployed the `dev` API using the `dw-changes` branch: http://wp-np3-bc.ebi.ac.uk/interpro/api/

I also manually changed some of the panther entries in the DB to use them as test data:
* PTHR10000: Entry AND description AI generated unreviewed
* PTHR10003: Entry AI generated reviewed - Description imported from interpro but not LLM
* PTHR10005: Entry AI generated unreviewed - Description imported from interpro but not LLM
* PTHR10009: Description imported from interpro, which was in turn LLM-generated