### PR TITLE
Minor issues

### DIFF
--- a/patches/@nightingale-elements+nightingale-msa+4.5.0.patch
+++ b/patches/@nightingale-elements+nightingale-msa+4.5.0.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/@nightingale-elements/nightingale-msa/src/nightingale-msa.ts b/node_modules/@nightingale-elements/nightingale-msa/src/nightingale-msa.ts
+index a2fb149..3f9b144 100644
+--- a/node_modules/@nightingale-elements/nightingale-msa/src/nightingale-msa.ts
++++ b/node_modules/@nightingale-elements/nightingale-msa/src/nightingale-msa.ts
+@@ -14,6 +14,7 @@ import NightingaleElement, {
+ } from "@nightingale-elements/nightingale-new-core";
+ import object2style from "./utils/object2style";
+ import { Region, SequencesMSA } from "./types/types";
++import ConservationWorker from "./workers/conservation.worker.ts";
+ 
+ const DEAFULT_TILE_HEIGHT = 20;
+ const DEAFULT_COLOR_SCHEME = "clustal2";
+@@ -53,9 +54,7 @@ class NightingaleMSA extends withManager(
+   })
+   overlayConservtion?: boolean = false;
+ 
+-  worker = new Worker(
+-    new URL("./workers/conservation.worker.ts", import.meta.url)
+-  );
++  worker= new ConservationWorker();
+   
+   private sequenceViewer?: SequenceViewerComponent | null;
+   private labelPanel?: LabelsComponent | null;

--- a/src/components/DownloadForm/URLParameters/index.js
+++ b/src/components/DownloadForm/URLParameters/index.js
@@ -119,11 +119,12 @@ SelectedParameter.propTypes = {
 const URLParameters = ({ type, data, search, onChange }) => {
   const [toAdd, setToAdd] = useState(null);
   const [toRemove, setToRemove] = useState(null);
+  const payloadIsReady = data && !data.loading && data.ok && data.payload;
   useEffect(() => {
     if (toAdd) setToAdd(null);
   });
   useEffect(() => {
-    return () => onChange({ target: null });
+    return () => payloadIsReady && onChange({ target: null });
   }, [toRemove]);
   const selectedParameters = Object.keys(search || {});
   if (toAdd) {
@@ -137,7 +138,7 @@ const URLParameters = ({ type, data, search, onChange }) => {
       setToRemove(null);
     }
   }
-  if (data.loading || !data.ok || !data.payload) return null;
+  if (!payloadIsReady) return null;
   const parameters = Object.fromEntries(
     (data.payload.paths?.[`/${type}/{sourceDB}`]?.get?.parameters || [])
       .filter((p) => p.$ref)

--- a/src/components/File/FileButton/index.tsx
+++ b/src/components/File/FileButton/index.tsx
@@ -39,6 +39,7 @@ export type FileButtonProps = {
   handleClick: (event: Event) => void;
   shouldLinkToResults?: boolean;
   showIcon?: boolean;
+  search?: Record<string, string>;
 };
 
 const FileButton = ({
@@ -56,6 +57,7 @@ const FileButton = ({
   shouldLinkToResults = true,
   showIcon,
   minWidth,
+  search,
 }: FileButtonProps) => {
   const downloading = Number.isFinite(progress) && !successful;
   const failed = successful === false;
@@ -93,6 +95,7 @@ const FileButton = ({
           shouldLinkToResults={shouldLinkToResults}
           subpath={subpath}
           fileType={fileType}
+          search={search}
         />
       }
     >

--- a/src/components/File/TooltipContent/index.tsx
+++ b/src/components/File/TooltipContent/index.tsx
@@ -7,12 +7,19 @@ import local from './style.css';
 
 const css = cssBinder(local);
 
+const getSearchString = (search?: Record<string, string>): string => {
+  const entries = Object.entries(search || []);
+  if (entries.length === 0) return '';
+  return `?${entries.map(([k, v]) => `${k}=${v}`).join('&')}`;
+};
+
 type Props = {
   shouldLinkToResults: boolean;
   title: string;
   count: number;
   subpath?: string;
   fileType: string;
+  search?: Record<string, string>;
 };
 
 const TooltipContent = ({
@@ -21,6 +28,7 @@ const TooltipContent = ({
   count,
   subpath,
   fileType,
+  search,
 }: Props) => {
   return count === 0 ? (
     <div>
@@ -39,13 +47,13 @@ const TooltipContent = ({
                 main: { key: 'result' },
                 result: { type: 'download' },
               },
-              hash: `${subpath || ''}|${fileType}`,
+              hash: `${subpath || ''}${getSearchString(search)}|${fileType}`,
             }}
             className={css(
               'vf-button',
               'vf-button--tertiary',
               'vf-button--sm',
-              'in-popup'
+              'in-popup',
             )}
           >
             See more download options

--- a/src/components/Help/Documentation/index.js
+++ b/src/components/Help/Documentation/index.js
@@ -13,8 +13,6 @@ import ipro from 'styles/interpro-new.css';
 import ebiGlobalStyles from 'ebi-framework/css/ebi-global.css';
 import local from './style.css';
 
-import { InterProLogo } from 'components/Header/Title';
-
 const f = foundationPartial(ebiGlobalStyles, fonts, ipro, local);
 
 const SchemaOrgData = loadable({

--- a/src/components/ProteinViewer/style.css
+++ b/src/components/ProteinViewer/style.css
@@ -17,6 +17,7 @@
 }
 .track-component {
   width: var(--track-space, 80%);
+  max-height: 2rem;
   background: #fafafa;
   cursor: move;
 }

--- a/src/components/Related/Taxonomy/Sunburst/style.css
+++ b/src/components/Related/Taxonomy/Sunburst/style.css
@@ -3,9 +3,11 @@
   flex-wrap: wrap;
 
   & .panel-component {
-    flex-grow: 2;
+    flex-grow: 1;
+    width: 70%;
   }
   & .panel-legends {
+    flex-grow: 1;
     width: 30%;
     padding-left: 1em;
   }
@@ -38,6 +40,15 @@
     & input {
       margin-left: 0.7em;
       margin-right: 0.7em;
+      width: 100%;
+    }
+  }
+}
+
+/* small screen only*/
+@media screen and (max-width: 40em) {
+  .sunburst {
+    & .panel-component {
       width: 100%;
     }
   }

--- a/src/components/Set/ClanViewer/index.tsx
+++ b/src/components/Set/ClanViewer/index.tsx
@@ -141,15 +141,20 @@ class ClanViewer extends PureComponent<Props, State> {
       .filter((e) => (e as HTMLElement).nodeName === 'g')
       .filter((e) => (e as HTMLElement).classList.contains('node'))?.[0];
     if (g) {
-      this.props.goToCustomLocation({
-        description: {
-          main: { key: 'entry' },
-          entry: {
-            db: this.props.db,
-            accession: (g as HTMLElement).dataset.accession,
+      const accession = (g as HTMLElement).dataset.accession;
+      if ((event as MouseEvent).metaKey || (event as MouseEvent).altKey) {
+        window.open(`/entry/${this.props.db}/${accession}`, '_blank')?.focus();
+      } else {
+        this.props.goToCustomLocation({
+          description: {
+            main: { key: 'entry' },
+            entry: {
+              db: this.props.db,
+              accession,
+            },
           },
-        },
-      });
+        });
+      }
     }
   };
   _refreshLabels = () => {

--- a/src/components/Set/ClanViewer/index.tsx
+++ b/src/components/Set/ClanViewer/index.tsx
@@ -142,7 +142,7 @@ class ClanViewer extends PureComponent<Props, State> {
       .filter((e) => (e as HTMLElement).classList.contains('node'))?.[0];
     if (g) {
       const accession = (g as HTMLElement).dataset.accession;
-      if ((event as MouseEvent).metaKey || (event as MouseEvent).altKey) {
+      if ((event as MouseEvent).metaKey || (event as MouseEvent).ctrlKey) {
         window.open(`/entry/${this.props.db}/${accession}`, '_blank')?.focus();
       } else {
         this.props.goToCustomLocation({

--- a/src/components/Structure/Viewer/index.tsx
+++ b/src/components/Structure/Viewer/index.tsx
@@ -88,25 +88,25 @@ class StructureView extends PureComponent<Props> {
       ) {
         this.viewer.initViewer(
           this._structureViewerCanvas.current,
-          this._structureViewer.current
+          this._structureViewer.current,
         );
         if (ColorByResidueLddtTheme.colorThemeProvider)
           this.viewer.representation.structure.themes.colorThemeRegistry.add(
-            ColorByResidueLddtTheme.colorThemeProvider
+            ColorByResidueLddtTheme.colorThemeProvider,
           );
         if (ColorByResidueLddtTheme.labelProvider)
           this.viewer.managers.lociLabels.addProvider(
-            ColorByResidueLddtTheme.labelProvider
+            ColorByResidueLddtTheme.labelProvider,
           );
         this.viewer.customModelProperties.register(
           ColorByResidueLddtTheme.propertyProvider,
-          true
+          true,
         );
 
         this.viewer.customModelProperties.register(AfConfidenceProvider, true);
         // this.viewer.managers.lociLabels.addProvider(this.labelAfConfScore);
         this.viewer.representation.structure.themes.colorThemeRegistry.add(
-          AfConfidenceColorThemeProvider
+          AfConfidenceColorThemeProvider,
         );
       }
       // mouseover ?????
@@ -116,12 +116,12 @@ class StructureView extends PureComponent<Props> {
     if (this.props.url) {
       this.loadStructureInViewer(
         this.props.url,
-        this.props.ext || DEFAULT_EXTENSION
+        this.props.ext || DEFAULT_EXTENSION,
       );
     } else {
       this.loadStructureInViewer(
         `https://www.ebi.ac.uk/pdbe/static/entry/${this.name}_updated.cif`,
-        'mmcif'
+        'mmcif',
       );
     }
   }
@@ -132,12 +132,12 @@ class StructureView extends PureComponent<Props> {
       if (this.props.url) {
         this.loadStructureInViewer(
           this.props.url,
-          this.props.ext || DEFAULT_EXTENSION
+          this.props.ext || DEFAULT_EXTENSION,
         );
       } else {
         this.loadStructureInViewer(
           `https://www.ebi.ac.uk/pdbe/static/entry/${this.name}_updated.cif`,
-          'mmcif'
+          'mmcif',
         );
       }
     }
@@ -167,12 +167,12 @@ class StructureView extends PureComponent<Props> {
           await this.viewer.clear();
           const data = await this.viewer.builders.data.download(
             { url: url },
-            { state: { isGhost: false } }
+            { state: { isGhost: false } },
           );
           const trajectory =
             await this.viewer.builders.structure.parseTrajectory(
               data,
-              format as BuiltInTrajectoryFormat
+              format as BuiltInTrajectoryFormat,
             );
           const outcome = this.viewer.builders.structure.hierarchy.applyPreset(
             trajectory,
@@ -184,7 +184,7 @@ class StructureView extends PureComponent<Props> {
               },
               showUnitcell: false,
               representationPreset: 'auto',
-            }
+            },
           );
           if (outcome)
             outcome.then(() => {
@@ -232,7 +232,7 @@ class StructureView extends PureComponent<Props> {
             s.components,
             {
               color: UniformColorThemeProvider.name,
-            }
+            },
           );
         }
       })
@@ -251,7 +251,7 @@ class StructureView extends PureComponent<Props> {
                 PluginCommands.Canvas3D.SetSettings(this.viewer, {
                   settings: (props) => {
                     props.renderer.selectColor = Color(
-                      selection.color as number
+                      selection.color as number,
                     );
                     props.renderer.selectStrength = 0.8;
                     props.marking.enabled = false;
@@ -274,7 +274,7 @@ class StructureView extends PureComponent<Props> {
                   MS.set(...positions),
                   MS.ammp('auth_seq_id'),
                 ]),
-              })
+              }),
             );
           }
           return MS.struct.combinator.merge(atomGroups);
@@ -306,7 +306,7 @@ class StructureView extends PureComponent<Props> {
           s.components,
           {
             color: colouringTheme as typeof ChainIdColorThemeProvider.name,
-          }
+          },
         );
       }
     });

--- a/src/components/Structure/Viewer/style.css
+++ b/src/components/Structure/Viewer/style.css
@@ -9,10 +9,15 @@
       align-items: center;
       justify-content: center;
       height: 88%;
+      max-width: 80vw;
     }
 
     & .structure-label {
       height: 1em;
     }
   }
+}
+
+:global(.split-view) .structure-viewer-ref {
+  max-width: 50vw;
 }

--- a/src/components/ToggleSwitch/index.tsx
+++ b/src/components/ToggleSwitch/index.tsx
@@ -19,6 +19,7 @@ type Props = {
   offValue?: string;
   handleChange?: (evt?: React.ChangeEvent) => void;
   addAccessionStyle?: boolean;
+  width?: string;
 };
 
 const ToggleSwitch = ({
@@ -33,6 +34,7 @@ const ToggleSwitch = ({
   offValue = 'Off',
   handleChange,
   addAccessionStyle = false,
+  width,
 }: Props) => {
   const [isOn, setIsOn] = useState(switchCond);
   useEffect(() => {
@@ -45,6 +47,7 @@ const ToggleSwitch = ({
       setIsOn(!isOn);
     }
   };
+  const paddleStyle = width ? { width } : {};
   return (
     <div className={css('new-switch', size)}>
       <label htmlFor={id}>
@@ -64,6 +67,7 @@ const ToggleSwitch = ({
             addAccessionStyle ? 'accession-selector' : '',
             disabled ? 'disabled' : '',
           )}
+          style={{ ...paddleStyle }}
           htmlFor={id}
         >
           {SRLabel ? (

--- a/src/components/ToggleSwitch/style.css
+++ b/src/components/ToggleSwitch/style.css
@@ -1,5 +1,8 @@
 .new-switch {
-  height: 2rem;
+  --paddle-side: 1.5rem;
+  --gap: 0.25rem;
+  --height: calc(var(--paddle-side) + var(--gap) + var(--gap));
+  height: var(--height);
   position: relative;
   margin-bottom: 1rem;
   outline: 0;
@@ -26,7 +29,7 @@
   position: relative;
   display: block;
   width: 4rem;
-  height: 2rem;
+  height: var(--height);
   border-radius: 0;
   background: #777;
   transition: all 0.25s ease-out;
@@ -42,11 +45,11 @@ input + .switch-paddle {
 
 .switch-paddle::after {
   position: absolute;
-  top: 0.25rem;
-  left: 0.25rem;
+  top: var(--gap);
+  left: var(--gap);
   display: block;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: var(--paddle-side);
+  height: var(--paddle-side);
   transform: translate3d(0, 0, 0);
   border-radius: 0;
   background: #fefefe;
@@ -58,7 +61,7 @@ input:checked ~ .switch-paddle {
 }
 
 input:checked ~ .switch-paddle::after {
-  left: 2.25rem;
+  left: calc(100% - var(--paddle-side) - var(--gap));
 }
 input:disabled ~ .switch-paddle {
   cursor: not-allowed;
@@ -92,57 +95,27 @@ input:checked + label > .switch-inactive {
 }
 
 .new-switch.tiny {
-  height: 1.5rem;
+  --paddle-side: 1rem;
 }
 .new-switch.tiny .switch-paddle {
   width: 3rem;
-  height: 1.5rem;
   font-size: 0.625rem;
-}
-.new-switch.tiny .switch-paddle::after {
-  top: 0.25rem;
-  left: 0.25rem;
-  width: 1rem;
-  height: 1rem;
-}
-.new-switch.tiny input:checked ~ .switch-paddle::after {
-  left: 1.75rem;
 }
 
 .new-switch.small {
-  height: 1.75rem;
+  --paddle-side: 1.25rem;
 }
 .new-switch.small .switch-paddle {
   width: 3.5rem;
-  height: 1.75rem;
   font-size: 0.75rem;
-}
-.new-switch.small .switch-paddle::after {
-  top: 0.25rem;
-  left: 0.25rem;
-  width: 1.25rem;
-  height: 1.25rem;
-}
-.new-switch.small input:checked ~ .switch-paddle::after {
-  left: 2rem;
 }
 
 .new-switch.large {
-  height: 2.5rem;
+  --paddle-side: 1.5rem;
 }
 .new-switch.large .switch-paddle {
   width: 5rem;
-  height: 2.5rem;
   font-size: 1rem;
-}
-.new-switch.large .switch-paddle::after {
-  top: 0.25rem;
-  left: 0.25rem;
-  width: 2rem;
-  height: 2rem;
-}
-.new-switch.large input:checked ~ .switch-paddle::after {
-  left: 2.75rem;
 }
 
 .disabled {
@@ -154,8 +127,4 @@ input:checked + label > .switch-inactive {
   & span.switch-inactive {
     right: 1em;
   }
-}
-
-.new-switch input:checked ~ label.switch-paddle.accession-selector::after {
-  left: 5.75rem;
 }

--- a/src/subPages/SimilarProteins/index.tsx
+++ b/src/subPages/SimilarProteins/index.tsx
@@ -54,6 +54,7 @@ const SimilarProteins = ({
               )
             }
             addAccessionStyle={true}
+            width="14rem"
           />
         </Tooltip>
       </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -161,6 +161,7 @@ const getConfigFor = (env, mode) => {
     mode,
     output: {
       publicPath,
+      // workerPublicPath: `${publicPath}js/workers/`,
       filename: path.join('js', `[id].${name}.[name].[fullhash:3].js`),
       chunkFilename: path.join('js', `[id].${name}.[name].[chunkhash:3].js`),
       globalObject: 'self',
@@ -201,7 +202,7 @@ const getConfigFor = (env, mode) => {
     module: {
       rules: [
         {
-          test: /\.worker\.js$/i,
+          test: /\.worker\.[jt]s$/i,
           use: [
             {
               loader: 'worker-loader',


### PR DESCRIPTION
A collection of small fixes reported on GH issues:

* FIX #580: There is a bug in nightingale where the `height` parameter of the interpro track is not doing anything. It has been reported, but on the interpro website we will avoid this issue by setting a `max-height` in the container div.
* FIX #575: Now it detects if the command or alt button are pressed while clicking on a Pfam entry on the clan visualization, and if so, opens the link in a new tab.
* FIX #564: The problem comes down to NIghtingale using a different syntax for web workers, as it is using rollup and not webpack to bundle the components. Webpack5 is supposed to support the same syntax, so I tried to move into that, but I didn't manage, and after many hours trying different setups, I gave up and changed the nightingale component using `patch-package`.
* FIX #576: Somehow the Mol* viewer is too greedy and in some cases, it was using more than 50% of the split view. I'm forcing it to stay in place via CSS `max-width: 50vw`.
* FIX #577: Gave both the sunburst and the labels the same wight in `flex-grow`; set a fix width for both (`70%` and `30%`), and change it to `100%` for small screens.
* FIX #578: Now `<ToggleSwitch>` has a prop `width` to make it wider when the labels are too long. Also played with CSS variables in the style to simplify the logic of the element size.
* FIX #482: The tooltip now receives the `search` object, which includes the modifiers, and includes it in the link to the Download Form. The Form was also updated to wait until it has received the OpenAPI payload, before refreshing the parameters.