### PR TITLE
Inline RST links

### DIFF
--- a/src/components/ContentFromRST/index.js
+++ b/src/components/ContentFromRST/index.js
@@ -20,7 +20,7 @@ const InterProScan = loadable({
 
 const substitutions = {};
 
-const rstembeddedLink = /^`(.+)\s*<(.+)>`_{1,2}$/;
+const rstembeddedLink = /`(.+)\s*<(.+)>`_{1,2}/;
 // eslint-disable-next-line complexity
 const Switch = ({ type, ...rest }) => {
   switch (type) {


### PR DESCRIPTION
Properly formats reStructuredText links that do not take the full length of the line.

Example: www.ebi.ac.uk/interpro/help/training/

![image](https://github.com/user-attachments/assets/91316b64-b4e7-4ca8-b4c9-6f6bbde838fb)

The link to the application of the next InterPro course is not properly formatted on the live website.