### PR TITLE
Links to Foldseek

### DIFF
--- a/scripts/browse-with-puppetteer.js
+++ b/scripts/browse-with-puppetteer.js
@@ -62,14 +62,14 @@ function delay(milliseconds) {
       const key = argv.substring(2).toLowerCase();
       if (SHOULD_RUN[key] === undefined) {
         console.error(`Error: invalid argument: [${argv}]`);
-        console.error(`List of valid arguments:`);
-        console.error(`  --interpro`);
-        console.error(`  --dbs`);
-        console.error(`  --protein`);
-        console.error(`  --structure`);
-        console.error(`  --taxonomy`);
-        console.error(`  --proteome`);
-        console.error(`  --set`);
+        console.error('List of valid arguments:');
+        console.error('  --interpro');
+        console.error('  --dbs');
+        console.error('  --protein');
+        console.error('  --structure');
+        console.error('  --taxonomy');
+        console.error('  --proteome');
+        console.error('  --set');
         process.exit(1);
       } else {
         shouldRun.add(key);

--- a/src/components/AlphaFold/Model/index.tsx
+++ b/src/components/AlphaFold/Model/index.tsx
@@ -164,6 +164,15 @@ const AlphaFoldModel = ({
                   >
                     UniProtKB
                   </UniProtLink>
+                  <br />
+                  Find similar structures with{' '}
+                  <Link
+                    href={`https://search.foldseek.com/search?accession=${modelInfo.uniprotAccession}&source=AlphaFoldDB`}
+                    className={css('ext')}
+                    target="_blank"
+                  >
+                    Foldseek
+                  </Link>
                 </span>
               </li>
               <li>

--- a/src/components/Protein/Summary/index.tsx
+++ b/src/components/Protein/Summary/index.tsx
@@ -43,6 +43,7 @@ import fonts from 'EBI-Icon-fonts/fonts.css';
 import ipro from 'styles/interpro-vf.css';
 import local from './style.css';
 import summary from 'styles/summary.css';
+import BaseLink from 'components/ExtLink/BaseLink';
 
 const css = cssBinder(summary, fonts, ipro, local);
 
@@ -280,6 +281,30 @@ export const SummaryProtein = ({ data, loading, isoform }: Props) => {
                     UniProt
                   </UniProtLink>
                 </li>
+                {metadata.in_alphafold ? (
+                  <>
+                    <li>
+                      <BaseLink
+                        id={metadata.accession}
+                        target={'_blank'}
+                        pattern="https://alphafold.ebi.ac.uk/entry/{id}"
+                        className={css('ext')}
+                      >
+                        AlphaFold
+                      </BaseLink>
+                    </li>
+                    <li>
+                      <BaseLink
+                        id={metadata.accession}
+                        target={'_blank'}
+                        pattern="https://search.foldseek.com/search?accession={id}&source=AlphaFoldDB"
+                        className={css('ext')}
+                      >
+                        Foldseek
+                      </BaseLink>
+                    </li>
+                  </>
+                ) : null}
               </ul>
             </section>
             <hr style={{ margin: '0.8em' }} />

--- a/src/components/Structure/Summary/__snapshots__/test.js.snap
+++ b/src/components/Structure/Summary/__snapshots__/test.js.snap
@@ -170,6 +170,16 @@ exports[`<SummaryStructure /> should render 1`] = `
               Proteopedia
             </BaseLink>
           </li>
+          <li>
+            <BaseLink
+              className="ext"
+              id="102m"
+              pattern="https://search.foldseek.com/search?accession={id}&source=PDB"
+              target="_blank"
+            >
+              Foldseek
+            </BaseLink>
+          </li>
         </ul>
       </section>
     </div>

--- a/src/components/Structure/Summary/index.tsx
+++ b/src/components/Structure/Summary/index.tsx
@@ -43,6 +43,10 @@ const EXTERNAL_LINKS = [
     pattern: 'https://proteopedia.org/wiki/index.php/{id}',
     label: 'Proteopedia',
   },
+  {
+    pattern: 'https://search.foldseek.com/search?accession={id}&source=PDB',
+    label: 'Foldseek',
+  },
 ];
 
 interface LoadedProps
@@ -180,7 +184,7 @@ export const getURLForMatches = createSelector(
         page_size: 200,
         extra_fields: 'short_name',
       },
-    })
+    }),
 );
 
 export default loadData({

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -365,6 +365,7 @@ interface ProteinMetadata extends Metadata {
   gene: string;
   protein_evidence: number;
   is_fragment: boolean;
+  in_alphafold: boolean;
   ida_accession: string;
   source_organism: SourceOrganism;
 }


### PR DESCRIPTION
Add links to Foldseek so users can perform protein structure searches. Links are added on the summary pages of PDBe structures (e.g. `/interpro/structure/PDB/10gs/`) and protein pages (if an AlphaFold prediction is available, e.g. `/interpro/protein/unreviewed/A0A009GN48/`).