### PR TITLE
Moved reference section below description

### DIFF
--- a/src/components/Entry/Summary/__snapshots__/test.js.snap
+++ b/src/components/Entry/Summary/__snapshots__/test.js.snap
@@ -68,6 +68,54 @@ exports[`<SummaryEntry /> should render 1`] = `
             }
           />
         </React.Fragment>
+        <OtherSections
+          citations={
+            {
+              "extra": [],
+              "included": [],
+            }
+          }
+          hasIntegratedCitations={false}
+          metadata={
+            {
+              "accession": "IPR000001",
+              "counters": {
+                "domain_architectures": 511,
+                "matches": 44375,
+                "proteins": 6786,
+                "proteomes": 343,
+                "sets": 0,
+                "structures": 698,
+                "taxa": 675,
+              },
+              "cross_references": {},
+              "description": [
+                "<p>Kringle</p>",
+              ],
+              "go_terms": {},
+              "literature": {},
+              "name": {
+                "name": "Kringle",
+                "short": "Kringle",
+              },
+              "overlaps_with": [
+                {
+                  "accession": "IPR013806",
+                  "name": "Kringle-like fold",
+                  "type": "homologous_superfamily",
+                },
+                {
+                  "accession": "IPR038178",
+                  "name": "Kringle superfamily",
+                  "type": "homologous_superfamily",
+                },
+              ],
+              "source_database": "interpro",
+              "type": "domain",
+              "wikipedia": "",
+            }
+          }
+        />
       </section>
     </div>
     <div
@@ -117,53 +165,5 @@ exports[`<SummaryEntry /> should render 1`] = `
       />
     </div>
   </section>
-  <OtherSections
-    citations={
-      {
-        "extra": [],
-        "included": [],
-      }
-    }
-    hasIntegratedCitations={false}
-    metadata={
-      {
-        "accession": "IPR000001",
-        "counters": {
-          "domain_architectures": 511,
-          "matches": 44375,
-          "proteins": 6786,
-          "proteomes": 343,
-          "sets": 0,
-          "structures": 698,
-          "taxa": 675,
-        },
-        "cross_references": {},
-        "description": [
-          "<p>Kringle</p>",
-        ],
-        "go_terms": {},
-        "literature": {},
-        "name": {
-          "name": "Kringle",
-          "short": "Kringle",
-        },
-        "overlaps_with": [
-          {
-            "accession": "IPR013806",
-            "name": "Kringle-like fold",
-            "type": "homologous_superfamily",
-          },
-          {
-            "accession": "IPR038178",
-            "name": "Kringle superfamily",
-            "type": "homologous_superfamily",
-          },
-        ],
-        "source_database": "interpro",
-        "type": "domain",
-        "wikipedia": "",
-      }
-    }
-  />
 </div>
 `;

--- a/src/components/Entry/Summary/index.tsx
+++ b/src/components/Entry/Summary/index.tsx
@@ -43,14 +43,6 @@ const OtherSections = ({
   hasIntegratedCitations,
 }: OtherSectionsProps) => (
   <>
-    {!Object.keys(metadata.go_terms || []).length ||
-    metadata.source_database.toLowerCase() !== 'interpro' ? null : (
-      <GoTerms
-        terms={metadata.go_terms || []}
-        type="entry"
-        db={metadata.source_database}
-      />
-    )}
     {Object.keys(metadata.literature || []).length ? (
       <section id="references">
         <div className={css('vf-grid')}>
@@ -61,6 +53,15 @@ const OtherSections = ({
         <Literature included={included} extra={extra} />
       </section>
     ) : null}
+
+    {!Object.keys(metadata.go_terms || []).length ||
+    metadata.source_database.toLowerCase() !== 'interpro' ? null : (
+      <GoTerms
+        terms={metadata.go_terms || []}
+        type="entry"
+        db={metadata.source_database}
+      />
+    )}
 
     {Object.keys(metadata.cross_references || {}).length ? (
       <section id="cross_references" data-testid="entry-crossreferences">
@@ -160,22 +161,22 @@ const SummaryEntry = ({
 
           <section className={css('vf-stack')}>
             {selectDescriptionComponent(hasLLM)}
+            <OtherSections
+              metadata={metadata}
+              citations={
+                { included, extra } as {
+                  included: Array<[string, Reference]>;
+                  extra: Array<[string, Reference]>;
+                }
+              }
+              hasIntegratedCitations={integratedCitations?.length > 0}
+            />
           </section>
         </div>
         <div className={css('vf-stack')}>
           <SidePanel metadata={metadata} dbInfo={dbInfo} />
         </div>
       </section>
-      <OtherSections
-        metadata={metadata}
-        citations={
-          { included, extra } as {
-            included: Array<[string, Reference]>;
-            extra: Array<[string, Reference]>;
-          }
-        }
-        hasIntegratedCitations={integratedCitations?.length > 0}
-      />
       {hasWiki && (
         <section>
           <h4>Wikipedia</h4>


### PR DESCRIPTION
Changed the position of references as requested in [IBU-11215](https://www.ebi.ac.uk/panda/jira/browse/IBU-11215).

- The references are now above the GO Terms (e.g. IPR 000003)
![image](https://github.com/user-attachments/assets/8d49c54a-20d3-4723-bd2f-fbc23bbc691d)

- The references are now in the same section of the description, so that if the right section is too long, they don't get pushed down (e.g. IPR000001)

![image](https://github.com/user-attachments/assets/26abc97e-8f5b-4e96-a27d-30612f80c165)
