### PR TITLE
Multiple wikipedia pages

### DIFF
--- a/src/components/Entry/Summary/Wikipedia/index.tsx
+++ b/src/components/Entry/Summary/Wikipedia/index.tsx
@@ -80,16 +80,15 @@ const Wikipedia = ({ title, extract, thumbnail, data }: WikipediaProps) => {
     <div className={css('wiki-article')}>
       <div className={css('vf-grid', 'wiki-content')}>
         <div className={css('vf-grid__col--span-3', 'columns')}>
-          <h4>
+          <h5>
             <Link
               className={css('ext-link')}
               target="_blank"
               href={`https://en.wikipedia.org/wiki/${title}`}
             >
               {title.replace(/_/g, ' ')}
-            </Link>{' '}
-            <div className={css('tag')}>Wikipedia</div>
-          </h4>
+            </Link>
+          </h5>
           {convertHtmlToReact(extract)}
         </div>
         <div className={css('columns')}>

--- a/src/components/Entry/Summary/__snapshots__/test.js.snap
+++ b/src/components/Entry/Summary/__snapshots__/test.js.snap
@@ -165,8 +165,5 @@ exports[`<SummaryEntry /> should render 1`] = `
       }
     }
   />
-  <section>
-    <Tabs />
-  </section>
 </div>
 `;

--- a/src/components/Entry/Summary/__snapshots__/test.js.snap
+++ b/src/components/Entry/Summary/__snapshots__/test.js.snap
@@ -165,6 +165,8 @@ exports[`<SummaryEntry /> should render 1`] = `
       }
     }
   />
-  <section />
+  <section>
+    <Tabs />
+  </section>
 </div>
 `;

--- a/src/components/Entry/Summary/index.tsx
+++ b/src/components/Entry/Summary/index.tsx
@@ -171,13 +171,14 @@ const SummaryEntry = ({
         hasIntegratedCitations={integratedCitations?.length > 0}
       />
       <section>
-        {metadata.source_database === 'pfam' && metadata.wikipedia ? (
-          <Wikipedia
-            title={metadata.wikipedia.title}
-            extract={metadata.wikipedia.extract}
-            thumbnail={metadata.wikipedia.thumbnail}
-          />
-        ) : null}
+        {metadata.source_database === 'pfam' &&
+          (metadata.wikipedia || []).map((wiki) => (
+            <Wikipedia
+              title={wiki.title}
+              extract={wiki.extract}
+              thumbnail={wiki.thumbnail}
+            />
+          ))}
       </section>
     </div>
   );

--- a/src/components/Entry/Summary/index.tsx
+++ b/src/components/Entry/Summary/index.tsx
@@ -13,6 +13,7 @@ import Literature, {
 } from 'components/Entry/Literature';
 import CrossReferences from 'components/Entry/CrossReferences';
 import Loading from 'components/SimpleCommonComponents/Loading';
+import Tabs from 'components/Tabs';
 
 import MemberDBSubtitle from './MemberDBSubtitle';
 import SidePanel from './SidePanel';
@@ -171,14 +172,18 @@ const SummaryEntry = ({
         hasIntegratedCitations={integratedCitations?.length > 0}
       />
       <section>
-        {metadata.source_database === 'pfam' &&
-          (metadata.wikipedia || []).map((wiki) => (
-            <Wikipedia
-              title={wiki.title}
-              extract={wiki.extract}
-              thumbnail={wiki.thumbnail}
-            />
-          ))}
+        <Tabs>
+          {metadata.source_database === 'pfam' &&
+            (metadata.wikipedia || []).map((wiki, key) => (
+              <div key={key} title={wiki.title.replaceAll('_', ' ')}>
+                <Wikipedia
+                  title={wiki.title}
+                  extract={wiki.extract}
+                  thumbnail={wiki.thumbnail}
+                />
+              </div>
+            ))}
+        </Tabs>
       </section>
     </div>
   );

--- a/src/components/Entry/Summary/index.tsx
+++ b/src/components/Entry/Summary/index.tsx
@@ -175,6 +175,7 @@ const SummaryEntry = ({
       />
       {hasWiki && (
         <section>
+          <h4>Wikipedia</h4>        
           <Tabs>
             {(metadata.wikipedia || []).map((wiki, key) => (
               <div key={key} title={wiki.title.replaceAll('_', ' ')}>

--- a/src/components/Entry/Summary/index.tsx
+++ b/src/components/Entry/Summary/index.tsx
@@ -136,6 +136,8 @@ const SummaryEntry = ({
     return null;
   };
   const hasLLM = hasLLMParagraphs(metadata.description || []);
+  const hasWiki =
+    metadata.source_database === 'pfam' && !!metadata.wikipedia?.length;
   return (
     <div className={css('vf-stack', 'vf-stack--400')}>
       <section className={css('vf-grid', 'summary-grid')}>
@@ -171,10 +173,10 @@ const SummaryEntry = ({
         }
         hasIntegratedCitations={integratedCitations?.length > 0}
       />
-      <section>
-        <Tabs>
-          {metadata.source_database === 'pfam' &&
-            (metadata.wikipedia || []).map((wiki, key) => (
+      {hasWiki && (
+        <section>
+          <Tabs>
+            {(metadata.wikipedia || []).map((wiki, key) => (
               <div key={key} title={wiki.title.replaceAll('_', ' ')}>
                 <Wikipedia
                   title={wiki.title}
@@ -183,8 +185,9 @@ const SummaryEntry = ({
                 />
               </div>
             ))}
-        </Tabs>
-      </section>
+          </Tabs>
+        </section>
+      )}
     </div>
   );
 };

--- a/src/components/Entry/Summary/style.css
+++ b/src/components/Entry/Summary/style.css
@@ -1,6 +1,6 @@
 /* overlapping entries Tree : to align exactly with title */
-@import '../../../styles/colors.css';
-@import '../../../styles/timing.css';
+@import "../../../styles/colors.css";
+@import "../../../styles/timing.css";
 
 .list-items {
   padding-left: 1px;
@@ -20,7 +20,7 @@
 .wiki-article {
   font-family: sans-serif;
   font-size: 0.875em;
-  /*margin: 0.2rem;*/
+  margin-bottom: 1rem;
 
   & .th-infobox {
     text-align: center;

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -334,7 +334,7 @@ interface EntryMetadata extends Metadata {
     type: string;
   }> | null;
   cross_references: Record<string, CrossReference>;
-  wikipedia: WikipediaEntry;
+  wikipedia?: Array<WikipediaEntry>;
   set_info?: {
     accession: string;
     name: string;


### PR DESCRIPTION
The website now expects the Wikipedia field to be an array of objects.
And with it, it organizes the different articles in tabs at the end of the entry summary page.

Example PF00001