### PR TITLE
Fixed matches expanding column

### DIFF
--- a/src/components/Matches/EntriesOnProtein/__snapshots__/test.js.snap
+++ b/src/components/Matches/EntriesOnProtein/__snapshots__/test.js.snap
@@ -44,6 +44,7 @@ exports[`<EntriesOnProtein /> should render 1`] = `
         margin-color="#fafafa"
         shape="roundRectangle"
         use-ctrl-to-zoom={true}
+        width={300}
       />
     </TooltipForTrack>
   </div>

--- a/src/components/Matches/EntriesOnProtein/index.tsx
+++ b/src/components/Matches/EntriesOnProtein/index.tsx
@@ -78,6 +78,7 @@ const EntriesOnProtein = ({ matches, match }: Props) => {
             id={`track_${entry.accession}`}
             data={data || []}
             shape="roundRectangle"
+            width={300}
             expanded
             use-ctrl-to-zoom
           />

--- a/src/components/Matches/EntriesOnStructure/__snapshots__/test.js.snap
+++ b/src/components/Matches/EntriesOnStructure/__snapshots__/test.js.snap
@@ -54,6 +54,7 @@ exports[`<EntriesOnStructure /> should render 1`] = `
                   margin-color="#fafafa"
                   shape="roundRectangle"
                   use-ctrl-to-zoom={true}
+                  width={300}
                 />
               </TooltipForTrack>
             </div>

--- a/src/components/Matches/EntriesOnStructure/index.tsx
+++ b/src/components/Matches/EntriesOnStructure/index.tsx
@@ -98,6 +98,7 @@ const EntriesOnStructure = ({ matches, match }: Props) => {
                           id={`track_${structure.accession}`}
                           shape="roundRectangle"
                           data={data?.[m.chain || ''] || []}
+                          width={300}
                           expanded
                           use-ctrl-to-zoom
                         />

--- a/src/components/Matches/StructureOnProtein/__snapshots__/test.js.snap
+++ b/src/components/Matches/StructureOnProtein/__snapshots__/test.js.snap
@@ -54,6 +54,7 @@ exports[`<StructureOnProtein /> should render 1`] = `
                   margin-color="#fafafa"
                   shape="rectangle"
                   use-ctrl-to-zoom={true}
+                  width={300}
                 />
               </TooltipForTrack>
             </div>

--- a/src/components/Matches/StructureOnProtein/index.tsx
+++ b/src/components/Matches/StructureOnProtein/index.tsx
@@ -113,6 +113,7 @@ const StructureOnProtein = ({ matches, match }: Props) => {
                           margin-color="#fafafa"
                           id={`track_${structure.accession}_${m.chain}`}
                           shape="rectangle"
+                          width={300}
                           expanded
                           use-ctrl-to-zoom
                         />

--- a/src/components/Matches/style.css
+++ b/src/components/Matches/style.css
@@ -74,6 +74,7 @@
 
 .matchColumn {
   min-width: 200px;
+  max-width: max-content;
 }
 .exact {
   background-color: var(--colors-marktext);

--- a/src/components/ProteinViewer/style.css
+++ b/src/components/ProteinViewer/style.css
@@ -145,7 +145,7 @@ body table.matches-in-table tr:first-of-type td {
   border-top: 0;
 }
 .track-in-table {
-  max-width: 400px;
+  max-width: 300px;
 }
 .track-in-table text {
   fill: var(--colors-graydark);


### PR DESCRIPTION
The column displaying tracks kept expanding for some entries. max-width was required

Closes #637. The example reported was about entry [PF11133](https://www.ebi.ac.uk/interpro/entry/pfam/PF11133/structure/PDB/#table).

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/8933bd69-e3ba-45be-b4b4-1bb63ce229dc">