### PR TITLE
Add link to page where download job was initiated

### DIFF
--- a/src/actions/creators/index.ts
+++ b/src/actions/creators/index.ts
@@ -224,6 +224,7 @@ export const downloadURL = (
   fileType: DownloadFileTypes,
   subset: boolean,
   endpoint: string,
+  originURL?: string,
 ) =>
   ({
     type: types.DOWNLOAD_URL,
@@ -231,6 +232,7 @@ export const downloadURL = (
     fileType,
     subset,
     endpoint,
+    originURL,
   }) as DownloadAction;
 
 export const downloadError = (
@@ -257,7 +259,14 @@ export const downloadSuccess = (
     length,
     date,
     version,
-  }: { blob: Blob; length: number; date: string; version: string },
+    originURL,
+  }: {
+    blob: Blob;
+    length: number;
+    date: string;
+    version: string;
+    originURL: string;
+  },
 ) =>
   ({
     type: types.DOWNLOAD_SUCCESS,
@@ -269,6 +278,7 @@ export const downloadSuccess = (
     length,
     date,
     version,
+    originURL,
   }) as DownloadAction;
 
 export const downloadProgress = (

--- a/src/actions/types/index.ts
+++ b/src/actions/types/index.ts
@@ -91,6 +91,7 @@ export interface DownloadAction
   length?: number;
   date?: string;
   version?: string;
+  originURL?: string;
 }
 
 export interface InitialDownloadsAction

--- a/src/components/Download/Actions/index.js
+++ b/src/components/Download/Actions/index.js
@@ -16,6 +16,7 @@ import { foundationPartial } from 'styles/foundation';
 import ipro from 'styles/interpro-new.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import local from './style.css';
+import { toPublicAPI } from 'utils/url';
 
 const f = foundationPartial(fonts, ipro, local);
 
@@ -54,27 +55,41 @@ class Actions extends PureComponent /*:: <Props> */ {
 
     return (
       <div id="dassd" style={{ whiteSpace: 'nowrap' }}>
-        <Tooltip title="Download job">
-          <Link
-            buttonType="hollow"
-            className={f('icon', 'icon-common', 'ico-neutral', 'icon-download')}
-            href={blobURL}
-            download={fileName}
-            disabled={!blobURL}
-            aria-label="Download job"
-            style={{ color: 'var(--colors-light-txt)' }}
-          />
-        </Tooltip>
-        <Tooltip title="Delete job">
-          <Button
-            type="hollow"
-            icon="icon-trash"
-            textColor="var(--colors-light-txt)"
-            className={f('margin-left-large')}
-            onClick={this._handleDelete}
-            aria-label="Delete job"
-          />
-        </Tooltip>
+        <Link
+          buttonType="hollow"
+          href={blobURL}
+          download={fileName}
+          disabled={!blobURL}
+          aria-label="Download results"
+          style={{ color: 'var(--colors-light-txt)' }}
+        >
+          <span
+            className={f('icon', 'icon-common', 'icon-download')}
+            data-icon="&#xf019;"
+          />{' '}
+          Download
+        </Link>
+        <Link
+          buttonType="hollow"
+          href={toPublicAPI(localID.split('|')[0])}
+          aria-label="Browsable API"
+          style={{ color: 'var(--colors-light-txt)' }}
+        >
+          <span
+            className={f('icon', 'icon-common', 'icon-code')}
+            data-icon="&#xf121;"
+          />{' '}
+          API
+        </Link>
+        <Button
+          type="hollow"
+          icon="icon-trash"
+          textColor="var(--colors-light-txt)"
+          onClick={this._handleDelete}
+          aria-label="Delete results"
+        >
+          <span>Delete</span>
+        </Button>
       </div>
     );
   }

--- a/src/components/Download/Summary/index.js
+++ b/src/components/Download/Summary/index.js
@@ -79,15 +79,18 @@ class Summary extends PureComponent /*:: < {download: Array<Object>} > */ {
           </div>
           <Table dataTable={download} contentType="files" actualSize={0}>
             <Column
-              dataKey="localID"
-              renderer={(localID /*: string */) => (
-                <Link target="_blank" href={localID.split('|')[0]}>
-                  {' '}
-                  {localID.split('|')[0]}{' '}
-                </Link>
-              )}
+              dataKey="originURL"
+              renderer={(originURL /*: string */) => {
+                const url = new URL(originURL);
+                return (
+                  <Link target="_blank" href={originURL}>
+                    {url.pathname}
+                    {url.search}
+                  </Link>
+                );
+              }}
             >
-              URL
+              Source
             </Column>
             <Column dataKey="fileType">Type</Column>
             <Column

--- a/src/components/Download/Summary/index.js
+++ b/src/components/Download/Summary/index.js
@@ -51,6 +51,11 @@ const GoToNewDownload = () => (
   </Link>
 );
 
+function localIDtoOriginURL(url) {
+  const regex = /^https?:\/\/[^\/]+\/api\/|\|(?:json|tsv|fasta)$/g;
+  return url.replace(regex, '');
+}
+
 class Summary extends PureComponent /*:: < {download: Array<Object>} > */ {
   static propTypes = {
     download: T.arrayOf(T.object).isRequired,
@@ -58,6 +63,13 @@ class Summary extends PureComponent /*:: < {download: Array<Object>} > */ {
 
   render() {
     const { download } = this.props;
+
+    // Handle old saved download jobs that don't have an originURL
+    for (const downloadObj of download) {
+      if (!downloadObj.originURL)
+        downloadObj.originURL = localIDtoOriginURL(downloadObj.localID);
+    }
+
     return (
       <div className={f('row')}>
         <div className={f('large-12', 'columns')}>

--- a/src/components/DownloadForm/Controls/index.tsx
+++ b/src/components/DownloadForm/Controls/index.tsx
@@ -45,6 +45,7 @@ export class Controls extends PureComponent<Props> {
       this.props.fileType,
       this.props.subset,
       this.props.entityType,
+      window.location.href,
     );
   });
 

--- a/src/components/File/index.tsx
+++ b/src/components/File/index.tsx
@@ -99,6 +99,7 @@ export class File extends PureComponent<Props, State> {
       this.props.fileType,
       !!this.props.subset,
       this.props.endpoint,
+      window.location.href,
     );
   });
 

--- a/src/components/SearchResults/index.tsx
+++ b/src/components/SearchResults/index.tsx
@@ -99,22 +99,6 @@ export const SearchResults = ({
         status={status}
       >
         <HighlightToggler />
-        <Exporter>
-          <div className={css('menu-grid')}>
-            <label htmlFor="json">JSON</label>
-            <FileExporter
-              fileType="json"
-              name={`SearchResults-${searchValue}.json`}
-              count={hitCount}
-            />
-            <label htmlFor="tsv">TSV</label>
-            <FileExporter
-              fileType="tsv"
-              name={`SearchResults-${searchValue}.tsv`}
-              count={hitCount}
-            />
-          </div>
-        </Exporter>
         <Column
           dataKey="id"
           renderer={(

--- a/src/reducers/download/index.ts
+++ b/src/reducers/download/index.ts
@@ -45,6 +45,7 @@ export default (
           successful: null,
           blobURL: null,
           size: null,
+          originURL: action.originURL,
         },
       };
     case DOWNLOAD_ERROR:
@@ -70,6 +71,7 @@ export default (
           date: action.date,
           version: action.version,
           fileType: action.fileType,
+          originURL: action.originURL,
         },
       };
     case DOWNLOAD_DELETE:
@@ -80,7 +82,10 @@ export default (
     case SET_INITIAL_DOWNLOADS:
       const savedDownloads: Record<string, DownloadProgress> = {};
       Object.entries(action.downloads).forEach(
-        ([key, { blob, date, fileType, length, subset, version }]) => {
+        ([
+          key,
+          { blob, date, fileType, length, subset, version, originURL },
+        ]) => {
           savedDownloads[key] = {
             progress: 1,
             successful: true,
@@ -91,6 +96,7 @@ export default (
             fileType,
             date,
             version,
+            originURL,
           };
         },
       );

--- a/src/types/state.d.ts
+++ b/src/types/state.d.ts
@@ -191,6 +191,7 @@ type DownloadProgress = {
   date?: Date;
   length?: number;
   subset?: boolean;
+  originURL?: string;
 };
 
 type CompletedDownload = DownloadProgress & {
@@ -198,6 +199,7 @@ type CompletedDownload = DownloadProgress & {
   date: Date;
   length: number;
   subset: boolean;
+  originURL?: string;
 };
 
 type Server =


### PR DESCRIPTION
Currently, when listing [download jobs](https://www.ebi.ac.uk/interpro/result/download/#table), the first column is the URL to the API page used to fetch records. This can be confusing for non-technical users, but also can be misleading as results may span over several pages instead of all being returned by one page.

This PR adds some logic to keep track of the URL of the page where the download job was created.

Example to test:

1. Go to `/entry/InterPro/?type=active_site`
2. Open the _Download_ dropdown
3. Click _Generate TSV_
4. Go to `/result/download/` or `Results > Your downloads`

Live website:

![image](https://github.com/user-attachments/assets/389cffc3-84d6-4fba-9101-01af40b48a73)

This branch:

![image](https://github.com/user-attachments/assets/acd44a6a-98ca-4ad5-ba29-5f4a0e0431c9)

The first column is now a link to the _website_ page where the download job was created. The link to the first page of the API has been moved under "Actions".

