### PR TITLE
Display short names

### DIFF
--- a/src/components/Matches/index.tsx
+++ b/src/components/Matches/index.tsx
@@ -384,6 +384,32 @@ const Matches = ({
         {focusType === 'taxonomy' ? 'Tax ID' : 'Accession'}
       </Column>
       <Column
+        dataKey="counters.extra_fields.short_name"
+        displayIf={primary === 'entry'}
+        renderer={(
+          name: string,
+          {
+            accession,
+            source_database: sourceDatabase,
+          }: { accession: string; source_database: string },
+        ) => (
+          <Link
+            to={
+              primary && {
+                description: {
+                  main: { key: primary },
+                  [primary]: { db: sourceDatabase, accession },
+                },
+              }
+            }
+          >
+            <HighlightedText text={name} textToHighlight={search?.search} />
+          </Link>
+        )}
+      >
+        Short Name
+      </Column>
+      <Column
         dataKey="name"
         renderer={(
           name: string,
@@ -412,32 +438,6 @@ const Matches = ({
           </>
         )}
       />
-      <Column
-        dataKey="counters.extra_fields.short_name"
-        displayIf={primary === 'entry' && secondary === 'set'}
-        renderer={(
-          name: string,
-          {
-            accession,
-            source_database: sourceDatabase,
-          }: { accession: string; source_database: string },
-        ) => (
-          <Link
-            to={
-              primary && {
-                description: {
-                  main: { key: primary },
-                  [primary]: { db: sourceDatabase, accession },
-                },
-              }
-            }
-          >
-            <HighlightedText text={name} textToHighlight={search?.search} />
-          </Link>
-        )}
-      >
-        Short Name
-      </Column>
       <Column
         dataKey="source_organism"
         displayIf={primary === 'protein'}

--- a/src/higherOrder/loadData/defaults/index.js
+++ b/src/higherOrder/loadData/defaults/index.js
@@ -101,6 +101,9 @@ export const getUrl = createSelector(
         }
         if (hash === 'table') {
           switch (description.main.key) {
+            case 'entry':
+              _search.extra_fields = 'short_name';
+              break;
             case 'taxonomy':
             case 'proteome':
               _search.extra_fields = 'counters:entry-protein';

--- a/src/higherOrder/loadData/defaults/index.js
+++ b/src/higherOrder/loadData/defaults/index.js
@@ -188,7 +188,7 @@ export const getReversedUrl = createSelector(
       extra_fields: undefined,
       page_size: search.page_size || settingsPageSize,
     };
-    if (description.main.key === 'set' && description?.entry?.isFilter) {
+    if (newMain === 'entry') {
       newQuery.extra_fields = 'short_name';
     }
     const counters = getNeededCountersForSubpages(

--- a/src/higherOrder/loadData/defaults/test.js
+++ b/src/higherOrder/loadData/defaults/test.js
@@ -159,7 +159,7 @@ describe('getUrlForApi', () => {
       };
 
       expect(getUrlForApi(state)).toBe(
-        'https://www.example.com:443/basename/entry/InterPro/?page_size=50',
+        'https://www.example.com:443/basename/entry/InterPro/?page_size=50&extra_fields=short_name',
       );
     });
 

--- a/src/pages/Entry/index.js
+++ b/src/pages/Entry/index.js
@@ -314,6 +314,33 @@ class List extends PureComponent /*:: <Props> */ {
             </Column>
 
             <Column
+              dataKey="counters.extra_fields.short_name"
+              renderer={(_, meta, extra) =>
+                extra.short_name ? (
+                  <Link
+                    to={(customLocation) => ({
+                      description: {
+                        ...customLocation.description,
+                        entry: {
+                          ...customLocation.description.entry,
+                          accession: meta.accession,
+                        },
+                      },
+                      search: {},
+                    })}
+                  >
+                    <HighlightedText
+                      text={extra.short_name}
+                      textToHighlight={search.search}
+                    />
+                  </Link>
+                ) : null
+              }
+            >
+              Short name
+            </Column>
+
+            <Column
               dataKey="name"
               renderer={(
                 name /*: string */,


### PR DESCRIPTION
Add a column showing the short name of the entry/signature, e.g.

* InterPro entries: `/interpro/entry/InterPro/#table`
* Pfam signatures: `/interpro/entry/pfam/#table`
* NCBIfam signatures matching `A0A000`: `/interpro/protein/UniProt/A0A000/entry/ncbifam/#table`
* PIRSF signatures found in the _Hibiscus syriacus_ proteome: `/interpro/proteome/uniprot/UP000436088/entry/pirsf/#table`