### PR TITLE
Sort InterPro releases by version number

### DIFF
--- a/src/pages/Release_notes/index.js
+++ b/src/pages/Release_notes/index.js
@@ -50,9 +50,10 @@ const ReleaseNotesSelectorWithData = (
 ) => {
   const [showFullList, setShowFullList] = useState(false);
   if (loading || !payload) return <Loading />;
-  const releasesToShow = showFullList
-    ? Object.entries(payload)
-    : Object.entries(payload).slice(-1);
+  const allRelease = Object.entries(payload).sort(
+    ([a], [b]) => Number(a) - Number(b),
+  );
+  const releasesToShow = showFullList ? allRelease : allRelease.slice(-2, -1);
   return (
     <>
       {!showFullList && (


### PR DESCRIPTION
Addresses the issue reported in #639 (to reproduce, head to https://www.ebi.ac.uk/interpro/release_notes/ and click "Show Previous Releases).