### PR TITLE
Structure highlight fixes

### DIFF
--- a/src/components/Structure/ViewerAndEntries/ProteinViewerForAlphafold/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/ProteinViewerForAlphafold/index.tsx
@@ -118,10 +118,14 @@ const ProteinViewerForAlphafold = ({
           default:
             break;
         }
-      } else {
-        if (eventType === 'mouseout') {
-          setHoverSelection([]);
-          isHovering.current = false;
+      } else if (eventType === 'mouseout') {
+        setHoverSelection([]);
+        isHovering.current = false;
+      } else if (eventType === 'click') {
+        if (fixedSelectionRef.current.length) {
+          setFixedSelection([]);
+        } else {
+          setFixedSelection(hoverSelectionRef.current);
         }
       }
     });

--- a/src/components/Structure/ViewerAndEntries/ProteinViewerForAlphafold/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/ProteinViewerForAlphafold/index.tsx
@@ -103,14 +103,14 @@ const ProteinViewerForAlphafold = ({
 
           case 'mouseover': {
             isHovering.current = true;
-            const colour =
+            const color =
               parseInt(event?.detail?.feature?.color?.substring(1), 16) || 0;
             const selection =
               highlight?.split(',').map((block: string) => {
                 const parts = block.split(':');
                 const start = Number(parts?.[0]) || 1;
                 const end = Number(parts?.[1]) || 1;
-                return { chain: 'A', start, end, colour };
+                return { chain: 'A', start, end, color };
               }) || [];
             setHoverSelection(selection);
             break;

--- a/src/components/Structure/ViewerAndEntries/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/index.tsx
@@ -50,8 +50,10 @@ type MinimalStructureFeature = MinimalFeature & {
 };
 type EntryHit = {
   struct_asym_id: string;
-  start_residue_number: number;
-  end_residue_number: number;
+  start: number;
+  end: number;
+  auth_start?: number;
+  auth_end?: number;
   accession: string;
   source_database: string;
   color?: string;
@@ -222,11 +224,13 @@ class StructureView extends PureComponent<Props, State> {
   _getChainMap(chain: string, locations: ProtVistaLocation[]) {
     const chainMap = [];
     for (const location of locations) {
-      for (const { start, end } of location.fragments) {
+      for (const { start, end, auth_start, auth_end } of location.fragments) {
         chainMap.push({
           struct_asym_id: chain,
-          start_residue_number: start,
-          end_residue_number: end,
+          start: start,
+          end: end,
+          auth_start: auth_start,
+          auth_end: auth_end,
           accession: chain,
           source_database: 'pdb',
         });
@@ -255,8 +259,10 @@ class StructureView extends PureComponent<Props, State> {
       for (const fragment of location.fragments) {
         map[chain].push({
           struct_asym_id: chain,
-          start_residue_number: Math.round(fragment.start),
-          end_residue_number: Math.round(fragment.end),
+          start: fragment.start,
+          end: fragment.end,
+          auth_start: fragment.auth_start,
+          auth_end: fragment.auth_end,
           accession: entry,
           source_database: db,
           parent: match.metadata.integrated
@@ -365,8 +371,8 @@ class StructureView extends PureComponent<Props, State> {
         const hexColour = parseInt(hit.color?.substring(1) || '', 16);
         selections.push({
           color: hexColour,
-          start: hit.start_residue_number,
-          end: hit.end_residue_number,
+          start: hit.auth_start || hit.start,
+          end: hit.auth_end || hit.end,
           chain: hit.struct_asym_id,
         });
       });

--- a/src/types/interpro-payloads.d.ts
+++ b/src/types/interpro-payloads.d.ts
@@ -272,6 +272,8 @@ type ProtVistaFragment = {
   fill?: string;
   protein_start?: number;
   protein_end?: number;
+  auth_start?: number;
+  auth_end?: number;
 };
 
 type ProtVistaLocation = {


### PR DESCRIPTION
There are cases where highlighting a domain on a PDB structure doesn't work, e.g. with [`3pzd`](https://www.ebi.ac.uk/interpro/structure/PDB/3pzd/#table):

<details>
<summary>Screenshot without highlight</summary>

![image](https://github.com/user-attachments/assets/b969f893-2b37-4397-a982-837ef85ea6a4)
</details>

<details>
<summary>Screenshot with highlight (any domain)</summary>

![image](https://github.com/user-attachments/assets/30780ef6-41a9-4dd3-b512-b34d6ffabc3e)
</details>

This is due to the residues _on the 3D structure_ having different positions. In the case of `3pzd` ([link to PDBe](https://www.ebi.ac.uk/pdbe/entry/pdb/3pzd/protein/1)), the first four amino acids of the sequence are `EFDT` (Glu - Phe - Asp - Thr). You would expect the position of the `E` glutamate to be `1`, but...

![image](https://github.com/user-attachments/assets/6f3e0ffe-5a03-492e-b8a3-42ca42facb49)

its position is `1501`.

I've added an alternative mapping to `entry_structure_locations.fragments` objects: `auth_start` and `auth_end`, which stores the positions of a match on the 3D structure, for instance:

```json
[
    {
        "fragments": [
            {
                "start": 89,
                "end": 193,
                "dc-status": "CONTINUOUS",
                "auth_start": 1589,
                "auth_end": 1693
            }
        ],
        "representative": false,
        "model": "PF00784",
        "score": null
    }
]
```

This PR uses `auth_start` and `auth_end`, when available, to correctly highlight domains.

This PR also fixes the highlight of clicked domains on AlphaFold structures, and highlights the domain in the colour they have on the protein viewer, instead of colouring them in green.

