### PR TITLE
wikipedia links in caption

### DIFF
--- a/src/components/Entry/Summary/Wikipedia/index.tsx
+++ b/src/components/Entry/Summary/Wikipedia/index.tsx
@@ -17,6 +17,8 @@ import ipro from 'styles/interpro-vf.css';
 
 const css = cssBinder(local, ipro);
 
+const wikiLinkPrefix = 'https://en.wikipedia.org/wiki/';
+
 interface WikipediaProps
   extends WikipediaEntry,
     LoadDataProps<WikipediaPayload> {}
@@ -74,7 +76,7 @@ const Wikipedia = ({ title, extract, thumbnail, data }: WikipediaProps) => {
   const imageLink = (
     <img src={`data:image/png;base64, ${thumbnail}`} alt="Structure" />
   );
-
+  const captionWithLinksSplit = article.caption.split(/(\[\[[^\]]+\]\])/);
   return (
     <div className={css('wiki-article')}>
       <div className={css('vf-grid', 'wiki-content')}>
@@ -83,7 +85,7 @@ const Wikipedia = ({ title, extract, thumbnail, data }: WikipediaProps) => {
             <Link
               className={css('ext-link')}
               target="_blank"
-              href={`https://en.wikipedia.org/wiki/${title}`}
+              href={`${wikiLinkPrefix}${title}`}
             >
               {title.replace(/_/g, ' ')}
             </Link>
@@ -103,7 +105,7 @@ const Wikipedia = ({ title, extract, thumbnail, data }: WikipediaProps) => {
                   <td colSpan={2} className={css('td-thumbnail')}>
                     {article.image ? (
                       <a
-                        href={`https://en.wikipedia.org/wiki/File:${article.image}`}
+                        href={`${wikiLinkPrefix}File:${article.image}`}
                         className="image"
                         target="_blank"
                         rel="noopener noreferrer"
@@ -113,7 +115,24 @@ const Wikipedia = ({ title, extract, thumbnail, data }: WikipediaProps) => {
                     ) : (
                       imageLink
                     )}
-                    <div>{article.caption}</div>
+                    <div>
+                      {captionWithLinksSplit.map((text, i) =>
+                        text.startsWith('[[') ? (
+                          <Link
+                            className={css('ext-link')}
+                            target="_blank"
+                            href={`${wikiLinkPrefix}${text.replaceAll(
+                              /[[\]]/g,
+                              '',
+                            )}`}
+                          >
+                            {text.replaceAll(/[[\]]/g, '')}
+                          </Link>
+                        ) : (
+                          <span key={i}>{text}</span>
+                        ),
+                      )}
+                    </div>
                   </td>
                 </tr>
               ) : null}
@@ -138,7 +157,7 @@ const Wikipedia = ({ title, extract, thumbnail, data }: WikipediaProps) => {
                       <tr key={id.name}>
                         <th scope="row" className={css('row-header')}>
                           <a
-                            href={`https://en.wikipedia.org/wiki/${id.name}`}
+                            href={`${wikiLinkPrefix}${id.name}`}
                             title={id.name}
                           >
                             {id.name}

--- a/src/components/Entry/Summary/Wikipedia/index.tsx
+++ b/src/components/Entry/Summary/Wikipedia/index.tsx
@@ -125,6 +125,7 @@ const Wikipedia = ({ title, extract, thumbnail, data }: WikipediaProps) => {
                               /[[\]]/g,
                               '',
                             )}`}
+                            key={i}
                           >
                             {text.replaceAll(/[[\]]/g, '')}
                           </Link>


### PR DESCRIPTION
The text for the caption in wikipedia panels might have links to wiki articles with the syntax `[[ link ]]`.

This PR parses those to create the links to the right place in wikipedia.