### PR TITLE
Structure page fixes and improvements

### DIFF
--- a/src/components/Related/DomainEntriesOnStructure/index.tsx
+++ b/src/components/Related/DomainEntriesOnStructure/index.tsx
@@ -338,7 +338,7 @@ const EntriesOnStructure = ({
           return (
             <div key={i} className={css('vf-stack')}>
               <h4 id={`protvista-${chainsData.chain}`}>
-                Chain{chainsList.length > 1 && 's'} {chainsList.join(',')}
+                Chain{chainsList.length > 1 && 's'}: {chainsList.join(', ')}
                 {accessionList.length > 0 && ' ('}
                 {accessionList &&
                   accessionList.map((acc, idx) => {

--- a/src/components/Related/DomainEntriesOnStructure/index.tsx
+++ b/src/components/Related/DomainEntriesOnStructure/index.tsx
@@ -281,16 +281,35 @@ const EntriesOnStructure = ({
     }
   };
 
+  const sequenceToChain: Record<
+    string,
+    { chainsData: DataForProteinChain; chains: string[] }
+  > = {};
+  merged.map((e) => {
+    if (!sequenceToChain[e.sequence.sequence])
+      sequenceToChain[e.sequence.sequence] = {
+        chainsData: e,
+        chains: [e.chain],
+      };
+    else sequenceToChain[e.sequence.sequence]['chains'].push(e.chain);
+  });
+
   return (
     <>
       <div className={css('vf-stack', 'vf-stack--400')}>
-        {merged.map((e, i) => {
+        {Object.values(sequenceToChain).map((data, i) => {
+          const chainsData = data['chainsData'];
+          const chainsList = data['chains'];
+
           const sequenceData = {
-            accession: `${e.chain}-${structure}`,
-            ...e.sequence,
+            accession: `${chainsData.chain}-${structure}`,
+            ...chainsData.sequence,
           };
 
-          const reorganizedTracks = reorganizeStructureViewer(e.chain, e.data);
+          const reorganizedTracks = reorganizeStructureViewer(
+            chainsData.chain,
+            chainsData.data,
+          );
           const tracks = flattenTracksObject(reorganizedTracks);
 
           tracks.map((entry) => {
@@ -302,10 +321,10 @@ const EntriesOnStructure = ({
           /* 
             - Take protein object for each "viewer" data 
             - take the accession 
-            - split the accession if it's composed of multiple uniprot accessiokn
+            - split the accession if it's composed of multiple uniprot accessions
           */
 
-          const splitAccessions = e.protein
+          const splitAccessions = chainsData.protein
             ?.map((p) => p.accession)
             .map((pAccession) => {
               if (pAccession) return pAccession.split(',');
@@ -318,8 +337,8 @@ const EntriesOnStructure = ({
 
           return (
             <div key={i} className={css('vf-stack')}>
-              <h4 id={`protvista-${e.chain}`}>
-                Chain {e.chain}
+              <h4 id={`protvista-${chainsData.chain}`}>
+                Chain{chainsList.length > 1 && 's'} {chainsList.join(',')}
                 {accessionList.length > 0 && ' ('}
                 {accessionList &&
                   accessionList.map((acc, idx) => {
@@ -343,7 +362,7 @@ const EntriesOnStructure = ({
                     );
                   })}
                 {accessionList.length > 0 && ')'}
-                {e.isChimeric && (
+                {chainsData.isChimeric && (
                   <Tooltip title="This chain maps to a Chimeric protein consisting of two or more proteins">
                     <div className={css('tag')}>
                       <span
@@ -360,8 +379,8 @@ const EntriesOnStructure = ({
                 tracks={
                   tracks as Array<[string, Array<Record<string, unknown>>]>
                 }
-                chain={e.chain}
-                id={`${e.chain}`}
+                chain={chainsData.chain}
+                id={`${chainsData.chain}`}
                 protein={sequenceData}
                 viewerType={'structures'}
               />

--- a/src/components/Structure/Summary/index.tsx
+++ b/src/components/Structure/Summary/index.tsx
@@ -32,7 +32,7 @@ const EXTERNAL_LINKS = [
   },
   { pattern: 'https://www.cathdb.info/pdb/{id}', label: 'CATH' },
   {
-    pattern: 'http://scop.mrc-lmb.cam.ac.uk/search?t=txt;q={id}',
+    pattern: 'https://www.ebi.ac.uk/pdbe/scop/search?t=txt;q={id}',
     label: 'SCOP',
   },
   {

--- a/src/components/Structure/Viewer/index.tsx
+++ b/src/components/Structure/Viewer/index.tsx
@@ -126,6 +126,29 @@ class StructureView extends PureComponent<Props> {
     }
   }
 
+  delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /* 
+  Delays take into account: 
+    - animation times
+    - the MolStar viewer not handling well multiple commands at once 
+  */
+  async resetOperations() {
+    if (this.viewer) {
+      if (this.props.onReset) {
+        await this.delay(100);
+        this.props.onReset();
+        this.applyChainIdTheme();
+      }
+
+      PluginCommands.Camera.ResetAxes(this.viewer, {});
+      await this.delay(500);
+      PluginCommands.Camera.Reset(this.viewer, {});
+    }
+  }
+
   componentDidUpdate(prevProps: Props) {
     if (this.name !== `${this.props.id}` || prevProps.url !== this.props.url) {
       this.name = `${this.props.id}`;
@@ -144,12 +167,7 @@ class StructureView extends PureComponent<Props> {
     if (this.viewer) {
       this.setSpin(this.props.isSpinning);
       if (this.props.shouldResetViewer) {
-        PluginCommands.Camera.Reset(this.viewer, {});
-        this.clearSelections();
-        this.applyChainIdTheme();
-        if (this.props.onReset) {
-          this.props.onReset();
-        }
+        this.resetOperations();
       }
       if ((this.props.selections?.length || 0) > 0) {
         this.highlightSelections(this.props.selections as Array<Selection>);

--- a/src/components/Structure/ViewerAndEntries/EntrySelection/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/EntrySelection/index.tsx
@@ -11,18 +11,20 @@ type Props = {
   updateStructure: (memberDB: string | null, entry: string) => void;
   entryMap: Object;
   selectedEntry?: string;
+  entriesNames: Record<string, string | NameObject>;
 };
 
 const EntrySelection = ({
   entryMap,
   selectedEntry,
+  entriesNames,
   updateStructure,
 }: Props) => {
   const selectionGroups = [];
   selectionGroups.push(
     <option key="{NO_SELECTION}" value={NO_SELECTION}>
       Highlight Entry in the 3D structure
-    </option>
+    </option>,
   );
 
   for (const [memberDB, entries] of Object.entries(entryMap)) {
@@ -31,14 +33,14 @@ const EntrySelection = ({
       const key = `${memberDB}$-${entry}`;
       entryList.push(
         <option key={key} value={entry}>
-          {entry}
-        </option>
+          {entriesNames[entry] as string}
+        </option>,
       );
     }
     selectionGroups.push(
       <optgroup key={memberDB} label={memberDB}>
         {entryList}
-      </optgroup>
+      </optgroup>,
     );
   }
   const onSelectionChange = (e: React.FormEvent) => {

--- a/src/components/Structure/ViewerAndEntries/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/index.tsx
@@ -313,7 +313,7 @@ class StructureView extends PureComponent<Props, State> {
       // create matches in structure hierarchy
 
       for (const match of this.props.matches) {
-        let entry = match.metadata.accession;
+        const entry = match.metadata.accession;
         const db = match.metadata.source_database;
         if (!memberDBMap[db]) memberDBMap[db] = {};
         if (!memberDBMap[db][entry]) memberDBMap[db][entry] = {};

--- a/src/components/Structure/ViewerAndEntries/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/index.tsx
@@ -291,16 +291,29 @@ class StructureView extends PureComponent<Props, State> {
     return hits;
   }
 
+  getEntryNames() {
+    const accessionToName: Record<string, NameObject | string> = {};
+    if (this.props.matches) {
+      for (const match of this.props.matches) {
+        const entryName = match.metadata.name;
+        const entryAccession = match.metadata.accession;
+        accessionToName[entryAccession] = entryName || entryAccession;
+      }
+    }
+    return accessionToName;
+  }
+
   createEntryMap() {
     const memberDBMap: Record<
       string,
       Record<string, Record<string, Array<EntryHit>>>
-    > = { pdb: {} };
+    > = {};
 
     if (this.props.matches) {
       // create matches in structure hierarchy
+
       for (const match of this.props.matches) {
-        const entry = match.metadata.accession;
+        let entry = match.metadata.accession;
         const db = match.metadata.source_database;
         if (!memberDBMap[db]) memberDBMap[db] = {};
         if (!memberDBMap[db][entry]) memberDBMap[db][entry] = {};
@@ -317,15 +330,6 @@ class StructureView extends PureComponent<Props, State> {
             db,
             match,
           });
-          // create PDB chain mapping
-          if (!memberDBMap.pdb[structure.accession])
-            memberDBMap.pdb[structure.accession] = {};
-          if (!memberDBMap.pdb[structure.accession][chain]) {
-            memberDBMap.pdb[structure.accession][chain] = this._getChainMap(
-              chain,
-              structure.entry_structure_locations,
-            );
-          }
         }
       }
     }
@@ -407,6 +411,7 @@ class StructureView extends PureComponent<Props, State> {
             top: this.props.matches ? (
               <EntrySelection
                 entryMap={entryMap}
+                entriesNames={this.getEntryNames()}
                 updateStructure={this.showEntryInStructure}
                 selectedEntry={selectedEntry}
               />

--- a/src/components/Structure/ViewerAndEntries/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/index.tsx
@@ -493,10 +493,8 @@ class StructureView extends PureComponent<Props, State> {
             }}
             isSpinning={isSpinning}
             shouldResetViewer={shouldResetViewer}
-            selections={this.state.selectionsInStructure}
-            onReset={() => {
-              this.setState({ selectionsInStructure: null });
-            }}
+            selections={this.state.selectionsInStructure || []}
+            onReset={() => this.setState({ selectionsInStructure: null })}
           />
         </PictureInPicturePanel>
         <div


### PR DESCRIPTION
This PR addresses the following:
- the SCOP link is now the correct one;
- ProteinViewers are grouped by chain sequence (see 8v11);
- Highlight menu now displays names, not accessions;
- StructureViewer reset button works again.