### PR TITLE
Make text in cell shorter

### DIFF
--- a/src/components/Matches/index.tsx
+++ b/src/components/Matches/index.tsx
@@ -541,12 +541,12 @@ const Matches = ({
                 },
               }}
             >
-              View predicted structure
+              AlphaFold
             </Link>
           ) : null
         }
       >
-        Alphafold
+        Predicted structure
       </Column>
       <Column
         dataKey="match"

--- a/src/pages/Protein/index.js
+++ b/src/pages/Protein/index.js
@@ -367,12 +367,12 @@ class List extends PureComponent /*:: <ListProps> */ {
                       },
                     }}
                   >
-                    View predicted structure
+                    AlphaFold
                   </Link>
                 ) : null
               }
             >
-              AlphaFold
+              Predicted structure
             </Column>{' '}
           </Table>
         </section>

--- a/src/subPages/SimilarProteins/Table/index.tsx
+++ b/src/subPages/SimilarProteins/Table/index.tsx
@@ -222,12 +222,12 @@ const SimilarProteinTable = ({
                   },
                 }}
               >
-                View predicted structure
+                AlphaFold
               </Link>
             ) : null
           }
         >
-          AlphaFold
+          Predicted structure
         </Column>
       </Table>
     </>


### PR DESCRIPTION
Tiny PR that simply changes the text of the link to the AlphaFold page, and the header of the link's column.