### PR TITLE
Reorganize tracks

### DIFF
--- a/src/components/Protein/Isoforms/Viewer/index.tsx
+++ b/src/components/Protein/Isoforms/Viewer/index.tsx
@@ -8,7 +8,7 @@ import descriptionToPath from 'utils/processDescription/descriptionToPath';
 import NumberComponent from 'components/NumberComponent';
 import { groupByEntryType } from 'components/Related/DomainsOnProtein';
 import { byEntryType } from 'components/Related/DomainsOnProtein/DomainsOnProteinLoaded';
-import { selectRepresentativeDomains } from 'components/ProteinViewer/utils';
+import { selectRepresentativeData } from 'components/ProteinViewer/utils';
 import Loading from 'components/SimpleCommonComponents/Loading';
 
 import loadable from 'higherOrder/loadable';
@@ -70,9 +70,10 @@ const features2protvista = (features: FeatureMap) => {
   ];
 
   const sortedCategories = categories.sort(byEntryType);
-  const representativeDomains = selectRepresentativeDomains(
+  const representativeDomains = selectRepresentativeData(
     featArray,
     'locations',
+    'domain'
   );
 
   if (representativeDomains?.length) {

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -50,9 +50,13 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
   if (entry.source_database === 'mobidblt') {
     return (
       <>
-        <Link target="_blank" href={`https://mobidb.org/${entry.protein}`}>
-          {entry.accession}
-        </Link>
+        {isPrinting ? (
+          <span>{entry.accession}</span>
+        ) : (
+          <Link target="_blank" href={`https://mobidb.org/${entry.protein}`}>
+            {entry.accession}
+          </Link>
+        )}
         {entry.children &&
           entry.children.map((d) => (
             <div

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { NOT_MEMBER_DBS } from 'menuConfig';
 import Link from 'components/generic/Link';
+
 import {
   Genome3dLink,
   AlphafoldLink,
@@ -25,6 +26,7 @@ type PropsEL = {
 };
 
 const EXCEPTIONAL_TYPES = [
+  'disordered_regions',
   'residue',
   'sequence_conservation',
   'chain',
@@ -46,13 +48,24 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
     entry.accession) as string;
 
   if (entry.source_database === 'mobidblt') {
-    const mobiLabel = `MobiDB-lite: ${label.replace('Mobidblt-', '')}`;
-    return isPrinting ? (
-      <span>{mobiLabel}</span>
-    ) : (
-      <Link href={`https://mobidb.org/${entry.protein}`}>{mobiLabel}</Link>
+    return (
+      <>
+        <Link target="_blank" href={`https://mobidb.org/${entry.protein}`}>
+          {entry.accession}
+        </Link>
+        {entry.children &&
+          entry.children.map((d) => (
+            <div
+              className={css('track-accession-child')}
+              key={`main_${d.accession}`}
+            >
+              {d.accession}
+            </div>
+          ))}
+      </>
     );
   }
+
   if (entry.source_database === 'funfam') {
     return isPrinting ? (
       <span>{label}</span>
@@ -103,8 +116,33 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
         Go to UniProt
       </Link>
     );
-  if (entry.type === 'residue')
-    return <span>{entry.locations?.[0]?.description || ''}</span>;
+
+  if (entry.type === 'residue') {
+    const processedAccession = entry.accession.replace('residue:', '');
+    return isPrinting ? (
+      <span>Residue: {processedAccession}</span>
+    ) : (
+      <>
+        {entry.source_database !== 'pirsr' && (
+          <Link
+            to={{
+              description: {
+                main: { key: 'entry' },
+                entry: {
+                  db: entry.source_database,
+                  accession: processedAccession,
+                },
+              },
+            }}
+          >
+            {processedAccession}
+          </Link>
+        )}
+        <div>{entry.locations?.[0].description}</div>
+      </>
+    );
+  }
+
   if (
     NOT_MEMBER_DBS.has(entry.source_database || '') ||
     entry.type === 'chain' ||

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -26,7 +26,7 @@ type PropsEL = {
 };
 
 const EXCEPTIONAL_TYPES = [
-  'disordered_regions',
+  'intrinsically_disordered_regions',
   'residue',
   'sequence_conservation',
   'chain',

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -54,7 +54,7 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
           <span>{entry.accession}</span>
         ) : (
           <Link target="_blank" href={`https://mobidb.org/${entry.protein}`}>
-            {entry.accession}
+            {entry.accession.replace('Mobidblt-', 'MobiDB-lite: ')}
           </Link>
         )}
         {entry.children &&
@@ -63,7 +63,7 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
               className={css('track-accession-child')}
               key={`main_${d.accession}`}
             >
-              {d.accession}
+              {d.accession.replace('Mobidblt-', '')}
             </div>
           ))}
       </>

--- a/src/components/ProteinViewer/Options/style.css
+++ b/src/components/ProteinViewer/Options/style.css
@@ -27,6 +27,7 @@
   align-items: center;
   justify-content: flex-end;
   font-size: 90%;
+  margin-left: auto;
 }
 
 .view-options select {

--- a/src/components/ProteinViewer/Popup/Entry/index.tsx
+++ b/src/components/ProteinViewer/Popup/Entry/index.tsx
@@ -117,27 +117,20 @@ const ProtVistaEntryPopup = ({
       )}
 
       {integrated ? (
-        <p>
-          Integrated in &nbsp;
-          <span>
-            <Link
-              to={{
-                description: {
-                  main: { key: 'entry' },
-                  entry: {
-                    db: 'interpro',
-                    accession: integrated,
-                  },
-                },
-              }}
-            >
-              {integrated}
-            </Link>
-          </span>
-        </p>
-      ) : (
-        <p> Not integrated </p>
-      )}
+        <h6>
+          Integrated:{' '}
+          <Link
+            to={{
+              description: {
+                main: { key: 'entry' },
+                entry: { db: 'interpro', accession: integrated },
+              },
+            }}
+          >
+            <span style={{ color: 'white' }}>{integrated}</span>
+          </Link>
+        </h6>
+      ) : null}
       <ul>
         {(newLocations || locations || []).map(
           ({ fragments, model_acc: model, subfamily }, j) => (

--- a/src/components/ProteinViewer/Popup/Entry/index.tsx
+++ b/src/components/ProteinViewer/Popup/Entry/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Positions from '../Positions';
+import Link from 'components/generic/Link';
 
 import cssBinder from 'styles/cssBinder';
 import ipro from 'styles/interpro-vf.css';
@@ -11,6 +12,7 @@ export type EntryDetail = {
   target?: HTMLElement;
   feature?: {
     accession: string;
+    integrated: string;
     description: string;
     name: string;
     type: string;
@@ -53,6 +55,9 @@ const ProtVistaEntryPopup = ({
     confidence,
   } = detail?.feature || {};
   const isInterPro = sourceDatabase.toLowerCase() === 'interpro';
+  const integrated = detail.feature?.integrated;
+
+  console.log(integrated);
 
   // To include the type of fragment of the secondary structure
   let type = originalType;
@@ -110,6 +115,29 @@ const ProtVistaEntryPopup = ({
           <small>({entry})</small>
         </p>
       )}
+
+      {integrated ? (
+        <p>
+          Integrated in &nbsp;
+          <span>
+            <Link
+              to={{
+                description: {
+                  main: { key: 'entry' },
+                  entry: {
+                    db: 'interpro',
+                    accession: integrated,
+                  },
+                },
+              }}
+            >
+              {integrated}
+            </Link>
+          </span>
+        </p>
+      ) : (
+        <p> Not integrated </p>
+      )}
       <ul>
         {(newLocations || locations || []).map(
           ({ fragments, model_acc: model, subfamily }, j) => (
@@ -130,7 +158,7 @@ const ProtVistaEntryPopup = ({
               )}
               <Positions fragments={fragments} protein={protein} />
             </li>
-          )
+          ),
         )}
       </ul>
       {confidence && <p>Confidence: {confidence}</p>}

--- a/src/components/ProteinViewer/Popup/Entry/index.tsx
+++ b/src/components/ProteinViewer/Popup/Entry/index.tsx
@@ -57,8 +57,6 @@ const ProtVistaEntryPopup = ({
   const isInterPro = sourceDatabase.toLowerCase() === 'interpro';
   const integrated = detail.feature?.integrated;
 
-  console.log(integrated);
-
   // To include the type of fragment of the secondary structure
   let type = originalType;
   if (originalType === 'secondary_structure' && locations) {

--- a/src/components/ProteinViewer/Popup/Residue/index.tsx
+++ b/src/components/ProteinViewer/Popup/Residue/index.tsx
@@ -12,6 +12,7 @@ export type ResidueDetail = {
       end: number;
     };
   };
+  highlight: string;
 };
 type Props = {
   detail: ResidueDetail;
@@ -20,22 +21,17 @@ type Props = {
 
 const ProtVistaResiduePopup = ({ detail, sourceDatabase }: Props) => {
   if (!detail?.feature) return null;
-  let { accession, currentResidue } = detail.feature;
+
+  let accession = detail.feature.accession;
 
   if (sourceDatabase === 'PIRSF') {
     accession = accession.replace('PIRSF', 'PIRSR');
-  }
-  if (sourceDatabase === 'PIRSR') {
     accession = accession.replace(/\.\d+/, '');
-
-    currentResidue = detail?.feature.locations[0].fragments[0];
-    currentResidue.description = detail?.feature.locations[0].description;
   }
-  const start = currentResidue?.start;
-  const end = currentResidue?.end;
-  const description = currentResidue?.description || '';
-  const residue = currentResidue?.residue || currentResidue?.residues || '';
-  const hasMultiple = end && end !== start;
+
+  const residueLocation: ProtVistaLocation = detail?.feature.locations[0];
+  const residueDescription: string = residueLocation.description || '';
+
   return (
     <section>
       <h6>
@@ -44,10 +40,10 @@ const ProtVistaResiduePopup = ({ detail, sourceDatabase }: Props) => {
           ? accession.split('residue:')[1]
           : accession}
       </h6>
-      {description && <p>[{description}]</p>}
+      {residueDescription && <p>{residueDescription}</p>}
       <div>
-        Residue{hasMultiple && 's'}: {start}
-        {hasMultiple && `-${end}`} ({residue})
+        // Display only the position of the currently highlighted residue
+        Residue({detail.highlight.split(':')[0]})
       </div>
     </section>
   );

--- a/src/components/ProteinViewer/Popup/Residue/index.tsx
+++ b/src/components/ProteinViewer/Popup/Residue/index.tsx
@@ -42,8 +42,8 @@ const ProtVistaResiduePopup = ({ detail, sourceDatabase }: Props) => {
       </h6>
       {residueDescription && <p>{residueDescription}</p>}
       <div>
-        // Display only the position of the currently highlighted residue
-        Residue({detail.highlight.split(':')[0]})
+        {/* Display only the position of the currently highlighted residue */}
+        Residue ({detail.highlight.split(':')[0]})
       </div>
     </section>
   );

--- a/src/components/ProteinViewer/Popup/index.tsx
+++ b/src/components/ProteinViewer/Popup/index.tsx
@@ -8,6 +8,7 @@ import ProtVistaConservationPopup, { ConservationDetail } from './Conservation';
 import Genome3DPopup, { Genome3DDetail } from './Genome3D';
 import RepeatsDBPopup, { RepeatsDBDetail } from './RepeatsDB';
 import DisProtPopup, { DisProtDetail } from './DisProt';
+import { ExtendedFeature } from '..';
 
 export type PopupDetail = (
   | ConservationDetail
@@ -31,11 +32,7 @@ const ProtVistaPopup = ({ detail, sourceDatabase, currentLocation }: Props) => {
   }
 
   // comes from a residue
-  if (
-    (detail?.target?.classList &&
-      detail.target.classList.contains('residue')) ||
-    sourceDatabase === 'PIRSR'
-  ) {
+  if ((detail.feature as ExtendedFeature).type === 'residue') {
     return (
       <ProtVistaResiduePopup
         detail={detail as ResidueDetail}

--- a/src/components/ProteinViewer/Popup/index.tsx
+++ b/src/components/ProteinViewer/Popup/index.tsx
@@ -32,7 +32,10 @@ const ProtVistaPopup = ({ detail, sourceDatabase, currentLocation }: Props) => {
   }
 
   // comes from a residue
-  if ((detail.feature as ExtendedFeature).type === 'residue') {
+  if (
+    (detail.feature as ExtendedFeature).type === 'residue' ||
+    (detail.feature as ExtendedFeature).residues !== undefined
+  ) {
     return (
       <ProtVistaResiduePopup
         detail={detail as ResidueDetail}

--- a/src/components/ProteinViewer/ShowMoreTracks/index.tsx
+++ b/src/components/ProteinViewer/ShowMoreTracks/index.tsx
@@ -19,10 +19,13 @@ const ShowMoreTracks = ({ showMore, showMoreChanged }: Props) => {
   return (
     <div>
       <button
-        style={{ boxShadow: 'none' }}
+        style={{
+          boxShadow: 'none',
+          transform: 'none',
+        }}
         className={css(
           'vf-button',
-          'vf-button--link',
+          'vf-button--secondary',
           'vf-button--sm',
           'showmore-btn',
         )}

--- a/src/components/ProteinViewer/ShowMoreTracks/index.tsx
+++ b/src/components/ProteinViewer/ShowMoreTracks/index.tsx
@@ -1,32 +1,39 @@
-
 import React from 'react';
 import cssBinder from 'styles/cssBinder';
-import styles from './style.css'
+import styles from './style.css';
 
 import tooltip from 'components/SimpleCommonComponents/Tooltip/style.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 
 const css = cssBinder(styles, fonts, tooltip);
 
-
 type Props = {
-    showMore: boolean,
-    showMoreChanged: (v: boolean) => void;
-}
+  showMore: boolean;
+  showMoreChanged: (v: boolean) => void;
+};
 
-{/* Button to show/hide all secondary tracks (maintains internal view/show state of the specific track)*/ }
-const ShowMoreTracks = ({
-    showMore, 
-    showMoreChanged
-}: Props) => {
-    console.log(showMore)
-    return (
-        <div className={css('showmore-btn')}>
-            <button style = {{boxShadow: "none"}} className={css("vf-button vf-button--link vf-button--sm")} onClick={() => {showMoreChanged(!showMore)}}>
-                {showMore ? "Show less tracks" : "Show more tracks"}
-            </button>
-        </div>
-    )
+{
+  /* Button to show/hide all secondary tracks (maintains internal view/show state of the specific track)*/
 }
+const ShowMoreTracks = ({ showMore, showMoreChanged }: Props) => {
+  return (
+    <div>
+      <button
+        style={{ boxShadow: 'none' }}
+        className={css(
+          'vf-button',
+          'vf-button--link',
+          'vf-button--sm',
+          'showmore-btn',
+        )}
+        onClick={() => {
+          showMoreChanged(!showMore);
+        }}
+      >
+        {showMore ? 'Show less annotations' : 'Show more annotations'}
+      </button>
+    </div>
+  );
+};
 
-export default ShowMoreTracks
+export default ShowMoreTracks;

--- a/src/components/ProteinViewer/ShowMoreTracks/index.tsx
+++ b/src/components/ProteinViewer/ShowMoreTracks/index.tsx
@@ -30,7 +30,7 @@ const ShowMoreTracks = ({ showMore, showMoreChanged }: Props) => {
           showMoreChanged(!showMore);
         }}
       >
-        {showMore ? 'Show less annotations' : 'Show more annotations'}
+        {showMore ? 'Show less annotations' : 'Show all annotations'}
       </button>
     </div>
   );

--- a/src/components/ProteinViewer/ShowMoreTracks/index.tsx
+++ b/src/components/ProteinViewer/ShowMoreTracks/index.tsx
@@ -1,0 +1,32 @@
+
+import React from 'react';
+import cssBinder from 'styles/cssBinder';
+import styles from './style.css'
+
+import tooltip from 'components/SimpleCommonComponents/Tooltip/style.css';
+import fonts from 'EBI-Icon-fonts/fonts.css';
+
+const css = cssBinder(styles, fonts, tooltip);
+
+
+type Props = {
+    showMore: boolean,
+    showMoreChanged: (v: boolean) => void;
+}
+
+{/* Button to show/hide all secondary tracks (maintains internal view/show state of the specific track)*/ }
+const ShowMoreTracks = ({
+    showMore, 
+    showMoreChanged
+}: Props) => {
+    console.log(showMore)
+    return (
+        <div className={css('showmore-btn')}>
+            <button style = {{boxShadow: "none"}} className={css("vf-button vf-button--link vf-button--sm")} onClick={() => {showMoreChanged(!showMore)}}>
+                {showMore ? "Show less tracks" : "Show more tracks"}
+            </button>
+        </div>
+    )
+}
+
+export default ShowMoreTracks

--- a/src/components/ProteinViewer/ShowMoreTracks/style.css
+++ b/src/components/ProteinViewer/ShowMoreTracks/style.css
@@ -1,4 +1,3 @@
 .showmore-btn {
-  margin-right: -5px;
-  padding: 0px;
+  margin: 0;
 }

--- a/src/components/ProteinViewer/ShowMoreTracks/style.css
+++ b/src/components/ProteinViewer/ShowMoreTracks/style.css
@@ -1,7 +1,4 @@
 .showmore-btn {
-    text-align: right;
-    margin-top: 10px; 
-    margin-right: -25px;
-    margin-bottom: -10px;
-    padding: 0px;
+  margin-right: -5px;
+  padding: 0px;
 }

--- a/src/components/ProteinViewer/ShowMoreTracks/style.css
+++ b/src/components/ProteinViewer/ShowMoreTracks/style.css
@@ -1,0 +1,7 @@
+.showmore-btn {
+    text-align: right;
+    margin-top: 10px; 
+    margin-right: -25px;
+    margin-bottom: -10px;
+    padding: 0px;
+}

--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -323,6 +323,23 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                           use-ctrl-to-zoom
                         />
                       )}
+                      {entry.type === 'ptm' && ( <></>
+                        /*<NightingaleColoredSequence
+                          id={getTrackAccession(entry.accession)}
+                          data={entry.data as string}
+                          length={sequence.length}
+                          scale="H:90,M:70,L:50,D:0"
+                          height={12}
+                          color-range="#ff7d45:0,#ffdb13:50,#65cbf3:70,#0053d6:90,#0053d6:100"
+                          margin-right={10}
+                          margin-left={20}
+                          margin-color="#fafafa"
+                          highlight-event="onmouseover"
+                          highlight-color={highlightColor}
+                          className="confidence"
+                          use-ctrl-to-zoom
+                        />*/
+                      )}
                       {entry.type === 'variation' && (
                         <NightingaleVariation
                           id={getTrackAccession(entry.accession)}

--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -76,6 +76,7 @@ const mapToFeatures = (entry: ExtendedFeature, colorDomainsBy: string) =>
     accession: entry.accession,
     name: entry.name,
     short_name: entry.short_name,
+    integrated: entry.integrated,
     source_database: entry.source_database,
     locations: [loc],
     color: getTrackColor(entry, colorDomainsBy),
@@ -97,6 +98,7 @@ const mapToContributors = (entry: ExtendedFeature, colorDomainsBy: string) =>
     source_database: child.source_database,
     entry_type: child.entry_type,
     type: child.type,
+    integrated: child.integrated,
     locations: (child.entry_protein_locations || child.locations || []).map(
       (loc) => ({
         ...loc,
@@ -180,7 +182,7 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                 ?.name ||
               detail.feature?.source_database ||
               '';
-            if (customLocation)
+            if (customLocation) {
               openTooltip(
                 detail.target,
                 <ProtVistaPopup
@@ -189,6 +191,7 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                   currentLocation={customLocation}
                 />,
               );
+            }
             break;
           }
           default:
@@ -323,7 +326,8 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                           use-ctrl-to-zoom
                         />
                       )}
-                      {entry.type === 'ptm' && ( <></>
+                      {entry.type === 'ptm' && (
+                        <></>
                         /*<NightingaleColoredSequence
                           id={getTrackAccession(entry.accession)}
                           data={entry.data as string}

--- a/src/components/ProteinViewer/grid.css
+++ b/src/components/ProteinViewer/grid.css
@@ -11,9 +11,10 @@
 .protvista-grid .view-options-wrap {
   margin-top: 30px;
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   padding-bottom: 0.2rem;
+  margin-bottom: 10px;
 }
 .protvista-grid > header {
   background: #fafafa;

--- a/src/components/ProteinViewer/grid.css
+++ b/src/components/ProteinViewer/grid.css
@@ -12,10 +12,11 @@
   margin-top: 30px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   padding-bottom: 0.2rem;
   margin-bottom: 10px;
+  gap: 5px;
 }
+
 .protvista-grid > header {
   background: #fafafa;
   padding: 0.5rem 0.3rem;

--- a/src/components/ProteinViewer/grid.css
+++ b/src/components/ProteinViewer/grid.css
@@ -9,6 +9,7 @@
 }
 
 .protvista-grid .view-options-wrap {
+  margin-top: 30px;
   display: flex;
   align-items: baseline;
   justify-content: space-between;

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -34,7 +34,6 @@ import tooltip from 'components/SimpleCommonComponents/Tooltip/style.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import RepresentativeDomainsTrack from './RepresentativeDomainsTrack';
 import ShowMoreTracks from './ShowMoreTracks';
-import FeatureShape from '@nightingale-elements/nightingale-track/dist/FeatureShape';
 
 TracksInCategory.displayName = 'TracksInCategory';
 Header.displayName = 'TracksHeader';
@@ -130,10 +129,10 @@ export const ProteinViewer = ({
 
   // List of "main" tracks to be displayed, the rest are hidden by default
   const mainTracks = [
-    'AlphaFold confidence',
+    'alphafold confidence',
     'representative domains',
     'representative families',
-    'variants',
+    'pathogenic variants',
     'disordered regions',
     'residues',
   ];
@@ -154,7 +153,6 @@ export const ProteinViewer = ({
     features: true,
     predictions: true,
     'match conservation': true,
-    'Clinical significance: pathogenic and likely pathogenic variants': true,
   });
 
   const categoryRefs = useRef<ExpandedHandle[]>([]);
@@ -266,8 +264,6 @@ export const ProteinViewer = ({
               >
                 {children}
               </Options>
-            </div>
-            <div className={css('track-sized')}>
               <ShowMoreTracks
                 showMore={showMore}
                 showMoreChanged={setShowMore}
@@ -290,7 +286,6 @@ export const ProteinViewer = ({
               []
               {(data as unknown as ProteinViewerData<ExtendedFeature>)
                 .filter(([_, tracks]) => tracks && tracks.length)
-
                 .map(([type, entries, component]) => {
                   entries.forEach((entry: ExtendedFeature) => {
                     entry.protein = protein.accession;
@@ -305,15 +300,19 @@ export const ProteinViewer = ({
                   }
 
                   if (type == 'residues') {
-                    let residuesEntries: ExtendedFeature[] = [];
-                    residuesEntries = [...entries];
-                    for (let i = 0; i < residuesEntries.length; i++) {
-                      delete residuesEntries[i].entry_protein_locations;
-                      residuesEntries[i].type = 'residue';
-                      residuesEntries[i].locations = residuesToLocations(
-                        residuesEntries[i].residues,
-                      );
-                    }
+                    const residuesEntries: ExtendedFeature[] = [];
+                    entries.map((entry) => {
+                      const tempFeature: ExtendedFeature = {
+                        accession: entry.accession,
+                        name: entry.name,
+                        protein: entry.protein,
+                        source_database: entry.source_database,
+                        type: 'residue',
+                        locations: residuesToLocations(entry.residues),
+                      };
+                      residuesEntries.push(tempFeature);
+                    });
+
                     entries = residuesEntries;
                   }
 

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -139,25 +139,25 @@ export const ProteinViewer = ({
   ];
 
   const [hideCategory, setHideCategory] = useState<CategoryVisibility>({
-    'secondary structure': true,
-    family: true,
-    domain: true,
-    'homologous superfamily': true,
-    repeat: true,
-    'conserved site': true,
-    'active site': true,
-    'binding site': true,
-    ptm: true,
-    unintegrated: true,
-    'other features': true,
-    'other residues': true,
-    features: true,
-    predictions: true,
-    'match conservation': true,
-    'coiled-coils, signal peptides, transmembrane regions': true,
-    'short linear motifs': true,
-    'pfam-n': true,
-    funfam: true,
+    'secondary structure': false,
+    family: false,
+    domain: false,
+    'homologous superfamily': false,
+    repeat: false,
+    'conserved site': false,
+    'active site': false,
+    'binding site': false,
+    ptm: false,
+    unintegrated: false,
+    'other features': false,
+    'other residues': false,
+    features: false,
+    predictions: false,
+    'match conservation': false,
+    'coiled-coils, signal peptides, transmembrane regions': false,
+    'short linear motifs': false,
+    'pfam-n': false,
+    funfam: false,
   });
 
   const categoryRefs = useRef<ExpandedHandle[]>([]);
@@ -319,6 +319,10 @@ export const ProteinViewer = ({
                     });
 
                     entries = residuesEntries;
+                  }
+
+                  if (type == 'domain') {
+                    console.log(type, entries);
                   }
 
                   return (

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -132,7 +132,7 @@ export const ProteinViewer = ({
     'alphafold confidence',
     'representative domains',
     'representative families',
-    'pathogenic variants',
+    'pathogenic and likely pathogenic variants',
     'intrinsically disordered regions',
     'spurious proteins',
     'residues',
@@ -148,11 +148,6 @@ export const ProteinViewer = ({
     'active site': false,
     'binding site': false,
     ptm: false,
-    unintegrated: false,
-    'other features': false,
-    'other residues': false,
-    features: false,
-    predictions: false,
     'match conservation': false,
     'coiled-coils, signal peptides, transmembrane regions': false,
     'short linear motifs': false,
@@ -319,10 +314,6 @@ export const ProteinViewer = ({
                     });
 
                     entries = residuesEntries;
-                  }
-
-                  if (type == 'domain') {
-                    console.log(type, entries);
                   }
 
                   return (

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -133,7 +133,7 @@ export const ProteinViewer = ({
     'representative domains',
     'representative families',
     'pathogenic variants',
-    'disordered regions',
+    'intrinsically disordered regions',
     'spurious proteins',
     'residues',
   ];

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -210,20 +210,6 @@ export const ProteinViewer = ({
     }
   };
 
-  const residuesToLocations = (
-    residues: Residue[] | undefined,
-  ): ExtendedFeatureLocation[] => {
-    const newLocations: ExtendedFeatureLocation[] = [];
-    if (residues) {
-      residues.map((residue) => {
-        residue.locations.map((location) => {
-          newLocations.push(location);
-        });
-      });
-    }
-    return newLocations;
-  };
-
   return (
     <div ref={mainRef} className={css('fullscreenable', 'margin-bottom-large')}>
       <div
@@ -297,23 +283,6 @@ export const ProteinViewer = ({
                   let hideDiv: string = '';
                   if (!showMore && !mainTracks.includes(type)) {
                     hideDiv = 'none';
-                  }
-
-                  if (type == 'residues') {
-                    const residuesEntries: ExtendedFeature[] = [];
-                    entries.map((entry) => {
-                      const tempFeature: ExtendedFeature = {
-                        accession: entry.accession,
-                        name: entry.name,
-                        protein: entry.protein,
-                        source_database: entry.source_database,
-                        type: 'residue',
-                        locations: residuesToLocations(entry.residues),
-                      };
-                      residuesEntries.push(tempFeature);
-                    });
-
-                    entries = residuesEntries;
                   }
 
                   return (

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -33,6 +33,7 @@ import grid from './grid.css';
 import tooltip from 'components/SimpleCommonComponents/Tooltip/style.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import RepresentativeDomainsTrack from './RepresentativeDomainsTrack';
+import ShowMoreTracks from './ShowMoreTracks';
 
 TracksInCategory.displayName = 'TracksInCategory';
 Header.displayName = 'TracksHeader';
@@ -131,9 +132,9 @@ export const ProteinViewer = ({
   const mainTracks = [
     'AlphaFold confidence',
     'representative domains',
-    'representative families', // coming soon
+    'representative families', 
     'variants',
-    'disordered regions', // data coming from (?)
+    'disordered regions',
     'residues'
   ];
 
@@ -251,17 +252,19 @@ export const ProteinViewer = ({
               >
                 {children}
               </Options>
-
+            </div>
+            <div className={css('track-sized')}>
+              <ShowMoreTracks showMore={showMore} showMoreChanged={setShowMore} />
             </div>
           </div>
 
           <div ref={componentsRef} id={idRef.current}>
+
             <div
               className={css('protvista-grid', {
                 printing: isPrinting,
               })}
             >
-
               <Header
                 length={protein.length}
                 sequence={protein.sequence}
@@ -269,7 +272,7 @@ export const ProteinViewer = ({
                 ref={navigationRef}
               />
 
-[]
+              []
               {(data as unknown as ProteinViewerData<ExtendedFeature>)
                 .filter(([_, tracks]) => tracks && tracks.length)
 
@@ -281,7 +284,6 @@ export const ProteinViewer = ({
 
                   const LabelComponent = component?.component || 'span';
 
-
                   // Show only the main tracks unless button "Show more" is clicked
                   let hideDiv: string = ""
                   if (!showMore && !mainTracks.includes(type)) {
@@ -289,71 +291,82 @@ export const ProteinViewer = ({
                   }
 
                   return (
-                    <div
-                      key={type}
-                      // Conditioanally display the div containing the track
-                      style={{ display: hideDiv }}
-                      className={css(
-                        'tracks-container',
-                        'track-sized',
-                        'protvista-grid',
-                        {
-                          printing: isPrinting,
-                        },
-                      )}
-                    >
-                      <header >
-                        <button
-                          onClick={() =>
-                            setHideCategory(
-                              switchCategoryVisibility(hideCategory, type),
-                            )
-                          }
-                          className={css('as-text')}
-                        >
-                          <span
-                            className={css(
-                              'icon',
-                              'icon-common',
-                              hideCategory[type]
-                                ? 'icon-caret-right'
-                                : 'icon-caret-down',
-                            )}
-                          />{' '}
-                          {type}
-                        </button>
-                      </header>
-                      {component && (
-                        <div className={css('track-accession')}>
-                          <LabelComponent {...(component?.attributes || {})} />
-                        </div>
-                      )}{' '}
-                      {type === 'representative domains' ? (
-                        <RepresentativeDomainsTrack
-                          hideCategory={hideCategory[type]}
-                          highlightColor={highlightColor}
-                          entries={entries}
-                          length={protein.sequence.length}
-                          openTooltip={openTooltip}
-                          closeTooltip={closeTooltip}
-                          isPrinting={isPrinting}
-                        />
-                      ) : (
-                        <TracksInCategory
-                          entries={entries}
-                          sequence={protein.sequence}
-                          hideCategory={hideCategory[type]}
-                          highlightColor={highlightColor}
-                          openTooltip={openTooltip}
-                          closeTooltip={closeTooltip}
-                          isPrinting={isPrinting}
-                          ref={(ref: ExpandedHandle) =>
-                            categoryRefs.current.push(ref)
-                          }
-                          databases={dataBase?.payload?.databases}
-                        />
-                      )}
-                    </div>
+                      <div
+                        key={type}
+                        // Conditioanally display the div containing the track
+                        style={{ display: hideDiv }}
+                        className={css(
+                          'tracks-container',
+                          'track-sized',
+                          'protvista-grid',
+                          {
+                            printing: isPrinting,
+                          },
+                        )}
+                      >
+                        <header >
+                          <button
+                            onClick={() =>
+                              setHideCategory(
+                                switchCategoryVisibility(hideCategory, type),
+                              )
+                            }
+                            className={css('as-text')}
+                          >
+                            <span
+                              className={css(
+                                'icon',
+                                'icon-common',
+                                hideCategory[type]
+                                  ? 'icon-caret-right'
+                                  : 'icon-caret-down',
+                              )}
+                            />{' '}
+                            {type}
+                          </button>
+                        </header>
+                        {component && (
+                          <div className={css('track-accession')}>
+                            <LabelComponent {...(component?.attributes || {})} />
+                          </div>
+                        )}{' '}
+                        {type === 'representative domains' ? (
+                          <RepresentativeDomainsTrack
+                            hideCategory={hideCategory[type]}
+                            highlightColor={highlightColor}
+                            entries={entries}
+                            length={protein.sequence.length}
+                            openTooltip={openTooltip}
+                            closeTooltip={closeTooltip}
+                            isPrinting={isPrinting}
+                          />
+                        ) : (type === 'representative families') ? (
+                          <RepresentativeDomainsTrack
+                            hideCategory={hideCategory[type]}
+                            highlightColor={highlightColor}
+                            entries={entries}
+                            length={protein.sequence.length}
+                            openTooltip={openTooltip}
+                            closeTooltip={closeTooltip}
+                            isPrinting={isPrinting}
+                          />
+                        ) :
+                          (
+                            <TracksInCategory
+                              entries={entries}
+                              sequence={protein.sequence}
+                              hideCategory={hideCategory[type]}
+                              highlightColor={highlightColor}
+                              openTooltip={openTooltip}
+                              closeTooltip={closeTooltip}
+                              isPrinting={isPrinting}
+                              ref={(ref: ExpandedHandle) =>
+                                categoryRefs.current.push(ref)
+                              }
+                              databases={dataBase?.payload?.databases}
+                            />
+                          )}
+                      </div>
                   );
                 })}
               <ConservationMockupTrack
@@ -363,14 +376,8 @@ export const ProteinViewer = ({
                 isPrinting={isPrinting}
               />
 
-              {/* Button to show/hide all secondary tracks (maintains internal view/show state of the specific track)*/}
-              <div className={css('showmore-btn')}>
-                <button className={css("vf-button vf-button--tertiary vf-button--sm")} onClick={() => { setShowMore(!showMore) }}>
-                  {showMore ? "Show Less" : "Show More "}
-                </button>
-              </div>
-
             </div>
+
           </div>
         </NightingaleManager>
       </div>

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -134,6 +134,7 @@ export const ProteinViewer = ({
     'representative families',
     'pathogenic variants',
     'disordered regions',
+    'spurious proteins',
     'residues',
   ];
 
@@ -153,6 +154,10 @@ export const ProteinViewer = ({
     features: true,
     predictions: true,
     'match conservation': true,
+    'coiled-coils, signal peptides, transmembrane regions': true,
+    'short linear motifs': true,
+    'pfam-n': true,
+    funfam: true,
   });
 
   const categoryRefs = useRef<ExpandedHandle[]>([]);
@@ -314,6 +319,10 @@ export const ProteinViewer = ({
                     });
 
                     entries = residuesEntries;
+                  }
+
+                  if (type == 'other features') {
+                    console.log(entries);
                   }
 
                   return (

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -321,10 +321,6 @@ export const ProteinViewer = ({
                     entries = residuesEntries;
                   }
 
-                  if (type == 'other features') {
-                    console.log(entries);
-                  }
-
                   return (
                     <div
                       key={type}

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -121,11 +121,41 @@ export const ProteinViewer = ({
   loading = false,
   children,
 }: LoadedProps) => {
+
   const [isPrinting, setPrinting] = useState(false);
+
+  // State variable to show/hide "secondary" tracks
+  const [showMore, setShowMore] = useState(false);
+
+  // List of "main" tracks to be displayed, the rest are hidden by default
+  const mainTracks = [
+    'AlphaFold confidence',
+    'representative domains',
+    'representative families', // coming soon
+    'variants',
+    'disordered regions', // data coming from (?)
+    'residues'
+  ];
+
   const [hideCategory, setHideCategory] = useState<CategoryVisibility>({
+    'secondary structure': true,
+    'family': true,
+    'domain': true,
+    'homologous superfamily': true,
+    'repeat': true,
+    'conserved site': true,
+    'active site': true,
+    'binding site': true,
+    'ptm': true,
+    'unintegrated': true,
+    'other features': true,
     'other residues': true,
-    'external sources': true,
+    'features': true,
+    'predictions': true,
+    'match conservation': true,
+    'Clinical significance: pathogenic and likely pathogenic variants': true
   });
+
   const categoryRefs = useRef<ExpandedHandle[]>([]);
 
   const [_, setOverTooltip, overTooltipRef] = useStateRef(false);
@@ -221,32 +251,48 @@ export const ProteinViewer = ({
               >
                 {children}
               </Options>
+
             </div>
           </div>
+
           <div ref={componentsRef} id={idRef.current}>
             <div
               className={css('protvista-grid', {
                 printing: isPrinting,
               })}
             >
+
               <Header
                 length={protein.length}
                 sequence={protein.sequence}
                 highlightColor={highlightColor}
                 ref={navigationRef}
               />
+
+[]
               {(data as unknown as ProteinViewerData<ExtendedFeature>)
                 .filter(([_, tracks]) => tracks && tracks.length)
 
                 .map(([type, entries, component]) => {
                   entries.forEach((entry: ExtendedFeature) => {
                     entry.protein = protein.accession;
+
                   });
 
                   const LabelComponent = component?.component || 'span';
+
+
+                  // Show only the main tracks unless button "Show more" is clicked
+                  let hideDiv: string = ""
+                  if (!showMore && !mainTracks.includes(type)) {
+                    hideDiv = "none"
+                  }
+
                   return (
                     <div
                       key={type}
+                      // Conditioanally display the div containing the track
+                      style={{ display: hideDiv }}
                       className={css(
                         'tracks-container',
                         'track-sized',
@@ -256,7 +302,7 @@ export const ProteinViewer = ({
                         },
                       )}
                     >
-                      <header>
+                      <header >
                         <button
                           onClick={() =>
                             setHideCategory(
@@ -316,6 +362,14 @@ export const ProteinViewer = ({
                 conservationError={conservationError}
                 isPrinting={isPrinting}
               />
+
+              {/* Button to show/hide all secondary tracks (maintains internal view/show state of the specific track)*/}
+              <div className={css('showmore-btn')}>
+                <button className={css("vf-button vf-button--tertiary vf-button--sm")} onClick={() => { setShowMore(!showMore) }}>
+                  {showMore ? "Show Less" : "Show More "}
+                </button>
+              </div>
+
             </div>
           </div>
         </NightingaleManager>

--- a/src/components/ProteinViewer/style.css
+++ b/src/components/ProteinViewer/style.css
@@ -23,11 +23,6 @@
   cursor: move;
 }
 
-.showmore-btn {
-  text-align: end;
-  margin-top: 20px;
-}
-
 .track-length {
   display: flex;
   justify-content: space-between;

--- a/src/components/ProteinViewer/style.css
+++ b/src/components/ProteinViewer/style.css
@@ -12,6 +12,7 @@
   }
 }
 
+
 .track-row {
   display: flex;
 }
@@ -20,6 +21,11 @@
   max-height: 2rem;
   background: #fafafa;
   cursor: move;
+}
+
+.showmore-btn {
+  text-align: end;
+  margin-top: 20px;
 }
 
 .track-length {

--- a/src/components/ProteinViewer/style.css
+++ b/src/components/ProteinViewer/style.css
@@ -12,7 +12,6 @@
   }
 }
 
-
 .track-row {
   display: flex;
 }
@@ -186,4 +185,9 @@ body table.matches-in-table tr:first-of-type td {
 
 nightingale-manager {
   width: 100%;
+}
+
+g:global(.feature-group):has(g:global(.residues-group))
+  > g:global(.location-group) {
+  display: none;
 }

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -3,22 +3,25 @@ import { toPlural } from 'utils/pages/toPlural';
 import { NOT_MEMBER_DBS } from 'menuConfig';
 import { getTrackColor, EntryColorMode } from 'utils/entry-color';
 
-export const selectRepresentativeDomains = (
-  domains: Record<string, unknown>[],
+
+export const selectRepresentativeData = (
+  entries: Record<string, unknown>[],
   locationKey: string,
+  type: string,
 ) => {
-  const flatDomains = [];
-  for (const domain of domains) {
+  const flatRepresentativeData = [];
+
+  for (const entry of entries) {
     const { accession, short_name, name, source_database, integrated, chain } =
-      domain;
-    if (domain[locationKey] === null) {
+      entry;
+    if (entry[locationKey] === null || entry.type != type) {
       continue;
     }
-    for (const location of domain[locationKey] as Array<ProtVistaLocation>) {
+    for (const location of entry[locationKey] as Array<ProtVistaLocation>) {
       for (const fragment of location.fragments) {
         const { start, end } = fragment;
         if (location.representative) {
-          flatDomains.push({
+          flatRepresentativeData.push({
             accession,
             chain,
             short_name,
@@ -35,8 +38,9 @@ export const selectRepresentativeDomains = (
     }
   }
 
-  return flatDomains;
+  return flatRepresentativeData;
 };
+
 export const useProcessData = <M = Metadata>(
   results: EndpointWithMatchesPayload<M, MatchI>[] | undefined,
   endpoint: Endpoint,
@@ -71,10 +75,16 @@ const processData = <M = Metadata>(
     endpoint === 'structure'
       ? 'entry_structure_locations'
       : 'entry_protein_locations';
-  const representativeDomains = selectRepresentativeDomains(
-    results,
-    locationKey,
-  );
+
+
+  const representativeData = {
+    "domains": selectRepresentativeData(results, locationKey, "domain"),
+    "families": selectRepresentativeData(results, locationKey, "family")
+  }
+
+  const representativeDomains = representativeData['domains']
+  const representativeFamilies = representativeData["families"]
+
   const interproMap = new Map(
     interpro.map((ipro) => [
       `${ipro.accession}-${ipro.chain}-${ipro.protein}`,
@@ -105,6 +115,7 @@ const processData = <M = Metadata>(
     interpro,
     unintegrated,
     representativeDomains,
+    representativeFamilies,
     other: [],
   };
 };

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -3,7 +3,6 @@ import { toPlural } from 'utils/pages/toPlural';
 import { NOT_MEMBER_DBS } from 'menuConfig';
 import { getTrackColor, EntryColorMode } from 'utils/entry-color';
 
-
 export const selectRepresentativeData = (
   entries: Record<string, unknown>[],
   locationKey: string,
@@ -14,7 +13,7 @@ export const selectRepresentativeData = (
   for (const entry of entries) {
     const { accession, short_name, name, source_database, integrated, chain } =
       entry;
-    if (entry[locationKey] === null || entry.type != type) {
+    if (entry[locationKey] === null || entry.type !== type) {
       continue;
     }
     for (const location of entry[locationKey] as Array<ProtVistaLocation>) {
@@ -76,14 +75,13 @@ const processData = <M = Metadata>(
       ? 'entry_structure_locations'
       : 'entry_protein_locations';
 
-
   const representativeData = {
-    "domains": selectRepresentativeData(results, locationKey, "domain"),
-    "families": selectRepresentativeData(results, locationKey, "family")
-  }
+    domains: selectRepresentativeData(results, locationKey, 'domain'),
+    families: selectRepresentativeData(results, locationKey, 'family'),
+  };
 
-  const representativeDomains = representativeData['domains']
-  const representativeFamilies = representativeData["families"]
+  const representativeDomains = representativeData['domains'];
+  const representativeFamilies = representativeData['families'];
 
   const interproMap = new Map(
     interpro.map((ipro) => [

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -23,8 +23,8 @@ const FIRST_IN_ORDER = [
 ];
 
 const LASTS_IN_ORDER = [
+  'family', 
   'secondary_structure',
-  'family',
   'domain',
   'homologous_superfamily',
   'repeat',
@@ -49,8 +49,8 @@ export const byEntryType = (
     if (b.toLowerCase() === label) return 1;
   }
   for (const l of LASTS_IN_ORDER) {
-    if (a.toLowerCase() === l) return 1;
-    if (b.toLowerCase() === l) return -1;
+    if (a.toLowerCase() === l) return -1;
+    if (b.toLowerCase() === l) return 1;
   }
   return a > b ? 1 : 0;
 };
@@ -59,13 +59,18 @@ type tracksProps = {
   unintegrated: Array<MinimalFeature>;
   other?: Array<MinimalFeature>;
   representativeDomains?: Array<MinimalFeature>;
+  representativeFamilies?:  Array<MinimalFeature>;
+  disorderedRegions?:  Array<MinimalFeature>;
 };
 export const makeTracks = ({
   interpro,
   unintegrated,
   other,
   representativeDomains,
+  representativeFamilies,
+  disorderedRegions,
 }: tracksProps): ProteinViewerDataObject<MinimalFeature> => {
+  
   const groups = groupByEntryType(interpro);
   unintegrated.sort(orderByAccession);
   const mergedData: ProteinViewerDataObject<MinimalFeature> = {
@@ -75,7 +80,13 @@ export const makeTracks = ({
   if (other) mergedData.other_features = other;
   if (representativeDomains?.length)
     mergedData.representative_domains = representativeDomains;
+  if (representativeFamilies?.length)
+    mergedData.representative_families = representativeFamilies;
+  if (disorderedRegions?.length)
+    mergedData.disorderedRegions = disorderedRegions;
   return mergedData;
+
+  
 };
 
 export const flattenTracksObject = (
@@ -170,6 +181,8 @@ const DomainsOnProteinLoaded = ({
   children,
   title = 'Entry matches to this protein',
 }: Props) => {
+
+
   const sortedData = flattenTracksObject(dataMerged);
   const protein =
     (mainData as ProteinEntryPayload).metadata ||
@@ -199,7 +212,8 @@ const DomainsOnProteinLoaded = ({
       protein={protein}
       data={sortedData}
       title={title}
-      showConservationButton={showConservationButton}
+      show
+      ervationButton={showConservationButton}
       handleConservationLoad={handleConservationLoad}
       conservationError={conservationError}
       loading={loading}

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -13,17 +13,18 @@ const ProteinViewer = loadable({
   loading: null,
 });
 
+// 0A017SEX7 is a good example
 const UNDERSCORE = /_/g;
 const FIRST_IN_ORDER = [
   'representative_domains',
   'representative_families', // coming soon
   'variants',
   'disordered_regions', // data coming from (?)
-  'residues'
+  'residues',
 ];
 
 const LASTS_IN_ORDER = [
-  'family', 
+  'family',
   'secondary_structure',
   'domain',
   'homologous_superfamily',
@@ -59,8 +60,8 @@ type tracksProps = {
   unintegrated: Array<MinimalFeature>;
   other?: Array<MinimalFeature>;
   representativeDomains?: Array<MinimalFeature>;
-  representativeFamilies?:  Array<MinimalFeature>;
-  disorderedRegions?:  Array<MinimalFeature>;
+  representativeFamilies?: Array<MinimalFeature>;
+  disorderedRegions?: Array<MinimalFeature>;
 };
 export const makeTracks = ({
   interpro,
@@ -70,7 +71,6 @@ export const makeTracks = ({
   representativeFamilies,
   disorderedRegions,
 }: tracksProps): ProteinViewerDataObject<MinimalFeature> => {
-  
   const groups = groupByEntryType(interpro);
   unintegrated.sort(orderByAccession);
   const mergedData: ProteinViewerDataObject<MinimalFeature> = {
@@ -85,8 +85,6 @@ export const makeTracks = ({
   if (disorderedRegions?.length)
     mergedData.disorderedRegions = disorderedRegions;
   return mergedData;
-
-  
 };
 
 export const flattenTracksObject = (
@@ -137,7 +135,7 @@ export const addPTMTrack = (
         {
           accession: `ptm_${protein}`,
           data: proteomicsPayload,
-          type: "ptm", 
+          type: 'ptm',
           protein,
           source_database: 'proteinsAPI',
         },
@@ -181,8 +179,6 @@ const DomainsOnProteinLoaded = ({
   children,
   title = 'Entry matches to this protein',
 }: Props) => {
-
-
   const sortedData = flattenTracksObject(dataMerged);
   const protein =
     (mainData as ProteinEntryPayload).metadata ||
@@ -201,8 +197,8 @@ const DomainsOnProteinLoaded = ({
       );
   }
 
-  if (dataProteomics?.ok && dataProteomics.payload){
-    if (dataProteomics.payload.features.length > 0){
+  if (dataProteomics?.ok && dataProteomics.payload) {
+    if (dataProteomics.payload.features.length > 0) {
       /*addPTMTrack(dataProteomics.payload, protein.accession, sortedData);*/
     }
   }

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -19,7 +19,7 @@ const FIRST_IN_ORDER = [
   'representative_domains',
   'representative_families',
   'pathogenic_variants',
-  'disordered_regions',
+  'intrinsically_disordered_regions',
   'spurious_proteins',
   'residues',
 ];

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -20,6 +20,7 @@ const FIRST_IN_ORDER = [
   'representative_families',
   'pathogenic_variants',
   'disordered_regions',
+  'spurious_proteins',
   'residues',
 ];
 
@@ -28,6 +29,9 @@ const LASTS_IN_ORDER = [
   'secondary_structure',
   'domain',
   'homologous_superfamily',
+  'coiled-coils,_signal_peptides,_transmembrane_regions',
+  'short_linear_motifs',
+  'pfam-n',
   'repeat',
   'conserved_site',
   'active_site',

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -91,6 +91,7 @@ export const flattenTracksObject = (
       ])
   );
 };
+
 export const addVariationTrack = (
   variationPayload: ProteinsAPIVariation,
   protein: string,
@@ -113,6 +114,28 @@ export const addVariationTrack = (
   }
 };
 
+export const addPTMTrack = (
+  proteomicsPayload: ProteinsAPIProteomics,
+  protein: string,
+  tracks: ProteinViewerData,
+) => {
+  if (proteomicsPayload?.features?.length) {
+    const proteomicsTrack: [string, Array<unknown>] = [
+      'PTM Data',
+      [
+        {
+          accession: `ptm_${protein}`,
+          data: proteomicsPayload,
+          type: "ptm", 
+          protein,
+          source_database: 'proteinsAPI',
+        },
+      ],
+    ];
+    tracks.push(proteomicsTrack);
+  }
+};
+
 type Props = PropsWithChildren<{
   mainData:
     | {
@@ -126,6 +149,7 @@ type Props = PropsWithChildren<{
   dataMerged: ProteinViewerDataObject;
   dataConfidence?: RequestedData<AlphafoldConfidencePayload>;
   dataVariation?: RequestedData<ProteinsAPIVariation>;
+  dataProteomics?: RequestedData<ProteinsAPIProteomics>;
   conservationError?: string | null;
   showConservationButton?: boolean;
   handleConservationLoad?: () => void;
@@ -138,6 +162,7 @@ const DomainsOnProteinLoaded = ({
   dataMerged,
   dataConfidence,
   dataVariation,
+  dataProteomics,
   conservationError,
   showConservationButton,
   handleConservationLoad,
@@ -161,6 +186,12 @@ const DomainsOnProteinLoaded = ({
         protein.accession,
         sortedData,
       );
+  }
+
+  if (dataProteomics?.ok && dataProteomics.payload){
+    if (dataProteomics.payload.features.length > 0){
+      /*addPTMTrack(dataProteomics.payload, protein.accession, sortedData);*/
+    }
   }
 
   return (

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -17,28 +17,27 @@ const UNDERSCORE = /_/g;
 const FIRST_IN_ORDER = [
   'alphafold_confidence',
   'secondary_structure',
+  'spurious_proteins',
   'representative_domains',
   'representative_families',
   'pathogenic_and_likely_pathogenic_variants',
   'intrinsically_disordered_regions',
-  'spurious_proteins',
   'residues',
-];
-
-const LASTS_IN_ORDER = [
   'family',
   'domain',
   'homologous_superfamily',
-  'coiled-coils,_signal_peptides,_transmembrane_regions',
-  'short_linear_motifs',
-  'pfam-n',
   'repeat',
   'conserved_site',
   'active_site',
   'binding_site',
   'ptm',
-  'features',
-  'predictions',
+];
+
+const LASTS_IN_ORDER = [
+  'coiled-coils,_signal_peptides,_transmembrane_regions',
+  'short_linear_motifs',
+  'pfam-n',
+  'funfam',
   'match_conservation',
 ];
 
@@ -127,7 +126,7 @@ export const makeTracks = ({
   /* Logic to highlight matches from member DBs, not InterPro entries
       1. Remove Intepro entries as the "parent" of matches from member DBs.
       2. Merge unintegrated with result from (1.);
-      3. Sort matches in tracks based on their position but, if integrated, 
+      3. Sort matches in tracks based on their position but, if integrated,
       maintaining grouping for the same InterPro entry.
   */
 
@@ -140,9 +139,9 @@ export const makeTracks = ({
     allMatches as { accession: string; type: string }[],
   );
 
-  /* 3. 
+  /* 3.
         Group matches of the same type (e.g domain) by IntePro accession
-        sort matches by position within the same group, 
+        sort matches by position within the same group,
         sort all the groups based on first fragment of group.
   */
 
@@ -193,7 +192,7 @@ export const flattenTracksObject = (
   );
 };
 
-/* Processing of the payload needs to be slightly different 
+/* Processing of the payload needs to be slightly different
 to add tracks to the dataMerged object instead of the dataSorted object */
 export const addVariationTrack = (
   variationPayload: ProteinsAPIVariation,
@@ -272,8 +271,8 @@ const DomainsOnProteinLoaded = ({
     (mainData as ProteinEntryPayload).metadata ||
     (mainData as { payload: ProteinEntryPayload }).payload.metadata;
 
-  /* 
-  Special tracks are now added to the dataMerged object before being sorted based on FIRST_IN_ORDER. 
+  /*
+  Special tracks are now added to the dataMerged object before being sorted based on FIRST_IN_ORDER.
   Adding the tracks to the dataSorted object, caused the Alphafold track and variants track to be displayed always at the first/last position.
   */
   if (dataConfidence)

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -16,9 +16,10 @@ const UNDERSCORE = /_/g;
 
 const FIRST_IN_ORDER = [
   'alphafold_confidence',
+  'secondary_structure',
   'representative_domains',
   'representative_families',
-  'pathogenic_variants',
+  'pathogenic_and_likely_pathogenic_variants',
   'intrinsically_disordered_regions',
   'spurious_proteins',
   'residues',
@@ -26,7 +27,6 @@ const FIRST_IN_ORDER = [
 
 const LASTS_IN_ORDER = [
   'family',
-  'secondary_structure',
   'domain',
   'homologous_superfamily',
   'coiled-coils,_signal_peptides,_transmembrane_regions',
@@ -37,9 +37,6 @@ const LASTS_IN_ORDER = [
   'active_site',
   'binding_site',
   'ptm',
-  'unintegrated',
-  'other_features',
-  'other_residues',
   'features',
   'predictions',
   'match_conservation',
@@ -204,8 +201,8 @@ export const addVariationTrack = (
   tracks: ProteinViewerDataObject,
 ) => {
   if (variationPayload?.features?.length) {
-    tracks['pathogenic_variants'] = [];
-    tracks['pathogenic_variants'][0] = {
+    tracks['pathogenic_and_likely_pathogenic_variants'] = [];
+    tracks['pathogenic_and_likely_pathogenic_variants'][0] = {
       accession: `variation_${protein}`,
       data: variationPayload,
       type: 'variation',

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -16,6 +16,13 @@ const ProteinViewer = loadable({
 const UNDERSCORE = /_/g;
 const FIRST_IN_ORDER = [
   'representative_domains',
+  'representative_families', // coming soon
+  'variants',
+  'disordered_regions', // data coming from (?)
+  'residues'
+];
+
+const LASTS_IN_ORDER = [
   'secondary_structure',
   'family',
   'domain',
@@ -26,14 +33,13 @@ const FIRST_IN_ORDER = [
   'binding_site',
   'ptm',
   'unintegrated',
-];
-const LASTS_IN_ORDER = [
+  'other_features',
   'other_residues',
-  'residues',
   'features',
   'predictions',
   'match_conservation',
 ];
+
 export const byEntryType = (
   [a, _]: [string, unknown],
   [b, __]: [string, unknown],

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -228,7 +228,6 @@ const DomainOnProteinWithoutData = ({
       Using this logic we can go back to having the grouped entire section
     */
 
-    console.log(mergedData);
     const CPST = ['coils', 'phobius', 'signalp', 'tmhmm'];
     mergedData['coiled-coils,_signal_peptides,_transmembrane_regions'] =
       getFeature(CPST, 'other_features', mergedData) as MinimalFeature[];
@@ -242,14 +241,13 @@ const DomainOnProteinWithoutData = ({
       'other_features',
       mergedData,
     ) as MinimalFeature[];
-    mergedData['spurious_proteins'] = getFeature(
-      'antifam',
-      'other_features',
-      mergedData,
-    ) as MinimalFeature[];
-    mergedData['funfam'] = [];
 
-    console.log(mergedData);
+    if (Object.keys(mergedData).includes('region')) {
+      mergedData['spurious_proteins'] = mergedData['region'];
+      delete mergedData['region'];
+    }
+
+    // mergedData['funfam'] = [];
   }
   // if (conservation.data) {
   //   mergeConservationData(mergedData, conservation.data);

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -222,11 +222,11 @@ const DomainOnProteinWithoutData = ({
       mergedData,
     ) as MinimalFeature[];
 
-    /* 
-      Splitting the "other features" section in mulitple subsets
-      Using this logic we can go back to having the grouped entire section
+    /* Splitting the "other features" section in mulitple subsets.
+       Using this logic we can go back to having the "other_features" section again.
     */
 
+    // Create a section for each of the following types
     const CPST = ['coils', 'phobius', 'signalp', 'tmhmm'];
     mergedData['coiled-coils,_signal_peptides,_transmembrane_regions'] =
       getFeature(CPST, mergedData) as MinimalFeature[];
@@ -242,6 +242,16 @@ const DomainOnProteinWithoutData = ({
     }
 
     // mergedData['funfam'] = [];
+
+    // Filter the types above out of the "other_features" section
+    const toRemove = CPST.concat(['pfam-n', 'short_linear_motifs', 'mobidblt']);
+    mergedData['other_features'] = mergedData['other_features'].filter(
+      (entry) => {
+        return !toRemove.some((item) => entry.source_database?.includes(item));
+      },
+    );
+
+    /* End of logic for splitting "other_features" */
   }
   // if (conservation.data) {
   //   mergeConservationData(mergedData, conservation.data);

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -174,11 +174,10 @@ const DomainOnProteinWithoutData = ({
 
   const getFeature = (
     filter: string | string[],
-    existingSection: string,
     mergedData: ProteinViewerDataObject,
   ): ExtendedFeature[] => {
-    if (mergedData[existingSection]) {
-      return (mergedData[existingSection] as ExtendedFeature[]).filter(
+    if (mergedData['other_features']) {
+      return (mergedData['other_features'] as ExtendedFeature[]).filter(
         (entry) => {
           const entryDB = entry.source_database;
           if (entryDB) {
@@ -230,15 +229,10 @@ const DomainOnProteinWithoutData = ({
 
     const CPST = ['coils', 'phobius', 'signalp', 'tmhmm'];
     mergedData['coiled-coils,_signal_peptides,_transmembrane_regions'] =
-      getFeature(CPST, 'other_features', mergedData) as MinimalFeature[];
-    mergedData['pfam-n'] = getFeature(
-      'pfam-n',
-      'other_features',
-      mergedData,
-    ) as MinimalFeature[];
+      getFeature(CPST, mergedData) as MinimalFeature[];
+    mergedData['pfam-n'] = getFeature('pfam-n', mergedData) as MinimalFeature[];
     mergedData['short_linear_motifs'] = getFeature(
       'elm',
-      'other_features',
       mergedData,
     ) as MinimalFeature[];
 

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -172,6 +172,26 @@ const DomainOnProteinWithoutData = ({
     mergeResidues(mergedData, dataResidues.payload);
   }
 
+  const getFeature = (
+    filter: string | string[],
+    existingSection: string,
+    mergedData: ProteinViewerDataObject,
+  ): ExtendedFeature[] => {
+    if (mergedData[existingSection]) {
+      return (mergedData[existingSection] as ExtendedFeature[]).filter(
+        (entry) => {
+          const entryDB = entry.source_database;
+          if (entryDB) {
+            if (Array.isArray(filter))
+              return filter.some((item) => entryDB.includes(item));
+            else return filter.includes(entryDB);
+          }
+        },
+      );
+    }
+    return [];
+  };
+
   const filterMobiDBLiteFeatures = (
     mergedData: ProteinViewerDataObject,
   ): ExtendedFeature[] => {
@@ -202,6 +222,34 @@ const DomainOnProteinWithoutData = ({
     mergedData['disordered_regions'] = filterMobiDBLiteFeatures(
       mergedData,
     ) as MinimalFeature[];
+
+    /* 
+      Splitting the "other features" section in mulitple subsets
+      Using this logic we can go back to having the grouped entire section
+    */
+
+    console.log(mergedData);
+    const CPST = ['coils', 'phobius', 'signalp', 'tmhmm'];
+    mergedData['coiled-coils,_signal_peptides,_transmembrane_regions'] =
+      getFeature(CPST, 'other_features', mergedData) as MinimalFeature[];
+    mergedData['pfam-n'] = getFeature(
+      'pfam-n',
+      'other_features',
+      mergedData,
+    ) as MinimalFeature[];
+    mergedData['short_linear_motifs'] = getFeature(
+      'elm',
+      'other_features',
+      mergedData,
+    ) as MinimalFeature[];
+    mergedData['spurious_proteins'] = getFeature(
+      'antifam',
+      'other_features',
+      mergedData,
+    ) as MinimalFeature[];
+    mergedData['funfam'] = [];
+
+    console.log(mergedData);
   }
   // if (conservation.data) {
   //   mergeConservationData(mergedData, conservation.data);

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -67,6 +67,7 @@ interface LoadedProps
     LoadDataProps<ResiduesPayload, 'Residues'>,
     LoadDataProps<ProteinsAPIVariation, 'Variation'>,
     LoadDataProps<AlphafoldConfidencePayload, 'Confidence'>,
+    LoadDataProps<ProteinsAPIProteomics, "Proteomics">, 
     LoadDataProps<AlphafoldPayload, 'Prediction'>,
     LoadDataProps<
       PayloadList<EndpointWithMatchesPayload<EntryMetadata>> | ErrorPayload
@@ -79,6 +80,7 @@ const DomainOnProteinWithoutData = ({
   dataFeatures,
   dataConfidence,
   dataVariation,
+  dataProteomics,
   onMatchesLoaded,
   onFamiliesFound,
   children,
@@ -217,6 +219,7 @@ const DomainOnProteinWithoutData = ({
         dataMerged={mergedData}
         dataConfidence={dataConfidence}
         dataVariation={dataVariation}
+        dataProteomics={dataProteomics}
         loading={
           data?.loading ||
           dataFeatures?.loading ||
@@ -279,6 +282,7 @@ const getExtraURL = (query: string) =>
       return url;
     },
   );
+
 const getVariationURL = createSelector(
   (state: GlobalState) => state.settings.proteinsAPI,
   (state: GlobalState) =>
@@ -289,6 +293,21 @@ const getVariationURL = createSelector(
       hostname,
       port,
       pathname: root + 'variation/' + accession,
+    });
+    return url;
+  },
+);
+
+const getPTMPayload = createSelector(
+  (state: GlobalState) => state.settings.proteinsAPI,
+  (state: GlobalState) =>
+    state.customLocation.description.protein?.accession || '',
+  ({ protocol, hostname, port, root }: ParsedURLServer, accession: string) => {
+    const url = format({
+      protocol,
+      hostname,
+      port,
+      pathname: root + 'proteomics-ptm/' + accession,
     });
     return url;
   },
@@ -315,8 +334,13 @@ export default loadExternalSources(
             getUrl: getVariationURL,
             propNamespace: 'Variation',
           } as LoadDataParameters)(
-            loadData(getRelatedEntriesURL as LoadDataParameters)(
-              DomainOnProteinWithoutData,
+            loadData<ProteinsAPIProteomics, 'Proteomics'>({
+              getUrl: getPTMPayload,
+              propNamespace: 'Proteomics',
+            } as LoadDataParameters)(
+              loadData(getRelatedEntriesURL as LoadDataParameters)(
+                DomainOnProteinWithoutData,
+              ),
             ),
           ),
         ),

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -218,7 +218,7 @@ const DomainOnProteinWithoutData = ({
 
   if (dataFeatures && !dataFeatures.loading && dataFeatures.payload) {
     mergeExtraFeatures(mergedData, dataFeatures?.payload);
-    mergedData['disordered_regions'] = filterMobiDBLiteFeatures(
+    mergedData['intrinsically_disordered_regions'] = filterMobiDBLiteFeatures(
       mergedData,
     ) as MinimalFeature[];
 

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -235,16 +235,22 @@ const DomainOnProteinWithoutData = ({
       'elm',
       mergedData,
     ) as MinimalFeature[];
+    mergedData['funfam'] = getFeature('funfam', mergedData) as MinimalFeature[];
 
     if (Object.keys(mergedData).includes('region')) {
       mergedData['spurious_proteins'] = mergedData['region'];
       delete mergedData['region'];
     }
 
-    // mergedData['funfam'] = [];
+    //
 
     // Filter the types above out of the "other_features" section
-    const toRemove = CPST.concat(['pfam-n', 'short_linear_motifs', 'mobidblt']);
+    const toRemove = CPST.concat([
+      'pfam-n',
+      'short_linear_motifs',
+      'mobidblt',
+      'funfam',
+    ]);
     mergedData['other_features'] = mergedData['other_features'].filter(
       (entry) => {
         return !toRemove.some((item) => entry.source_database?.includes(item));

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -62,16 +62,16 @@ type Props = PropsWithChildren<{
 }>;
 interface LoadedProps
   extends Props,
-  ExtenalSourcesProps,
-  LoadDataProps<ExtraFeaturesPayload, 'Features'>,
-  LoadDataProps<ResiduesPayload, 'Residues'>,
-  LoadDataProps<ProteinsAPIVariation, 'Variation'>,
-  LoadDataProps<AlphafoldConfidencePayload, 'Confidence'>,
-  LoadDataProps<ProteinsAPIProteomics, "Proteomics">,
-  LoadDataProps<AlphafoldPayload, 'Prediction'>,
-  LoadDataProps<
-    PayloadList<EndpointWithMatchesPayload<EntryMetadata>> | ErrorPayload
-  > { }
+    ExtenalSourcesProps,
+    LoadDataProps<ExtraFeaturesPayload, 'Features'>,
+    LoadDataProps<ResiduesPayload, 'Residues'>,
+    LoadDataProps<ProteinsAPIVariation, 'Variation'>,
+    LoadDataProps<AlphafoldConfidencePayload, 'Confidence'>,
+    LoadDataProps<ProteinsAPIProteomics, 'Proteomics'>,
+    LoadDataProps<AlphafoldPayload, 'Prediction'>,
+    LoadDataProps<
+      PayloadList<EndpointWithMatchesPayload<EntryMetadata>> | ErrorPayload
+    > {}
 
 const DomainOnProteinWithoutData = ({
   data,
@@ -120,9 +120,13 @@ const DomainOnProteinWithoutData = ({
     if (data && !data.loading) {
       if (processData) {
         onMatchesLoaded?.(payload?.results || []);
-        const { interpro, unintegrated, representativeDomains,
-          representativeFamilies, other } =
-          processData;
+        const {
+          interpro,
+          unintegrated,
+          representativeDomains,
+          representativeFamilies,
+          other,
+        } = processData;
         setProcessedData({
           interpro,
           unintegrated,
@@ -145,14 +149,19 @@ const DomainOnProteinWithoutData = ({
       return <EdgeCase text={edgeCaseText || ''} status={STATUS_TIMEOUT} />;
   }
   if (!processedData) return null;
-  const { interpro, unintegrated, other, representativeDomains, representativeFamilies } =
-    processedData;
+  const {
+    interpro,
+    unintegrated,
+    other,
+    representativeDomains,
+    representativeFamilies,
+  } = processedData;
   const mergedData = makeTracks({
     interpro: interpro as Array<{ accession: string; type: string }>,
     unintegrated: unintegrated as Array<{ accession: string; type: string }>,
     other: other as Array<MinimalFeature>,
     representativeDomains: representativeDomains as Array<MinimalFeature>,
-    representativeFamilies: representativeFamilies as Array<MinimalFeature>
+    representativeFamilies: representativeFamilies as Array<MinimalFeature>,
   });
   if (externalSourcesData.length) {
     mergedData.external_sources = externalSourcesData;
@@ -162,17 +171,24 @@ const DomainOnProteinWithoutData = ({
     mergeResidues(mergedData, dataResidues.payload);
   }
 
-  const filterMobiDBLiteFeatures = (mergedData: ProteinViewerDataObject): MinimalFeature[] => {
-    const mobiDBLiteEntries: MinimalFeature[] = (mergedData["other_features"] as MinimalFeature[])
-      .filter(
-        (k) => (k as MinimalFeature).accession == "Mobidblt-Consensus Disorder Prediction"
-      )
-    return mobiDBLiteEntries
-  }
+  const filterMobiDBLiteFeatures = (
+    mergedData: ProteinViewerDataObject,
+  ): MinimalFeature[] => {
+    const mobiDBLiteEntries: MinimalFeature[] = (
+      mergedData['other_features'] as MinimalFeature[]
+    ).filter(
+      (k) =>
+        (k as MinimalFeature).accession ==
+        'Mobidblt-Consensus Disorder Prediction',
+    );
+    return mobiDBLiteEntries;
+  };
 
   if (dataFeatures && !dataFeatures.loading && dataFeatures.payload) {
     mergeExtraFeatures(mergedData, dataFeatures?.payload);
-    mergedData["disordered_regions"] = filterMobiDBLiteFeatures(mergedData) as MinimalFeature[]
+    mergedData['disordered_regions'] = filterMobiDBLiteFeatures(
+      mergedData,
+    ) as MinimalFeature[];
   }
   // if (conservation.data) {
   //   mergeConservationData(mergedData, conservation.data);
@@ -240,10 +256,10 @@ const DomainOnProteinWithoutData = ({
           dataResidues?.loading ||
           false
         }
-      // Disabling Conservation until hmmer is working
-      // conservationError={conservation.error}
-      // showConservationButton={showConservationButton}
-      // handleConservationLoad={fetchConservationData}
+        // Disabling Conservation until hmmer is working
+        // conservationError={conservation.error}
+        // showConservationButton={showConservationButton}
+        // handleConservationLoad={fetchConservationData}
       >
         {children}
       </DomainsOnProteinLoaded>
@@ -327,6 +343,13 @@ const getPTMPayload = createSelector(
   },
 );
 
+/* To add then PTM data is complete
+* as LoadDataParameters)(
+loadData<ProteinsAPIProteomics, 'Proteomics'>({
+  getUrl: getPTMPayload,
+  propNamespace: 'Proteomics', 
+} */
+
 export default loadExternalSources(
   loadData<AlphafoldPayload, 'Prediction'>({
     getUrl: getAlphaFoldPredictionURL,
@@ -348,13 +371,8 @@ export default loadExternalSources(
             getUrl: getVariationURL,
             propNamespace: 'Variation',
           } as LoadDataParameters)(
-            loadData<ProteinsAPIProteomics, 'Proteomics'>({
-              getUrl: getPTMPayload,
-              propNamespace: 'Proteomics',
-            } as LoadDataParameters)(
-              loadData(getRelatedEntriesURL as LoadDataParameters)(
-                DomainOnProteinWithoutData,
-              ),
+            loadData(getRelatedEntriesURL as LoadDataParameters)(
+              DomainOnProteinWithoutData,
             ),
           ),
         ),

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -62,16 +62,16 @@ type Props = PropsWithChildren<{
 }>;
 interface LoadedProps
   extends Props,
-    ExtenalSourcesProps,
-    LoadDataProps<ExtraFeaturesPayload, 'Features'>,
-    LoadDataProps<ResiduesPayload, 'Residues'>,
-    LoadDataProps<ProteinsAPIVariation, 'Variation'>,
-    LoadDataProps<AlphafoldConfidencePayload, 'Confidence'>,
-    LoadDataProps<ProteinsAPIProteomics, "Proteomics">, 
-    LoadDataProps<AlphafoldPayload, 'Prediction'>,
-    LoadDataProps<
-      PayloadList<EndpointWithMatchesPayload<EntryMetadata>> | ErrorPayload
-    > {}
+  ExtenalSourcesProps,
+  LoadDataProps<ExtraFeaturesPayload, 'Features'>,
+  LoadDataProps<ResiduesPayload, 'Residues'>,
+  LoadDataProps<ProteinsAPIVariation, 'Variation'>,
+  LoadDataProps<AlphafoldConfidencePayload, 'Confidence'>,
+  LoadDataProps<ProteinsAPIProteomics, "Proteomics">,
+  LoadDataProps<AlphafoldPayload, 'Prediction'>,
+  LoadDataProps<
+    PayloadList<EndpointWithMatchesPayload<EntryMetadata>> | ErrorPayload
+  > { }
 
 const DomainOnProteinWithoutData = ({
   data,
@@ -101,6 +101,7 @@ const DomainOnProteinWithoutData = ({
   const [processedData, setProcessedData] = useState<{
     interpro: Record<string, unknown>[];
     representativeDomains?: Record<string, unknown>[];
+    representativeFamilies?: Record<string, unknown>[];
     unintegrated: Record<string, unknown>[];
     other: Array<MinimalFeature>;
   } | null>(null);
@@ -119,12 +120,14 @@ const DomainOnProteinWithoutData = ({
     if (data && !data.loading) {
       if (processData) {
         onMatchesLoaded?.(payload?.results || []);
-        const { interpro, unintegrated, representativeDomains, other } =
+        const { interpro, unintegrated, representativeDomains,
+          representativeFamilies, other } =
           processData;
         setProcessedData({
           interpro,
           unintegrated,
           representativeDomains,
+          representativeFamilies,
           other,
         });
         onFamiliesFound?.(interpro.filter((entry) => entry.type === 'family'));
@@ -142,13 +145,14 @@ const DomainOnProteinWithoutData = ({
       return <EdgeCase text={edgeCaseText || ''} status={STATUS_TIMEOUT} />;
   }
   if (!processedData) return null;
-  const { interpro, unintegrated, other, representativeDomains } =
+  const { interpro, unintegrated, other, representativeDomains, representativeFamilies } =
     processedData;
   const mergedData = makeTracks({
     interpro: interpro as Array<{ accession: string; type: string }>,
     unintegrated: unintegrated as Array<{ accession: string; type: string }>,
     other: other as Array<MinimalFeature>,
     representativeDomains: representativeDomains as Array<MinimalFeature>,
+    representativeFamilies: representativeFamilies as Array<MinimalFeature>
   });
   if (externalSourcesData.length) {
     mergedData.external_sources = externalSourcesData;
@@ -157,8 +161,18 @@ const DomainOnProteinWithoutData = ({
   if (dataResidues && !dataResidues.loading && dataResidues.payload) {
     mergeResidues(mergedData, dataResidues.payload);
   }
+
+  const filterMobiDBLiteFeatures = (mergedData: ProteinViewerDataObject): MinimalFeature[] => {
+    const mobiDBLiteEntries: MinimalFeature[] = (mergedData["other_features"] as MinimalFeature[])
+      .filter(
+        (k) => (k as MinimalFeature).accession == "Mobidblt-Consensus Disorder Prediction"
+      )
+    return mobiDBLiteEntries
+  }
+
   if (dataFeatures && !dataFeatures.loading && dataFeatures.payload) {
     mergeExtraFeatures(mergedData, dataFeatures?.payload);
+    mergedData["disordered_regions"] = filterMobiDBLiteFeatures(mergedData) as MinimalFeature[]
   }
   // if (conservation.data) {
   //   mergeConservationData(mergedData, conservation.data);
@@ -226,10 +240,10 @@ const DomainOnProteinWithoutData = ({
           dataResidues?.loading ||
           false
         }
-        // Disabling Conservation until hmmer is working
-        // conservationError={conservation.error}
-        // showConservationButton={showConservationButton}
-        // handleConservationLoad={fetchConservationData}
+      // Disabling Conservation until hmmer is working
+      // conservationError={conservation.error}
+      // showConservationButton={showConservationButton}
+      // handleConservationLoad={fetchConservationData}
       >
         {children}
       </DomainsOnProteinLoaded>

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -25,6 +25,7 @@ import mergeResidues from './mergeResidues';
 import DomainsOnProteinLoaded, { makeTracks } from './DomainsOnProteinLoaded';
 import loadExternalSources, { ExtenalSourcesProps } from './ExternalSourcesHOC';
 import { ProteinsAPIVariation } from '@nightingale-elements/nightingale-variation/dist/proteinAPI';
+import { ExtendedFeature } from 'src/components/ProteinViewer';
 
 export const orderByAccession = (
   a: { accession: string },
@@ -173,15 +174,27 @@ const DomainOnProteinWithoutData = ({
 
   const filterMobiDBLiteFeatures = (
     mergedData: ProteinViewerDataObject,
-  ): MinimalFeature[] => {
-    const mobiDBLiteEntries: MinimalFeature[] = (
-      mergedData['other_features'] as MinimalFeature[]
-    ).filter(
-      (k) =>
-        (k as MinimalFeature).accession ==
-        'Mobidblt-Consensus Disorder Prediction',
+  ): ExtendedFeature[] => {
+    const mobiDBLiteEntries: ExtendedFeature[] = (
+      mergedData['other_features'] as ExtendedFeature[]
+    ).filter((k) => (k as ExtendedFeature).accession.includes('Mobidblt'));
+
+    const mobiDBLiteConsensusWithChildren: ExtendedFeature[] =
+      mobiDBLiteEntries.filter((entry) =>
+        entry.accession.includes('Consensus'),
+      );
+    const mobiDBLiteChildren: ExtendedFeature[] = mobiDBLiteEntries.filter(
+      (entry) => !entry.accession.includes('Consensus'),
     );
-    return mobiDBLiteEntries;
+
+    if (mobiDBLiteConsensusWithChildren.length > 0) {
+      mobiDBLiteChildren.map((child) => {
+        child.protein = child.accession;
+      });
+      mobiDBLiteConsensusWithChildren[0].children = mobiDBLiteChildren;
+    }
+
+    return mobiDBLiteConsensusWithChildren;
   };
 
   if (dataFeatures && !dataFeatures.loading && dataFeatures.payload) {
@@ -328,7 +341,7 @@ const getVariationURL = createSelector(
   },
 );
 
-const getPTMPayload = createSelector(
+/*const getPTMPayload = createSelector(
   (state: GlobalState) => state.settings.proteinsAPI,
   (state: GlobalState) =>
     state.customLocation.description.protein?.accession || '',
@@ -341,7 +354,7 @@ const getPTMPayload = createSelector(
     });
     return url;
   },
-);
+);*/
 
 /* To add then PTM data is complete
 * as LoadDataParameters)(

--- a/src/components/Related/DomainsOnProtein/mergeResidues.ts
+++ b/src/components/Related/DomainsOnProtein/mergeResidues.ts
@@ -1,4 +1,4 @@
-import { orderByAccession } from '.';
+import { ExtendedFeature } from 'src/components/ProteinViewer';
 
 const PIRSR_ACCESSION_LENGTH = 11;
 const PIRSF_PREFIX_LENGTH = 5;
@@ -32,7 +32,7 @@ const mergePIRSFRResidues = (residues: Record<string, ResidueMetadata>) => {
         };
       }
       residues[acc].locations?.forEach(
-        (location) => (location.accession = acc)
+        (location) => (location.accession = acc),
       );
       newResidues[newAcc].locations?.push(...(residues[acc].locations || []));
     } else {
@@ -44,7 +44,7 @@ const mergePIRSFRResidues = (residues: Record<string, ResidueMetadata>) => {
 
 const mergeResidues = (
   data: ProteinViewerDataObject<MinimalFeature>,
-  residuesPayload: ResiduesPayload
+  residuesPayload: ResiduesPayload,
 ) => {
   const residuesWithEntryDetails: Array<FeatureWithResidues> = [];
   const residues: Record<string, ResidueEntry> =
@@ -53,13 +53,13 @@ const mergeResidues = (
   const { representative_domains: _, ...otherGroups } = data;
   Object.values(otherGroups).forEach(
     (
-      group /*: Array<{accession:string, residues: Array<Object>, children: any}> */
+      group /*: Array<{accession:string, residues: Array<Object>, children: any}> */,
     ) =>
       group.forEach((entry) => {
         const resAccession = entry.accession.startsWith('PIRSF')
           ? `PIRSR${entry.accession.substring(
               PIRSF_PREFIX_LENGTH,
-              PIRSR_ACCESSION_LENGTH
+              PIRSR_ACCESSION_LENGTH,
             )}`
           : entry.accession;
         if (residues[resAccession]) {
@@ -75,7 +75,7 @@ const mergeResidues = (
             const childResAccession = child.accession.startsWith('PIRSF')
               ? `PIRSR${child.accession.substring(
                   PIRSF_PREFIX_LENGTH,
-                  PIRSR_ACCESSION_LENGTH
+                  PIRSR_ACCESSION_LENGTH,
                 )}`
               : child.accession;
             if (residues[childResAccession]) {
@@ -86,12 +86,11 @@ const mergeResidues = (
               residues[childResAccession].linked = true;
             }
           });
-      })
+      }),
   );
 
-  const unlinkedResidues: Array<ResidueEntry> = [];
-
-  Object.values(residues)
+  // Previous way of handling other residues. Now merging them into residues.
+  /*Object.values(residues)
     .filter(({ linked }) => !linked)
     .forEach((residue) => {
       residue.locations.forEach((location, i) => {
@@ -103,11 +102,31 @@ const mergeResidues = (
         residueEntry.locations = [location];
         unlinkedResidues.push(residueEntry);
       });
-    });
-  unlinkedResidues.sort(orderByAccession);
+    });*/
 
-  data.residues = residuesWithEntryDetails;
-  data.other_residues = unlinkedResidues;
+  // Showing residues coming from MemberDBs first, then PIRSR
+  function sortResidues(rA: FeatureWithResidues, rB: FeatureWithResidues) {
+    if (rA.accession.includes('PIRSR') && !rB.accession.includes('PIRSR'))
+      return 1;
+    else if (
+      !rA.accession.includes('PIRSR') &&
+      rB.accession.includes('PIRSR')
+    ) {
+      return -1;
+    } else return 0;
+  }
+
+  // MemberDBs + PIRSR residues
+  const combinedResidues: FeatureWithResidues[] = [];
+  Object.values(residues).forEach((residue) => {
+    combinedResidues.push({
+      accession: residue.accession,
+      source_database: residue.source_database,
+      residues: [residue],
+    });
+  });
+
+  data.residues = combinedResidues.sort(sortResidues);
 };
 
 export default mergeResidues;

--- a/src/components/Related/DomainsOnProtein/mergeResidues.ts
+++ b/src/components/Related/DomainsOnProtein/mergeResidues.ts
@@ -89,8 +89,8 @@ const mergeResidues = (
       }),
   );
 
-  // Previous way of handling other residues. Now merging them into residues.
-  /*Object.values(residues)
+  const unlinkedResidues: ResidueEntry[] = [];
+  Object.values(residues)
     .filter(({ linked }) => !linked)
     .forEach((residue) => {
       residue.locations.forEach((location, i) => {
@@ -102,31 +102,11 @@ const mergeResidues = (
         residueEntry.locations = [location];
         unlinkedResidues.push(residueEntry);
       });
-    });*/
-
-  // Showing residues coming from MemberDBs first, then PIRSR
-  function sortResidues(rA: FeatureWithResidues, rB: FeatureWithResidues) {
-    if (rA.accession.includes('PIRSR') && !rB.accession.includes('PIRSR'))
-      return 1;
-    else if (
-      !rA.accession.includes('PIRSR') &&
-      rB.accession.includes('PIRSR')
-    ) {
-      return -1;
-    } else return 0;
-  }
-
-  // MemberDBs + PIRSR residues
-  const combinedResidues: FeatureWithResidues[] = [];
-  Object.values(residues).forEach((residue) => {
-    combinedResidues.push({
-      accession: residue.accession,
-      source_database: residue.source_database,
-      residues: [residue],
     });
-  });
 
-  data.residues = combinedResidues.sort(sortResidues);
+  data.residues = (residuesWithEntryDetails as ResidueEntry[]).concat(
+    unlinkedResidues,
+  );
 };
 
 export default mergeResidues;

--- a/src/components/Structure/ViewerAndEntries/ProteinViewerForAlphafold/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/ProteinViewerForAlphafold/index.tsx
@@ -26,25 +26,22 @@ const ProteinViewer = loadable({
   loading: null,
 });
 
+/* Processing of the payload needs to be slightly different 
+to add tracks to the dataMerged object instead of the dataSorted object */
 export const addConfidenceTrack = (
   dataConfidence: RequestedData<AlphafoldConfidencePayload>,
   protein: string,
-  tracks: ProteinViewerData,
+  tracks: ProteinViewerDataObject,
 ) => {
   if (dataConfidence?.payload?.confidenceCategory?.length) {
-    const confidenceTrack: [string, Array<unknown>] = [
-      'AlphaFold confidence',
-      [
-        {
-          accession: `confidence_af_${protein}`,
-          data: dataConfidence.payload.confidenceCategory.join(''),
-          type: 'confidence',
-          protein,
-          source_database: 'alphafold',
-        },
-      ],
-    ];
-    tracks.splice(0, 0, confidenceTrack);
+    tracks['alphafold_confidence'] = [];
+    tracks['alphafold_confidence'][0] = {
+      accession: `confidence_af_${protein}`,
+      data: dataConfidence.payload.confidenceCategory.join(''),
+      type: 'confidence',
+      protein,
+      source_database: 'alphafold',
+    };
   }
 };
 
@@ -134,8 +131,8 @@ const ProteinViewerForAlphafold = ({
     unintegrated: unintegrated as Array<MinimalFeature>,
     representativeDomains: representativeDomains as Array<MinimalFeature>,
   });
+  if (dataConfidence) addConfidenceTrack(dataConfidence, protein, groups);
   const tracks = flattenTracksObject(groups);
-  if (dataConfidence) addConfidenceTrack(dataConfidence, protein, tracks);
   if (!dataProtein.payload?.metadata) return null;
   return (
     <div ref={containerRef}>

--- a/src/types/external-payloads.d.ts
+++ b/src/types/external-payloads.d.ts
@@ -85,6 +85,13 @@ type Iprscan5Payload = {
   results: Array<Iprscan5Result>;
 };
 
+type ProteinsAPIProteomics = {
+  accession: string,
+  start: number,
+  end: number,
+  features: []
+}
+
 type IprscanParameterValue = {
   label: string;
   value: string;

--- a/src/utils/entry-color/index.js
+++ b/src/utils/entry-color/index.js
@@ -25,6 +25,7 @@ export const EntryColorMode /*: ColorModeMap */ = {
   accession: string,
   source_database: string,
   parent?: Entry,
+  integrated?: string
 }; */
 
 export const getTrackColor = (
@@ -58,6 +59,7 @@ export const getTrackColor = (
         acc = entry.parent.accession.split('').reverse().join('');
         return colorHash.hex(acc);
       }
+
       if (entry.integrated) {
         acc = entry.integrated.split('').reverse().join('');
         return colorHash.hex(acc);

--- a/src/utils/entry-color/index.js
+++ b/src/utils/entry-color/index.js
@@ -58,6 +58,10 @@ export const getTrackColor = (
         acc = entry.parent.accession.split('').reverse().join('');
         return colorHash.hex(acc);
       }
+      if (entry.integrated) {
+        acc = entry.integrated.split('').reverse().join('');
+        return colorHash.hex(acc);
+      }
   }
   return config.colors.get();
 };


### PR DESCRIPTION
This PR:

- Reorganizes tracks on the Protein summary page and hides (but makes expandable) all the ones considered "secondary". See [IBU-11247](https://www.ebi.ac.uk/panda/jira/browse/IBU-11247) for more;
- Adds representative family track;
- Adds disordered regions track;
- Changes the residue track so that domains are not shown;
- The logic for fetching PTM data is added but currently not used given the non-completeness of the PTM data;