### PR TITLE
Hide expiry date if in the past

### DIFF
--- a/src/components/IPScan/Status/SequenceList/index.tsx
+++ b/src/components/IPScan/Status/SequenceList/index.tsx
@@ -123,6 +123,7 @@ export const IPScanStatus = ({
     ((Number(search.page) || 1) - 1) * Number(pageSize),
     Number(pageSize),
   );
+  const expiryDate = new Date((job?.times?.created || 0) + MAX_TIME_ON_SERVER);
   return (
     <section>
       <IPScanVersionCheck
@@ -197,7 +198,7 @@ export const IPScanStatus = ({
           <StatusTooltip status={job?.status} />
         </section>
       </section>
-      {job?.status === 'finished' && (
+      {job?.status === 'finished' && expiryDate >= new Date() && (
         <section className={css('summary-row')}>
           <header>
             Expires{' '}
@@ -213,11 +214,7 @@ export const IPScanStatus = ({
               />
             </Tooltip>
           </header>
-          <section>
-            {new Date(
-              (job?.times?.created || 0) + MAX_TIME_ON_SERVER,
-            ).toDateString()}
-          </section>
+          <section>{expiryDate.toDateString()}</section>
         </section>
       )}
       <Table


### PR DESCRIPTION
If you open an InterProScan search that you haven't started yourself, your browser doesn't have job metadata like the creation date/time, which causes the the expiry date to epoch + one week (so 8 January 1970).

Example: https://www.ebi.ac.uk/interpro/result/InterProScan/iprscan5-R20250320-100548-0158-19647556-p1m/#table

This small PR hides the expiry date if it's in the past.