### PR TITLE
Using llm_updated flag

### DIFF
--- a/src/components/Description/index.tsx
+++ b/src/components/Description/index.tsx
@@ -54,6 +54,7 @@ class Description extends PureComponent<Props> {
           text,
           llm: typeof e === 'string' ? false : e.llm,
           checked: typeof e === 'string' ? false : e.checked,
+          updated: typeof e === 'string' ? false : e.updated,
         }),
       );
     });
@@ -63,7 +64,7 @@ class Description extends PureComponent<Props> {
         {sections
           .map((section, i) =>
             section
-              .map(({ text, llm, checked }, j) => (
+              .map(({ text, llm, checked, updated }, j) => (
                 <div
                   className={css('content', {
                     llm,
@@ -73,7 +74,11 @@ class Description extends PureComponent<Props> {
                   key={`${i}_${j}`}
                 >
                   {showBadges &&
-                    (llm ? <BadgeAI checked={checked} /> : <BadgeCurated />)}
+                    (llm ? (
+                      <BadgeAI checked={checked} updated={updated} />
+                    ) : (
+                      <BadgeCurated />
+                    ))}
                   <Paragraph
                     key={`${i}.${j}`}
                     p={text}

--- a/src/components/Entry/BadgeAI/index.tsx
+++ b/src/components/Entry/BadgeAI/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 
 type Props = {
   checked: boolean;
+  updated: boolean;
 };
 import cssBinder from 'styles/cssBinder';
 
@@ -16,22 +18,39 @@ export const BadgeCurated = () => {
     </span>
   );
 };
-const BadgeAI = ({ checked }: Props) => {
+const BadgeAI = ({ checked, updated }: Props) => {
   return (
     <span className={css('vf-badge', 'vf-badge--tertiary')}>
       AI-generated
       <span className={css('details')}>
         {checked ? 'Reviewed' : 'Unreviewed'}
+        {checked && updated && ' and updated'}
       </span>
     </span>
   );
 };
-export const MiniBadgeAI = () => {
-  return (
+
+export const getTooltipContentFormMetadata = (metadata: EntryMetadata) => {
+  let badgeTooltip: string | undefined = undefined;
+  if (metadata.is_reviewed_llm) {
+    if (metadata.is_updated_llm) {
+      badgeTooltip = 'AI-generated reviewed and updated';
+    } else {
+      badgeTooltip = 'AI-generated reviewed';
+    }
+  } else {
+    badgeTooltip = 'AI-generated unreviewed';
+  }
+  return badgeTooltip;
+};
+
+export const MiniBadgeAI = ({ tooltipText }: { tooltipText?: string }) => {
+  const badge = (
     <sup>
       <span className={css('vf-badge', 'vf-badge--tertiary', 'mini')}>AI</span>
     </sup>
   );
+  return tooltipText ? <Tooltip title={tooltipText}>{badge}</Tooltip> : badge;
 };
 
 export default BadgeAI;

--- a/src/components/Entry/Summary/InterProSubtitle/index.tsx
+++ b/src/components/Entry/Summary/InterProSubtitle/index.tsx
@@ -7,7 +7,7 @@ import cssBinder from 'styles/cssBinder';
 
 import ipro from 'styles/interpro-vf.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
-import { MiniBadgeAI } from '../../BadgeAI';
+import { getTooltipContentFormMetadata, MiniBadgeAI } from '../../BadgeAI';
 
 const css = cssBinder(ipro, fonts);
 
@@ -44,7 +44,11 @@ const InterProSubtitle = ({
             <td>Short name</td>
             <td>
               <i className={css('shortname')}>{metadata.name.short}</i>{' '}
-              {hasLLM && <MiniBadgeAI />}
+              {hasLLM && (
+                <MiniBadgeAI
+                  tooltipText={getTooltipContentFormMetadata(metadata)}
+                />
+              )}
             </td>
           </tr>
         )}

--- a/src/components/Entry/Summary/MemberDBSubtitle/index.tsx
+++ b/src/components/Entry/Summary/MemberDBSubtitle/index.tsx
@@ -7,7 +7,7 @@ import cssBinder from 'styles/cssBinder';
 
 import ipro from 'styles/interpro-vf.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
-import { MiniBadgeAI } from '../../BadgeAI';
+import { getTooltipContentFormMetadata, MiniBadgeAI } from '../../BadgeAI';
 
 const css = cssBinder(ipro, fonts);
 
@@ -26,6 +26,7 @@ const MemberDBSubtitle = ({
   ) {
     return null;
   }
+
   return (
     <table className={css('vf-table', 'left-headers')}>
       <tbody>
@@ -68,7 +69,11 @@ const MemberDBSubtitle = ({
             <td>Short name</td>
             <td>
               <i className={css('shortname')}>{metadata.name.short}</i>{' '}
-              {hasLLM && <MiniBadgeAI />}
+              {hasLLM && (
+                <MiniBadgeAI
+                  tooltipText={getTooltipContentFormMetadata(metadata)}
+                />
+              )}
             </td>
           </tr>
         )}

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -18,7 +18,7 @@ import cssBinder from 'styles/cssBinder';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import ipro from 'styles/interpro-vf.css';
 import styles from './style.css';
-import { MiniBadgeAI } from '../Entry/BadgeAI';
+import { getTooltipContentFormMetadata, MiniBadgeAI } from '../Entry/BadgeAI';
 
 const css = cssBinder(fonts, ipro, styles);
 
@@ -145,7 +145,14 @@ export class Title extends PureComponent<LoadedProps> {
                 'margin-bottom-large': isIPScanResult,
               })}
             >
-              {longName} {(metadata as EntryMetadata).is_llm && <MiniBadgeAI />}
+              {longName}{' '}
+              {(metadata as EntryMetadata).is_llm && (
+                <MiniBadgeAI
+                  tooltipText={getTooltipContentFormMetadata(
+                    metadata as EntryMetadata,
+                  )}
+                />
+              )}
             </h3>
             {
               // Showing Favourites only for InterPro entries for now

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -280,6 +280,7 @@ type StructuredDescription = {
   text: string;
   llm: boolean;
   checked: boolean;
+  updated: boolean;
 };
 
 type MetadataCounter =
@@ -346,6 +347,7 @@ interface EntryMetadata extends Metadata {
   is_removed?: boolean;
   is_llm?: boolean;
   is_reviewed_llm?: boolean;
+  is_updated_llm?: boolean;
   in_alphafold?: boolean;
   entry_annotations?: Record<string, unknown>;
 }


### PR DESCRIPTION
Changes required given the inclusion of the `llm_updated`flag in the payload of entries:

* Badge in Description component can now be: `AI-generated| Reviewed and updated`
* MiniBadges in Title and Summary now have a tooltip with these possible content:
  * AI-generated unreviewed
  * AI-generated reviewed
  * AI-generated reviewed and updated