### PR TITLE
Update default options

### DIFF
--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -252,11 +252,11 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
               ) {
                 (track as NightingaleInterProTrackCE).data = mapToFeatures(
                   entry,
-                  colorDomainsBy || 'ACCESSION',
+                  colorDomainsBy || 'MEMBER_DB',
                 );
                 const contributors = mapToContributors(
                   entry,
-                  colorDomainsBy || 'ACCESSION',
+                  colorDomainsBy || 'MEMBER_DB',
                 );
                 if (contributors)
                   (track as NightingaleInterProTrackCE).contributors =

--- a/src/reducers/settings/category/index.ts
+++ b/src/reducers/settings/category/index.ts
@@ -28,10 +28,10 @@ export const getDefaultSettingsFor = <T extends keyof SettingsState>(
     case 'ui':
       return {
         lowGraphics: false,
-        colorDomainsBy: EntryColorMode.ACCESSION,
+        colorDomainsBy: EntryColorMode.MEMBER_DB,
         labelContent: {
-          accession: true,
-          name: false,
+          accession: false,
+          name: true,
           short: true,
         },
         structureViewer: false,


### PR DESCRIPTION
Update the following default options in the protein viewer:

- label by: replace `accession` and `short name` by `name` and `short name`
- color by: replace `accession` by `member database`