### PR TITLE
Improved taxonomy tree bar 

### DIFF
--- a/src/components/Matches/EntriesOnProtein/__snapshots__/test.js.snap
+++ b/src/components/Matches/EntriesOnProtein/__snapshots__/test.js.snap
@@ -44,6 +44,7 @@ exports[`<EntriesOnProtein /> should render 1`] = `
         margin-color="#fafafa"
         shape="roundRectangle"
         use-ctrl-to-zoom={true}
+        width={300}
       />
     </TooltipForTrack>
   </div>

--- a/src/components/Matches/EntriesOnProtein/index.tsx
+++ b/src/components/Matches/EntriesOnProtein/index.tsx
@@ -78,6 +78,7 @@ const EntriesOnProtein = ({ matches, match }: Props) => {
             id={`track_${entry.accession}`}
             data={data || []}
             shape="roundRectangle"
+            width={300}
             expanded
             use-ctrl-to-zoom
           />

--- a/src/components/Matches/EntriesOnStructure/__snapshots__/test.js.snap
+++ b/src/components/Matches/EntriesOnStructure/__snapshots__/test.js.snap
@@ -54,6 +54,7 @@ exports[`<EntriesOnStructure /> should render 1`] = `
                   margin-color="#fafafa"
                   shape="roundRectangle"
                   use-ctrl-to-zoom={true}
+                  width={300}
                 />
               </TooltipForTrack>
             </div>

--- a/src/components/Matches/EntriesOnStructure/index.tsx
+++ b/src/components/Matches/EntriesOnStructure/index.tsx
@@ -98,6 +98,7 @@ const EntriesOnStructure = ({ matches, match }: Props) => {
                           id={`track_${structure.accession}`}
                           shape="roundRectangle"
                           data={data?.[m.chain || ''] || []}
+                          width={300}
                           expanded
                           use-ctrl-to-zoom
                         />

--- a/src/components/Matches/StructureOnProtein/__snapshots__/test.js.snap
+++ b/src/components/Matches/StructureOnProtein/__snapshots__/test.js.snap
@@ -54,6 +54,7 @@ exports[`<StructureOnProtein /> should render 1`] = `
                   margin-color="#fafafa"
                   shape="rectangle"
                   use-ctrl-to-zoom={true}
+                  width={300}
                 />
               </TooltipForTrack>
             </div>

--- a/src/components/Matches/StructureOnProtein/index.tsx
+++ b/src/components/Matches/StructureOnProtein/index.tsx
@@ -113,6 +113,7 @@ const StructureOnProtein = ({ matches, match }: Props) => {
                           margin-color="#fafafa"
                           id={`track_${structure.accession}_${m.chain}`}
                           shape="rectangle"
+                          width={300}
                           expanded
                           use-ctrl-to-zoom
                         />

--- a/src/components/ProteinViewer/style.css
+++ b/src/components/ProteinViewer/style.css
@@ -145,7 +145,7 @@ body table.matches-in-table tr:first-of-type td {
   border-top: 0;
 }
 .track-in-table {
-  max-width: 400px;
+  max-width: 300px;
 }
 .track-in-table text {
   fill: var(--colors-graydark);

--- a/src/components/Table/views/Tree/index.tsx
+++ b/src/components/Table/views/Tree/index.tsx
@@ -338,10 +338,8 @@ class TreeView extends Component<Props, State> {
     // Splitting string
     if (lineageString) {
       lineageIDs = lineageString.split(' ');
-      if (lineageIDs !== undefined) {
-        for (let i = 0; i < lineageIDs?.length; i++) {
-          lineageIDs[i] = lineageIDs[i].trim();
-        }
+      for (let i = 0; i < lineageIDs?.length; i++) {
+        lineageIDs[i] = lineageIDs[i].trim();
       }
     }
     return (
@@ -372,8 +370,8 @@ class TreeView extends Component<Props, State> {
                 <p>{currentNode?.rank}</p>
               </div>
             )}
-            {currentNode?.lineage && (
-              <nav className={'breadcrumbs'}>
+            {currentNode?.lineage && lineageIDs.length > 1 && (
+              <nav className={css('breadcrumbs')}>
                 {lineageIDs.map((key) => (
                   <li key={key}>
                     <Link

--- a/src/components/Table/views/Tree/index.tsx
+++ b/src/components/Table/views/Tree/index.tsx
@@ -336,13 +336,6 @@ class TreeView extends Component<Props, State> {
         <div className={css('node-details')}>
           <div className={css('node-info')}>
             <header>
-              <Tooltip title="[Tax ID]: [Tax Name]">
-                <span
-                  className={css('small', 'icon', 'icon-common')}
-                  data-icon="&#xf129;"
-                  aria-label="Tax ID: Tax Name"
-                />
-              </Tooltip>{' '}
               <Link
                 to={{
                   description: {
@@ -351,45 +344,36 @@ class TreeView extends Component<Props, State> {
                   },
                 }}
               >
-                {currentNode?.id}: {currentNode?.name}
+                {currentNode?.name}
               </Link>
             </header>
             {currentNode?.rank?.toLowerCase() !== 'no rank' && (
               <div>
-                <Tooltip title="Rank.">
-                  <span
-                    className={css('small', 'icon', 'icon-common')}
-                    data-icon="&#xf129;"
-                    aria-label="Rank."
-                  />
-                </Tooltip>{' '}
-                <i>{currentNode?.rank}</i>
+                <p>{currentNode?.rank}</p>
               </div>
             )}
             {currentNode?.lineage && (
-              <DropDownButton label="Lineage" fontSize="12px">
-                <ul>
-                  {Array.from(this._lineageNames.keys()).map((key) => (
-                    <li key={key}>
-                      <Link
-                        to={{
-                          description: {
-                            main: { key: 'taxonomy' },
-                            taxonomy: { db: 'uniprot', accession: key },
-                          },
-                        }}
-                      >
-                        {`${
-                          this._lineageNames
-                            ?.get(key)
-                            ?.charAt(0)
-                            ?.toUpperCase() || ''
-                        }${this._lineageNames.get(key)?.slice(1) || ''}`}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </DropDownButton>
+              <nav className={'breadcrumbs'}>
+                {Array.from(this._lineageNames.keys()).map((key) => (
+                  <li key={key}>
+                    <Link
+                      to={{
+                        description: {
+                          main: { key: 'taxonomy' },
+                          taxonomy: { db: 'uniprot', accession: key },
+                        },
+                      }}
+                    >
+                      {`${
+                        this._lineageNames
+                          ?.get(key)
+                          ?.charAt(0)
+                          ?.toUpperCase() || ''
+                      }${this._lineageNames.get(key)?.slice(1) || ''}`}
+                    </Link>
+                  </li>
+                ))}
+              </nav>
             )}
           </div>
           <div className={css('node-links')}>

--- a/src/components/Table/views/Tree/index.tsx
+++ b/src/components/Table/views/Tree/index.tsx
@@ -12,8 +12,6 @@ import Loading from 'components/SimpleCommonComponents/Loading';
 import Tree from 'components/Tree';
 import NumberComponent from 'components/NumberComponent';
 import abbreviateNumber from 'components/NumberComponent/utils/number-to-display-text';
-import DropDownButton from 'components/SimpleCommonComponents/DropDownButton';
-import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 import Tip from 'components/Tip';
 
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
@@ -330,8 +328,9 @@ class TreeView extends Component<Props, State> {
     };
 
     /* Compute breadcrumb */
+
     let lineageIDs: string[] | undefined = [];
-    let lineageString: string | undefined = currentNode?.lineage?.slice(
+    const lineageString: string | undefined = currentNode?.lineage?.slice(
       1,
       currentNode?.lineage?.length - 1,
     );

--- a/src/components/Table/views/Tree/index.tsx
+++ b/src/components/Table/views/Tree/index.tsx
@@ -173,6 +173,7 @@ class TreeView extends Component<Props, State> {
   _CDPMap: Map<string, Provider>;
   _lineageNames: Map<string, string>;
   _initialLoad: boolean;
+  _breadcrumbs: TaxNode[];
 
   constructor(props: Props) {
     super(props);
@@ -184,7 +185,8 @@ class TreeView extends Component<Props, State> {
     };
     this._CDPMap = new Map();
     this._lineageNames = new Map();
-    this._initialLoad = true; // Automatically opens the tree until it finds a branch of children when it loads the first time
+    this._initialLoad = true;
+    this._breadcrumbs = []; // Automatically opens the tree until it finds a branch of children when it loads the first time
   }
 
   static getDerivedStateFromProps(
@@ -259,6 +261,17 @@ class TreeView extends Component<Props, State> {
   };
 
   _handleNewFocus = (taxID: string) => {
+    /* Recomputing the lineage.
+       This handles the case of going back to one of the already open taxons.
+       E.g Tree is at Root -> Virus -> AnelloViridae and the desired action is Root -> Virus
+    
+    for (let i = 0; i < this._breadcrumbs.length; i++){
+      if (this._breadcrumbs[i].id == taxID){
+        this._storeLineageNames(this._breadcrumbs[i].id, this._breadcrumbs[i])
+        break
+      }
+    }*/
+
     if (taxID) {
       this.setState({ focused: taxID });
       if (this.props.onFocusChanged) {
@@ -266,6 +279,7 @@ class TreeView extends Component<Props, State> {
       }
     }
   };
+
   _handleLabelClick = (taxID: string) => {
     this.props.goToCustomLocation({
       description: {
@@ -278,8 +292,39 @@ class TreeView extends Component<Props, State> {
     });
   };
 
+  // Find the parent of a node among the ones already added to the breadcrumb
+  _parent = (node: TaxNode, breadcrumbs: TaxNode[]) => {
+    for (let i = breadcrumbs.length - 1; i >= 0; i--) {
+      let taxObj = breadcrumbs[i];
+      if (taxObj.children !== undefined) {
+        for (let j = 0; j < taxObj.children?.length; j++) {
+          if (taxObj.children[j].id == node.id) {
+            return taxObj;
+          }
+        }
+      }
+    }
+  };
+
   _storeLineageNames = (focused: string, data: TaxNode) => {
     if (focused === data.id) {
+      // Updating breadcrumb object and recreating lineage
+      /*
+      this._breadcrumbs.push(data)
+      let parentNode: TaxNode = data
+      let localBreadcrumbs: TaxNode[] = [data]
+      
+      while (parentNode.name != "root"){
+        parentNode = this._parent(parentNode as TaxNode, this._breadcrumbs) as TaxNode
+        console.log(parentNode)
+        localBreadcrumbs.push(parentNode)
+      }
+
+      localBreadcrumbs.reverse()
+
+      this._lineageNames.clear()
+      localBreadcrumbs.map((taxon) => {*/
+      // Adding the right tuple (id, name) to lineageNames */
       this._lineageNames.set(focused, data.name);
     } else {
       data?.children?.forEach((child) => {

--- a/src/components/Table/views/Tree/style.css
+++ b/src/components/Table/views/Tree/style.css
@@ -1,4 +1,4 @@
-@import './../../../../styles/colors.css';
+@import "./../../../../styles/colors.css";
 
 .button {
   width: 100%;
@@ -41,4 +41,8 @@
       pointer-events: none;
     }
   }
+}
+
+.breadcrumbs > li {
+  text-transform: none;
 }

--- a/src/components/Tree/style.css
+++ b/src/components/Tree/style.css
@@ -1,5 +1,5 @@
-@import '../../styles/timing.css';
-@import '../../styles/colors.css';
+@import "../../styles/timing.css";
+@import "../../styles/colors.css";
 
 .buttons {
   position: absolute;
@@ -57,4 +57,8 @@
   align-items: stretch;
   justify-content: center;
   border: 2px solid var(--colors-secondary-header);
+}
+
+.breadcrumbs > li {
+  text-transform: none !important;
 }

--- a/src/components/Tree/style.css
+++ b/src/components/Tree/style.css
@@ -58,7 +58,3 @@
   justify-content: center;
   border: 2px solid var(--colors-secondary-header);
 }
-
-.breadcrumbs > li {
-  text-transform: none !important;
-}


### PR DESCRIPTION
Improved the taxonomy tree bar following [IBU-11216](https://www.ebi.ac.uk/panda/jira/browse/IBU-11216)

- Removed the taxon id, now just the name is displayed;
- Removed tooltips;
- Replaced the dropdown selector with a breadcrumb (*important note below)

The result comes down to this:

![image](https://github.com/user-attachments/assets/4fccd59e-093d-4014-9b9a-009fccc6fa9b)


* NOTE
Something weird happens when you jump from a taxon to another. The selector (now the breadcrumbs), takes into account all the taxon visited, and not just the ones relevant to the current focus. Shouldn't the example below be something like (ROOT / VIRUS / OVALIVIRIDAE) ? 

![image](https://github.com/user-attachments/assets/ce4b922e-79a9-40a6-9e88-ea8ae764b720)

Is this an * actual * bug or am I missing something? I've implemented a couple of solutions but they all end up having a couple of problems that I think require @gustavo-salazar's guidance to be solved. 