### PR TITLE
Get representative boolean from location instead of fragment

### DIFF
--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -16,8 +16,8 @@ export const selectRepresentativeDomains = (
     }
     for (const location of domain[locationKey] as Array<ProtVistaLocation>) {
       for (const fragment of location.fragments) {
-        const { start, end, representative } = fragment;
-        if (representative) {
+        const { start, end } = fragment;
+        if (location.representative) {
           flatDomains.push({
             accession,
             chain,

--- a/src/types/interpro-payloads.d.ts
+++ b/src/types/interpro-payloads.d.ts
@@ -232,7 +232,6 @@ type ProtVistaFragment = {
   residues?: string;
   seq_feature?: string;
   fill?: string;
-  representative?: boolean;
   protein_start?: number;
   protein_end?: number;
 };
@@ -245,6 +244,7 @@ type ProtVistaLocation = {
     name: string;
     accession: string;
   };
+  representative?: boolean;
   description?: string;
   accession?: string;
   [other: string]: unknown;


### PR DESCRIPTION
The first representative domain selection algorithm was evaluating fragments independently, i.e. one fragment from one domain could be selected as representative, but not the other fragment(s).

I changed that, and for the past few months, the `representative` boolean has been available at both the `entry_protein_locations` and `fragments` levels, e.g. [A0A023HJ61](https://www.ebi.ac.uk/interpro/api/entry/all/protein/UniProt/A0A023HJ61/).

This PR changes the source of `representative` to use the one at the location level.

The `representative` property will stopped being added at the fragment level for the next release.