### PR TITLE
Warning for IPScan pages update

### DIFF
--- a/src/components/IPScan/Status/__snapshots__/test.js.snap
+++ b/src/components/IPScan/Status/__snapshots__/test.js.snap
@@ -9,13 +9,13 @@ exports[`<IPScanStatus /> should render 1`] = `
     type="warning"
   >
     <h4>
-      This page will be updated with Release 102.0
+      This page will be updated with release 102.0
     </h4>
     <p>
       We are working on a new version of this page: reorganising jobs with multiple sequences and supporting search with nucleotide sequences from the website.
     </p>
     <p>
-      Unfortunately the new version is incompatible with previously saved jobs in the browser. If you have any jobs you want to keep, please expport them as JSON, and import them back once the new version is released.
+      Unfortunately the new version is incompatible with previously saved jobs in the browser. If you have any jobs you want to keep, please export them as JSON, and import them back once the new version is released.
     </p>
   </Callout>
   <h3

--- a/src/components/IPScan/Status/__snapshots__/test.js.snap
+++ b/src/components/IPScan/Status/__snapshots__/test.js.snap
@@ -4,6 +4,20 @@ exports[`<IPScanStatus /> should render 1`] = `
 <div
   className="row columns"
 >
+  <Callout
+    icon="icon-bullhorn"
+    type="warning"
+  >
+    <h4>
+      This page will be updated with Release 102.0
+    </h4>
+    <p>
+      We are working on a new version of this page: reorganising jobs with multiple sequences and supporting search with nucleotide sequences from the website.
+    </p>
+    <p>
+      Unfortunately the new version is incompatible with previously saved jobs in the browser. If you have any jobs you want to keep, please expport them as JSON, and import them back once the new version is released.
+    </p>
+  </Callout>
   <h3
     className="light"
   >

--- a/src/components/IPScan/Status/index.js
+++ b/src/components/IPScan/Status/index.js
@@ -23,6 +23,7 @@ import CopyToClipboard from 'components/SimpleCommonComponents/CopyToClipboard';
 import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
 import Button from 'components/SimpleCommonComponents/Button';
 import SpinningCircle from 'components/SimpleCommonComponents/Loading/spinningCircle';
+import Callout from 'components/SimpleCommonComponents/Callout';
 
 import { format } from 'url';
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
@@ -141,6 +142,20 @@ export class IPScanStatus extends PureComponent /*:: <Props> */ {
     );
     return (
       <div className={f('row', 'columns')}>
+        <Callout type="warning" icon={f('icon-bullhorn')}>
+          <h4>This page will be updated with Release 102.0</h4>
+          <p>
+            We are working on a new version of this page: reorganising jobs with
+            multiple sequences and supporting search with nucleotide sequences
+            from the website.
+          </p>
+          <p>
+            Unfortunately the new version is incompatible with previously saved
+            jobs in the browser. If you have any jobs you want to keep, please
+            expport them as JSON, and import them back once the new version is
+            released.
+          </p>
+        </Callout>
         <h3 className={f('light')}>
           Your InterProScan Search Results{' '}
           <TooltipAndRTDLink rtdPage="searchways.html#sequence-search-results" />

--- a/src/components/IPScan/Status/index.js
+++ b/src/components/IPScan/Status/index.js
@@ -143,7 +143,7 @@ export class IPScanStatus extends PureComponent /*:: <Props> */ {
     return (
       <div className={f('row', 'columns')}>
         <Callout type="warning" icon={f('icon-bullhorn')}>
-          <h4>This page will be updated with Release 102.0</h4>
+          <h4>This page will be updated with release 102.0</h4>
           <p>
             We are working on a new version of this page: reorganising jobs with
             multiple sequences and supporting search with nucleotide sequences
@@ -152,7 +152,7 @@ export class IPScanStatus extends PureComponent /*:: <Props> */ {
           <p>
             Unfortunately the new version is incompatible with previously saved
             jobs in the browser. If you have any jobs you want to keep, please
-            expport them as JSON, and import them back once the new version is
+            export them as JSON, and import them back once the new version is
             released.
           </p>
         </Callout>


### PR DESCRIPTION
Adds a warning about the upcoming version of ipscan results. Informing the users that old results will be incompatible and encourage them to save their jobs.