### PR TITLE
Proteome page improvements

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -11,7 +11,9 @@ root:
   repeatsDB: https://repeatsdb.bio.unipd.it/api/search
   disprot: https://disprot.org/api/
   LLMFeedback: https://docs.google.com/forms/d/e/1FAIpQLSc9lPkgGOZBpnyLiHF87AbUYdAWyx_3YFTNNg4MGQEcqAK4jQ/viewform?usp=pp_url&entry.128814244=
-  
+  Rfam: https://www.ebi.ac.uk/ebisearch/ws/rest/rfam
+  UniProt: https://rest.uniprot.org/
+
 title: InterPro
 
 github:

--- a/src/components/Proteome/Summary/RfamLink/index.tsx
+++ b/src/components/Proteome/Summary/RfamLink/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { createSelector } from 'reselect';
+
+import loadData from 'higherOrder/loadData/ts';
+import { Params } from 'higherOrder/loadData/extract-params';
+
+import config from 'config';
+
+import BaseLink from 'components/ExtLink/BaseLink';
+
+type Props = {
+  accession: string;
+  className?: string;
+};
+interface LoadedProps extends Props, LoadDataProps<RfamPayload> {}
+
+const RFamLink = ({ data, accession, className }: LoadedProps) => {
+  if (!data) return null;
+  const { loading, payload } = data;
+  if (loading || !payload || payload.hitCount === 0) return null;
+
+  return (
+    <li>
+      <BaseLink
+        id={accession}
+        target={'_blank'}
+        pattern="https://rfam.org/genome/{id}"
+        className={className}
+      >
+        Rfam
+      </BaseLink>
+    </li>
+  );
+};
+
+const getRfamUrl = createSelector(
+  (_state: GlobalState, props: Props) => props.accession,
+  (accession) => {
+    if (!accession) return null;
+    return `${config.root.Rfam.href}?query=entry_type:Genome%20AND%20id:${accession}&format=json`;
+  },
+);
+
+export default loadData(getRfamUrl as Params)(RFamLink);

--- a/src/components/Proteome/Summary/UniProtDescription/index.tsx
+++ b/src/components/Proteome/Summary/UniProtDescription/index.tsx
@@ -22,7 +22,6 @@ const getProteomeUrl = createSelector(
   (state: GlobalState) => state.customLocation.description.proteome.accession,
   (accession) => {
     if (!accession) return null;
-    console.log(config.root);
     return `${config.root.UniProt.href}/proteomes/${accession}`;
   },
 );

--- a/src/components/Proteome/Summary/UniProtDescription/index.tsx
+++ b/src/components/Proteome/Summary/UniProtDescription/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { createSelector } from 'reselect';
+
+import loadData from 'higherOrder/loadData/ts';
+import { Params } from 'higherOrder/loadData/extract-params';
+
+import Loading from 'components/SimpleCommonComponents/Loading';
+
+import config from 'config';
+
+interface LoadedProps extends LoadDataProps<UniProtProteomesPayload> {}
+
+const UniProtDescription = ({ data }: LoadedProps) => {
+  if (!data) return null;
+  const { loading, payload } = data;
+  if (loading || !payload) return <Loading />;
+  return <div>{data.payload?.description}</div>;
+};
+
+const getProteomeUrl = createSelector(
+  (state: GlobalState) => state.customLocation.description.proteome.accession,
+  (accession) => {
+    if (!accession) return null;
+    console.log(config.root);
+    return `${config.root.UniProt.href}/proteomes/${accession}`;
+  },
+);
+export default loadData(getProteomeUrl as Params)(UniProtDescription);

--- a/src/components/Proteome/Summary/UniProtDescription/index.tsx
+++ b/src/components/Proteome/Summary/UniProtDescription/index.tsx
@@ -15,7 +15,12 @@ const UniProtDescription = ({ data }: LoadedProps) => {
   if (!data) return null;
   const { loading, payload } = data;
   if (loading || !payload) return <Loading />;
-  return <div>{data.payload?.description}</div>;
+  return data.payload?.description ? (
+    <>
+      <h4>Description</h4>
+      <p>{data.payload?.description}</p>
+    </>
+  ) : null;
 };
 
 const getProteomeUrl = createSelector(

--- a/src/components/Proteome/Summary/index.tsx
+++ b/src/components/Proteome/Summary/index.tsx
@@ -6,6 +6,7 @@ import ProteomeLink from 'components/ExtLink/ProteomeLink';
 import Loading from 'components/SimpleCommonComponents/Loading';
 
 import UniProtDescription from './UniProtDescription';
+import RFamLink from './RfamLink';
 
 import cssBinder from 'styles/cssBinder';
 
@@ -72,6 +73,7 @@ const SummaryProteome = ({ data, loading }: Props) => {
                   UniProt
                 </ProteomeLink>
               </li>
+              <RFamLink accession={metadata.accession} className={css('ext')} />
             </ul>
           </section>
         </div>

--- a/src/components/Proteome/Summary/index.tsx
+++ b/src/components/Proteome/Summary/index.tsx
@@ -5,6 +5,8 @@ import Species from 'components/Protein/Species';
 import ProteomeLink from 'components/ExtLink/ProteomeLink';
 import Loading from 'components/SimpleCommonComponents/Loading';
 
+import UniProtDescription from './UniProtDescription';
+
 import cssBinder from 'styles/cssBinder';
 
 import memberSelectorStyle from 'components/Table/TotalNb/style.css';
@@ -59,6 +61,7 @@ const SummaryProteome = ({ data, loading }: Props) => {
               </tr>
             </tbody>
           </table>
+          <UniProtDescription />
         </div>
         <div className={css('vf-stack')}>
           <section>

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -152,6 +152,8 @@ type SettingsState = {
   disprot: ParsedURLServer;
   wikipedia: ParsedURLServer;
   alphafold: ParsedURLServer;
+  uniprot: ParsedURLServer;
+  rfam: ParsedURLServer;
 };
 type UISettings = {
   lowGraphics: boolean;
@@ -539,6 +541,13 @@ type WikipediaPayload = {
     };
   };
 };
+
+type UniProtProteomesPayload = {
+  id: string;
+  description: string;
+  [key: string]: unknown;
+};
+
 type AlphafoldPayload = Array<{
   entryId: string;
   gene: string;

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -547,6 +547,11 @@ type UniProtProteomesPayload = {
   description: string;
   [key: string]: unknown;
 };
+type RfamPayload = {
+  hitCount: number;
+  entries: Array<unknown>;
+  [key: string]: unknown;
+};
 
 type AlphafoldPayload = Array<{
   entryId: string;


### PR DESCRIPTION
2 additions to the proteome page:
* An external link to Rfam: this one checks first the EBI search index of RFam to see if there is info there  for the given proteome
* A description directly fed from the UniProt API