### PR TITLE
AI Filter for entries

### DIFF
--- a/src/components/Entry/EntryListFilters/AIGeneratedFilter/index.tsx
+++ b/src/components/Entry/EntryListFilters/AIGeneratedFilter/index.tsx
@@ -20,9 +20,9 @@ import stylego from 'pages/style.css';
 const css = cssBinder(stylego, style);
 
 const categories = {
-  'Manually Curated': 'MC',
-  'AI-Generated and Reviewed': 'AI-R',
-  'AI-Generated and Unreviewed': 'AI-U',
+  Curated: 'curated',
+  'AI-Generated (reviewed)': 'ai-reviewed',
+  'AI-Generated (unreviewed)': 'ai-unreviewed',
 };
 type Categories = keyof typeof categories;
 
@@ -48,8 +48,8 @@ const AIGeneratedFilter = ({
 
   const _handleSelection = ({ target }: FormEvent) => {
     const value = (target as HTMLInputElement).value;
-    const { page, ai_category: _, cursor: __, ...restOfsearch } = search;
-    if (value !== 'All') restOfsearch.ai_category = value;
+    const { page, curation_status: _, cursor: __, ...restOfsearch } = search;
+    if (value !== 'All') restOfsearch.curation_status = value;
     goToCustomLocation?.({ ...customLocation, search: restOfsearch });
   };
 
@@ -83,13 +83,13 @@ const AIGeneratedFilter = ({
           {terms.map(([t, count]) => {
             const term = t as Categories | 'All';
             const checked =
-              (term === 'All' && !search.ai_category) ||
-              search.ai_category === categories[term as Categories];
+              (term === 'All' && !search.curation_status) ||
+              search.curation_status === categories[term as Categories];
             return (
               <label key={term} className={css('radio-btn-label', { checked })}>
                 <input
                   type="radio"
-                  name="ai_category"
+                  name="curation_status"
                   className={css('radio-btn')}
                   value={categories[term as Categories] || 'All'}
                   disabled={isStale}
@@ -130,11 +130,11 @@ const getUrlFor = createSelector(
       search: _,
       cursor: __,
       // eslint-disable-next-line camelcase
-      ai_category,
+      curation_status,
       ..._search
     } = search;
     // add to search
-    _search.group_by = 'ai_categories';
+    _search.group_by = 'curation_statuses';
     // build URL
     return format({
       protocol,

--- a/src/components/Entry/EntryListFilters/AIGeneratedFilter/index.tsx
+++ b/src/components/Entry/EntryListFilters/AIGeneratedFilter/index.tsx
@@ -1,0 +1,140 @@
+import React, { FormEvent } from 'react';
+
+import { createSelector } from 'reselect';
+import { format } from 'url';
+
+import NumberComponent from 'components/NumberComponent';
+import Tooltip from 'components/SimpleCommonComponents/Tooltip';
+import { getPayloadOrEmpty } from 'components/FiltersPanel';
+
+import loadData from 'higherOrder/loadData/ts';
+import descriptionToPath from 'utils/processDescription/descriptionToPath';
+
+import { goToCustomLocation } from 'actions/creators';
+
+import cssBinder from 'styles/cssBinder';
+
+import style from 'components/FiltersPanel/style.css';
+import stylego from 'pages/style.css';
+
+const css = cssBinder(stylego, style);
+
+const categories = {
+  'Manually Curated': 'MC',
+  'AI-Generated and Reviewed': 'AI-R',
+  'AI-Generated and Unreviewed': 'AI-U',
+};
+type Categories = keyof typeof categories;
+
+type Props = {
+  label?: string;
+  goToCustomLocation?: typeof goToCustomLocation;
+  customLocation?: InterProLocation;
+};
+
+interface LoadedProps extends Props, LoadDataProps<GroupByPayload> {}
+
+const AIGeneratedFilter = ({
+  data,
+  isStale,
+  customLocation,
+  goToCustomLocation,
+}: LoadedProps) => {
+  if (!data || !customLocation) return null;
+  const { loading, payload } = data;
+  const { search } = customLocation;
+
+  const _handleSelection = ({ target }: FormEvent) => {
+    const value = (target as HTMLInputElement).value;
+    const { page, ai_category: _, cursor: __, ...restOfsearch } = search;
+    if (value !== 'All') restOfsearch.ai_category = value;
+    goToCustomLocation?.({ ...customLocation, search: restOfsearch });
+  };
+
+  const terms = Object.entries<number>(
+    getPayloadOrEmpty(payload, loading, isStale),
+  ).sort(([, a], [, b]) => b - a);
+
+  if (!loading) {
+    terms.unshift(['All', NaN]);
+  }
+  console.log(terms);
+
+  return (
+    <div className={css('list-go', { stale: isStale })}>
+      <div className={css('filter')}>
+        {terms.map(([t, count]) => {
+          const term = t as Categories | 'All';
+          const checked =
+            (term === 'All' && !search.ai_category) ||
+            search.ai_category === categories[term as Categories];
+          return (
+            <label key={term} className={css('radio-btn-label', { checked })}>
+              <input
+                type="radio"
+                name="ai_category"
+                className={css('radio-btn')}
+                value={categories[term as Categories] || 'All'}
+                disabled={isStale}
+                onChange={_handleSelection}
+                checked={checked}
+                style={{ margin: '0.25em' }}
+              />
+              <span>{term}</span>
+
+              {typeof count === 'undefined' || isNaN(count) ? null : (
+                <NumberComponent
+                  label
+                  loading={loading}
+                  className={css('filter-label')}
+                  abbr
+                >
+                  {count}
+                </NumberComponent>
+              )}
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const getUrlFor = createSelector(
+  (state: GlobalState) => state.settings.api,
+  (state: GlobalState) => state.customLocation.description,
+  (state: GlobalState) => state.customLocation.search,
+  ({ protocol, hostname, port, root }, description, search) => {
+    // omit from search
+    const {
+      // eslint-disable-next-line camelcase
+      page_size,
+      search: _,
+      cursor: __,
+      // eslint-disable-next-line camelcase
+      ai_category,
+      ..._search
+    } = search;
+    // add to search
+    _search.group_by = 'ai_categories';
+    // build URL
+    return format({
+      protocol,
+      hostname,
+      port,
+      pathname: root + descriptionToPath(description),
+      query: _search,
+    });
+  },
+);
+
+const mapStateToProps = createSelector(
+  (state: GlobalState) => state.customLocation,
+  (customLocation) => ({ customLocation }),
+);
+
+export default loadData({
+  getUrl: getUrlFor,
+  mapStateToProps,
+  mapDispatchToProps: { goToCustomLocation },
+} as LoadDataParameters)(AIGeneratedFilter);

--- a/src/components/Entry/EntryListFilters/AIGeneratedFilter/index.tsx
+++ b/src/components/Entry/EntryListFilters/AIGeneratedFilter/index.tsx
@@ -28,7 +28,6 @@ type Categories = keyof typeof categories;
 
 type Props = {
   label?: string;
-  changeLabel: (s: string) => void;
   goToCustomLocation?: typeof goToCustomLocation;
   customLocation?: InterProLocation;
 };
@@ -36,7 +35,6 @@ type Props = {
 interface LoadedProps extends Props, LoadDataProps<GroupByPayload> {}
 
 const AIGeneratedFilter = ({
-  changeLabel,
   data,
   isStale,
   customLocation,
@@ -58,63 +56,46 @@ const AIGeneratedFilter = ({
   ).sort(([, a], [, b]) => b - a);
 
   if (!loading) {
-    terms.unshift(['All', NaN]);
+    terms.unshift(['All', terms.reduce((acc, [, count]) => acc + count, 0)]);
   }
 
-  const [showFilter, setShowFilter] = useState(true);
-
-  useEffect(() => {
-    if (terms.length > 0) {
-      // If loaded AI-generated reviewed and unreviewed counts will always be in position 2 and 3 of the terms obj
-      if (terms[2][1] == 0 && terms[3][1] == 0) {
-        setShowFilter(false);
-        changeLabel('');
-      } else {
-        setShowFilter(true);
-        changeLabel('AI-Generated Entries');
-      }
-    }
-  });
-
   return (
-    showFilter && (
-      <div className={css('list-go', { stale: isStale })}>
-        <div className={css('filter')}>
-          {terms.map(([t, count]) => {
-            const term = t as Categories | 'All';
-            const checked =
-              (term === 'All' && !search.curation_status) ||
-              search.curation_status === categories[term as Categories];
-            return (
-              <label key={term} className={css('radio-btn-label', { checked })}>
-                <input
-                  type="radio"
-                  name="curation_status"
-                  className={css('radio-btn')}
-                  value={categories[term as Categories] || 'All'}
-                  disabled={isStale}
-                  onChange={_handleSelection}
-                  checked={checked}
-                  style={{ margin: '0.25em' }}
-                />
-                <span>{term}</span>
+    <div className={css({ stale: isStale })}>
+      <div className={css('filter')}>
+        {terms.map(([t, count]) => {
+          const term = t as Categories | 'All';
+          const checked =
+            (term === 'All' && !search.curation_status) ||
+            search.curation_status === categories[term as Categories];
+          return term == 'All' || count > 0 ? (
+            <label key={term} className={css('radio-btn-label', { checked })}>
+              <input
+                type="radio"
+                name="curation_status"
+                className={css('radio-btn')}
+                value={categories[term as Categories] || 'All'}
+                disabled={isStale}
+                onChange={_handleSelection}
+                checked={checked}
+                style={{ margin: '0.25em' }}
+              />
+              <span>{term}</span>
 
-                {typeof count === 'undefined' || isNaN(count) ? null : (
-                  <NumberComponent
-                    label
-                    loading={loading}
-                    className={css('filter-label')}
-                    abbr
-                  >
-                    {count}
-                  </NumberComponent>
-                )}
-              </label>
-            );
-          })}
-        </div>
+              <NumberComponent
+                label
+                loading={loading}
+                className={css('filter-label')}
+                abbr
+              >
+                {count}
+              </NumberComponent>
+            </label>
+          ) : (
+            ''
+          );
+        })}
       </div>
-    )
+    </div>
   );
 };
 

--- a/src/components/Entry/EntryListFilters/AIGeneratedFilter/index.tsx
+++ b/src/components/Entry/EntryListFilters/AIGeneratedFilter/index.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent } from 'react';
+import React, { FormEvent, useEffect, useState } from 'react';
 
 import { createSelector } from 'reselect';
 import { format } from 'url';
@@ -28,6 +28,7 @@ type Categories = keyof typeof categories;
 
 type Props = {
   label?: string;
+  changeLabel: (s: string) => void;
   goToCustomLocation?: typeof goToCustomLocation;
   customLocation?: InterProLocation;
 };
@@ -35,6 +36,7 @@ type Props = {
 interface LoadedProps extends Props, LoadDataProps<GroupByPayload> {}
 
 const AIGeneratedFilter = ({
+  changeLabel,
   data,
   isStale,
   customLocation,
@@ -58,45 +60,61 @@ const AIGeneratedFilter = ({
   if (!loading) {
     terms.unshift(['All', NaN]);
   }
-  console.log(terms);
+
+  const [showFilter, setShowFilter] = useState(true);
+
+  useEffect(() => {
+    if (terms.length > 0) {
+      // If loaded AI-generated reviewed and unreviewed counts will always be in position 2 and 3 of the terms obj
+      if (terms[2][1] == 0 && terms[3][1] == 0) {
+        setShowFilter(false);
+        changeLabel('');
+      } else {
+        setShowFilter(true);
+        changeLabel('AI-Generated Entries');
+      }
+    }
+  });
 
   return (
-    <div className={css('list-go', { stale: isStale })}>
-      <div className={css('filter')}>
-        {terms.map(([t, count]) => {
-          const term = t as Categories | 'All';
-          const checked =
-            (term === 'All' && !search.ai_category) ||
-            search.ai_category === categories[term as Categories];
-          return (
-            <label key={term} className={css('radio-btn-label', { checked })}>
-              <input
-                type="radio"
-                name="ai_category"
-                className={css('radio-btn')}
-                value={categories[term as Categories] || 'All'}
-                disabled={isStale}
-                onChange={_handleSelection}
-                checked={checked}
-                style={{ margin: '0.25em' }}
-              />
-              <span>{term}</span>
+    showFilter && (
+      <div className={css('list-go', { stale: isStale })}>
+        <div className={css('filter')}>
+          {terms.map(([t, count]) => {
+            const term = t as Categories | 'All';
+            const checked =
+              (term === 'All' && !search.ai_category) ||
+              search.ai_category === categories[term as Categories];
+            return (
+              <label key={term} className={css('radio-btn-label', { checked })}>
+                <input
+                  type="radio"
+                  name="ai_category"
+                  className={css('radio-btn')}
+                  value={categories[term as Categories] || 'All'}
+                  disabled={isStale}
+                  onChange={_handleSelection}
+                  checked={checked}
+                  style={{ margin: '0.25em' }}
+                />
+                <span>{term}</span>
 
-              {typeof count === 'undefined' || isNaN(count) ? null : (
-                <NumberComponent
-                  label
-                  loading={loading}
-                  className={css('filter-label')}
-                  abbr
-                >
-                  {count}
-                </NumberComponent>
-              )}
-            </label>
-          );
-        })}
+                {typeof count === 'undefined' || isNaN(count) ? null : (
+                  <NumberComponent
+                    label
+                    loading={loading}
+                    className={css('filter-label')}
+                    abbr
+                  >
+                    {count}
+                  </NumberComponent>
+                )}
+              </label>
+            );
+          })}
+        </div>
       </div>
-    </div>
+    )
   );
 };
 

--- a/src/components/Entry/EntryListFilters/GOTermsFilter/index.tsx
+++ b/src/components/Entry/EntryListFilters/GOTermsFilter/index.tsx
@@ -65,7 +65,7 @@ const GOTermsFilter = ({
     terms.unshift(['All', NaN]);
   }
   return (
-    <div className={css('list-go', { stale: isStale })}>
+    <div className={css({ stale: isStale })}>
       <div className={css('filter')}>
         {terms.map(([t, count]) => {
           const term = t as Categories | 'All';

--- a/src/components/Entry/EntryListFilters/__snapshots__/test.js.snap
+++ b/src/components/Entry/EntryListFilters/__snapshots__/test.js.snap
@@ -11,5 +11,8 @@ exports[`<EntryListFilter /> should render 1`] = `
   <Memo(Connect(loadData(LatestFilter)))
     label="New entries"
   />
+  <Memo(Connect(loadData(AIGeneratedFilter)))
+    label="AI-Generated entries"
+  />
 </Memo(Connect(FiltersPanel))>
 `;

--- a/src/components/Entry/EntryListFilters/__snapshots__/test.js.snap
+++ b/src/components/Entry/EntryListFilters/__snapshots__/test.js.snap
@@ -12,7 +12,8 @@ exports[`<EntryListFilter /> should render 1`] = `
     label="New entries"
   />
   <Memo(Connect(loadData(AIGeneratedFilter)))
-    label="AI-Generated entries"
+    changeLabel={[Function]}
+    label="AI-Generated Entries"
   />
 </Memo(Connect(FiltersPanel))>
 `;

--- a/src/components/Entry/EntryListFilters/__snapshots__/test.js.snap
+++ b/src/components/Entry/EntryListFilters/__snapshots__/test.js.snap
@@ -12,7 +12,6 @@ exports[`<EntryListFilter /> should render 1`] = `
     label="New entries"
   />
   <Memo(Connect(loadData(AIGeneratedFilter)))
-    changeLabel={[Function]}
     label="AI-Generated Entries"
   />
 </Memo(Connect(FiltersPanel))>

--- a/src/components/Entry/EntryListFilters/index.tsx
+++ b/src/components/Entry/EntryListFilters/index.tsx
@@ -12,8 +12,6 @@ import AIGeneratedFilter from './AIGeneratedFilter';
 
 type Props = { mainDB?: string };
 export const EntryListFilter = ({ mainDB }: Props) => {
-  const [AILabel, setAILabel] = useState('AI-Generated Entries');
-
   return (
     <FiltersPanel>
       <EntryTypeFilter
@@ -24,7 +22,7 @@ export const EntryListFilter = ({ mainDB }: Props) => {
       {mainDB !== 'InterPro' && <IntegratedFilter label="InterPro State" />}
       {mainDB === 'InterPro' && <GOTermsFilter label="GO Terms" />}
       {mainDB === 'InterPro' && <LatestFilter label="New entries" />}
-      <AIGeneratedFilter label={AILabel} changeLabel={setAILabel} />
+      <AIGeneratedFilter label="AI-Generated Entries" />
     </FiltersPanel>
   );
 };

--- a/src/components/Entry/EntryListFilters/index.tsx
+++ b/src/components/Entry/EntryListFilters/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 
 import { createSelector } from 'reselect';
@@ -11,21 +11,23 @@ import GOTermsFilter from './GOTermsFilter';
 import AIGeneratedFilter from './AIGeneratedFilter';
 
 type Props = { mainDB?: string };
-export const EntryListFilter = ({ mainDB }: Props) => (
-  <FiltersPanel>
-    <EntryTypeFilter
-      label={`${
-        mainDB === 'InterPro' ? 'InterPro' : 'Member Database Entry'
-      } Type`}
-    />
-    {mainDB !== 'InterPro' && <IntegratedFilter label="InterPro State" />}
-    {mainDB === 'InterPro' && <GOTermsFilter label="GO Terms" />}
-    {mainDB === 'InterPro' && <LatestFilter label="New entries" />}
-    {mainDB === 'InterPro' && (
-      <AIGeneratedFilter label="AI-Generated entries" />
-    )}
-  </FiltersPanel>
-);
+export const EntryListFilter = ({ mainDB }: Props) => {
+  const [AILabel, setAILabel] = useState('AI-Generated Entries');
+
+  return (
+    <FiltersPanel>
+      <EntryTypeFilter
+        label={`${
+          mainDB === 'InterPro' ? 'InterPro' : 'Member Database Entry'
+        } Type`}
+      />
+      {mainDB !== 'InterPro' && <IntegratedFilter label="InterPro State" />}
+      {mainDB === 'InterPro' && <GOTermsFilter label="GO Terms" />}
+      {mainDB === 'InterPro' && <LatestFilter label="New entries" />}
+      <AIGeneratedFilter label={AILabel} changeLabel={setAILabel} />
+    </FiltersPanel>
+  );
+};
 
 const mapStateToProps = createSelector(
   (state: GlobalState) =>

--- a/src/components/Entry/EntryListFilters/index.tsx
+++ b/src/components/Entry/EntryListFilters/index.tsx
@@ -8,6 +8,7 @@ import EntryTypeFilter from './EntryTypeFilter';
 import IntegratedFilter from './IntegratedFilter';
 import LatestFilter from './LatestFilter';
 import GOTermsFilter from './GOTermsFilter';
+import AIGeneratedFilter from './AIGeneratedFilter';
 
 type Props = { mainDB?: string };
 export const EntryListFilter = ({ mainDB }: Props) => (
@@ -20,6 +21,9 @@ export const EntryListFilter = ({ mainDB }: Props) => (
     {mainDB !== 'InterPro' && <IntegratedFilter label="InterPro State" />}
     {mainDB === 'InterPro' && <GOTermsFilter label="GO Terms" />}
     {mainDB === 'InterPro' && <LatestFilter label="New entries" />}
+    {mainDB === 'InterPro' && (
+      <AIGeneratedFilter label="AI-Generated entries" />
+    )}
   </FiltersPanel>
 );
 


### PR DESCRIPTION
This PR adds an AI filter to the Browse page for InterPro and MemberDBs entries.

- The filter follows the same logic of the GOTerm filter.
- It's not shown if there's no LLM generated entries for a MemberDB (e.g. Pfam)