### PR TITLE
TED domains and minor other changes

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -14,6 +14,7 @@ root:
   UniProt: https://rest.uniprot.org/
   proteinsAPI: https://www.ebi.ac.uk/proteins/api/
   EBISurvey:
+  ted: https://ted.cathdb.info/
 
 title: InterPro
 

--- a/config/dev_config.yml
+++ b/config/dev_config.yml
@@ -15,6 +15,7 @@ root:
   Rfam: https://www.ebi.ac.uk/ebisearch/ws/rest/rfam
   UniProt: https://rest.uniprot.org/
   proteinsAPI: https://www.ebi.ac.uk/proteins/api/
+  ted: https://ted.cathdb.info/
 
 title: InterPro
 

--- a/config/master_config.yml
+++ b/config/master_config.yml
@@ -15,6 +15,7 @@ root:
   Rfam: https://www.ebi.ac.uk/ebisearch/ws/rest/rfam
   UniProt: https://rest.uniprot.org/
   proteinsAPI: https://www.ebi.ac.uk/proteins/api/
+  ted: https://ted.cathdb.info/
 
 github:
   InterProClient:

--- a/config/staging_config.yml
+++ b/config/staging_config.yml
@@ -15,6 +15,7 @@ root:
   Rfam: https://www.ebi.ac.uk/ebisearch/ws/rest/rfam
   UniProt: https://rest.uniprot.org/
   proteinsAPI: https://www.ebi.ac.uk/proteins/api/
+  ted: https://ted.cathdb.info/
 
 github:
   InterProClient:

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -206,7 +206,11 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
     return isPrinting ? (
       <span>DisProt consensus</span>
     ) : (
-      <Link href={`https://disprot.org/${entry.protein}`} target="_blank">
+      <Link
+        href={`https://disprot.org/${entry.protein}`}
+        target="_blank"
+        className={css('ext')}
+      >
         DisProt consensus
       </Link>
     );
@@ -218,6 +222,7 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
       <Link
         href={`https://ted.cathdb.info/uniprot/${entry.protein}`}
         target="_blank"
+        className={css('ext')}
       >
         TED domains
       </Link>

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -31,7 +31,7 @@ const EXCEPTIONAL_TYPES = [
   'variation',
   'ptm',
 ];
-const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:'];
+const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:', 'TED:'];
 
 export const isAnExceptionalLabel = (entry: ExtendedFeature): boolean => {
   return (
@@ -208,6 +208,18 @@ const ExceptionalLabels = ({ entry, isPrinting, databases }: PropsEL) => {
     ) : (
       <Link href={`https://disprot.org/${entry.protein}`} target="_blank">
         DisProt consensus
+      </Link>
+    );
+  }
+  if (entry.accession && entry.accession.startsWith('TED:')) {
+    return isPrinting ? (
+      <span>TED domains</span>
+    ) : (
+      <Link
+        href={`https://ted.cathdb.info/uniprot/${entry.protein}`}
+        target="_blank"
+      >
+        TED domains
       </Link>
     );
   }

--- a/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/ExceptionalLabels/index.tsx
@@ -32,6 +32,11 @@ const EXCEPTIONAL_TYPES = [
   'ptm',
 ];
 const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:', 'TED:'];
+const WITH_TOP_PADDING = ['REPEAT:', 'TED:'];
+
+export const isStandaloneLabel = (entry: ExtendedFeature): boolean => {
+  return WITH_TOP_PADDING.some((prefix) => entry.accession.startsWith(prefix));
+};
 
 export const isAnExceptionalLabel = (entry: ExtendedFeature): boolean => {
   return (

--- a/src/components/ProteinViewer/LabelsInTrack/index.tsx
+++ b/src/components/ProteinViewer/LabelsInTrack/index.tsx
@@ -11,7 +11,10 @@ import cssBinder from 'styles/cssBinder';
 import style from '../../ProteinViewer/style.css';
 import grid from '../../ProteinViewer/grid.css';
 import local from './style.css';
-import ExceptionalLabels, { isAnExceptionalLabel } from './ExceptionalLabels';
+import ExceptionalLabels, {
+  isAnExceptionalLabel,
+  isStandaloneLabel,
+} from './ExceptionalLabels';
 
 const css = cssBinder(style, grid, local);
 
@@ -31,9 +34,13 @@ const LabelsInTrack = ({
   const key = entry.source_database === 'pdb' ? 'structure' : 'entry';
   return (
     <div
-      className={css('track-label', {
-        hideCategory,
-      })}
+      className={css(
+        'track-label',
+        isStandaloneLabel(entry) ? 'inner-track-label' : null,
+        {
+          hideCategory,
+        },
+      )}
     >
       {isAnExceptionalLabel(entry) ? (
         <ExceptionalLabels entry={entry} isPrinting={isPrinting} />

--- a/src/components/ProteinViewer/LabelsInTrack/style.css
+++ b/src/components/ProteinViewer/LabelsInTrack/style.css
@@ -1,5 +1,5 @@
 .inner-track-label {
-  padding: 0px;
+  padding: 0;
   margin-top: 8px;
 }
 

--- a/src/components/ProteinViewer/Popup/DisProt/index.tsx
+++ b/src/components/ProteinViewer/Popup/DisProt/index.tsx
@@ -14,10 +14,10 @@ type Props = {
 };
 
 const DisProtPopup = ({ detail }: Props) => {
-  const { locations, type, protein } = detail.feature;
+  const { locations, protein } = detail.feature;
   return (
     <section>
-      <h5>DisProt: {type}</h5>
+      <h6>DisProt: {locations[0].description}</h6>
 
       {locations.map(({ fragments }, i) => (
         <div key={i}>

--- a/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
+++ b/src/components/ProteinViewer/Popup/RepeatsDB/index.tsx
@@ -17,7 +17,7 @@ const RepeatsDBPopup = ({ detail }: Props) => {
   const { locations, protein } = detail.feature;
   return (
     <section>
-      <h5>RepeatsDB: consensus</h5>
+      <h6>RepeatsDB {locations[0].description}</h6>
 
       {locations.map(({ fragments }, i) => (
         <div key={i}>

--- a/src/components/ProteinViewer/Popup/TED/index.tsx
+++ b/src/components/ProteinViewer/Popup/TED/index.tsx
@@ -17,9 +17,7 @@ const TEDPopup = ({ detail }: Props) => {
   const { accession, locations, protein } = detail.feature;
   return (
     <section>
-      <h6>
-        TED Consensus Domains: {accession.replace('TED:', '').split('-')[0]}
-      </h6>
+      <h6>TED Consensus Domains</h6>
       {locations.map(({ fragments }, i) => (
         <div key={i}>
           <Positions fragments={fragments} protein={protein} key={i} />

--- a/src/components/ProteinViewer/Popup/TED/index.tsx
+++ b/src/components/ProteinViewer/Popup/TED/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Positions from '../Positions';
+
+export type TEDDetails = {
+  feature: {
+    accession: string;
+    type: string;
+    protein: string;
+    locations: Array<ProtVistaLocation>;
+  };
+};
+type Props = {
+  detail: TEDDetails;
+};
+
+const TEDPopup = ({ detail }: Props) => {
+  const { accession, locations, protein } = detail.feature;
+  return (
+    <section>
+      <h6>
+        TED Consensus Domains: {accession.replace('TED:', '').split('-')[0]}
+      </h6>
+      {locations.map(({ fragments }, i) => (
+        <div key={i}>
+          <Positions fragments={fragments} protein={protein} key={i} />
+        </div>
+      ))}
+    </section>
+  );
+};
+export default TEDPopup;

--- a/src/components/ProteinViewer/Popup/TED/index.tsx
+++ b/src/components/ProteinViewer/Popup/TED/index.tsx
@@ -17,7 +17,7 @@ const TEDPopup = ({ detail }: Props) => {
   const { accession, locations, protein } = detail.feature;
   return (
     <section>
-      <h6>TED Consensus Domains</h6>
+      <h6>TED consensus domain</h6>
       {locations.map(({ fragments }, i) => (
         <div key={i}>
           <Positions fragments={fragments} protein={protein} key={i} />

--- a/src/components/ProteinViewer/Popup/index.tsx
+++ b/src/components/ProteinViewer/Popup/index.tsx
@@ -8,6 +8,7 @@ import ProtVistaConservationPopup, { ConservationDetail } from './Conservation';
 import RepeatsDBPopup, { RepeatsDBDetail } from './RepeatsDB';
 import ProtVistaPTMPopup, { PTMDetail } from './PTM';
 import DisProtPopup, { DisProtDetail } from './DisProt';
+import TEDPopup, { TEDDetails } from './TED';
 import { ExtendedFeature } from '../utils';
 
 export type PopupDetail = (
@@ -78,11 +79,11 @@ const ProtVistaPopup = ({ detail, sourceDatabase, currentLocation }: Props) => {
   )
     return <RepeatsDBPopup detail={detail as RepeatsDBDetail} />;
   if (
-    ((detail as RepeatsDBDetail)?.feature?.accession || '').startsWith(
-      'DISPROT:',
-    )
+    ((detail as DisProtDetail)?.feature?.accession || '').startsWith('DISPROT:')
   )
     return <DisProtPopup detail={detail as DisProtDetail} />;
+  if (((detail as TEDDetails)?.feature?.accession || '').startsWith('TED:'))
+    return <TEDPopup detail={detail as TEDDetails} />;
 
   // comes from the Entry track
   return (

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -121,6 +121,18 @@ const RepresentativeTrack = ({
     };
   }, [closeTooltip]);
 
+  let plural;
+  switch (type.toLowerCase()) {
+    case 'domain':
+      plural = 'domains';
+      break;
+    case 'family':
+      plural = 'families';
+      break;
+    default:
+      throw new Error(`Unsupported type ${type.toLowerCase()}`);
+  }
+
   return (
     <>
       <div className={css('track', { hideCategory })} ref={containerRef}>
@@ -139,7 +151,7 @@ const RepresentativeTrack = ({
         />
       </div>
       <div className={css('track-label', 'centered-label')}>
-        <b>Representative {type.toLowerCase()}</b>
+        <b>Representative {plural}</b>
       </div>
     </>
   );

--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -96,7 +96,7 @@ const mapToFeatures = (entry: ExtendedFeature, colorDomainsBy: string) =>
     integrated: entry.integrated,
     source_database: entry.source_database,
     locations: [loc],
-    color: getTrackColor(entry, colorDomainsBy),
+    color: loc.color ?? getTrackColor(entry, colorDomainsBy),
     entry_type: entry.entry_type,
     type: entry.type || 'entry',
     residues: entry.residues && JSON.parse(JSON.stringify(entry.residues)),
@@ -386,6 +386,7 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                           margin-left={20}
                           height={12}
                           id={getTrackAccession(entry.accession)}
+                          color={entry.color}
                           highlight-event="onmouseover"
                           highlight-color={highlightColor}
                           use-ctrl-to-zoom

--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -74,6 +74,8 @@ const MARGIN_CHANGE_TRACKS = [
 ];
 
 const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:', 'TED:'];
+const WITH_TOP_MARGIN = ['REPEAT:', 'TED:'];
+const WITH_BOTTOM_MARGIN = ['TED:'];
 
 const b2sh = new Map([
   ['N_TERMINAL_DISC', 'discontinuosStart'], // TODO fix spelling in this and nightingale
@@ -296,6 +298,12 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
             const isExternalSource = EXCEPTIONAL_PREFIXES.some((prefix) =>
               entry.accession.startsWith(prefix),
             );
+            const addTopMargin = WITH_TOP_MARGIN.some((prefix) =>
+              entry.accession.startsWith(prefix),
+            );
+            const addBottomMargin = WITH_BOTTOM_MARGIN.some((prefix) =>
+              entry.accession.startsWith(prefix),
+            );
 
             // Space unintegrated tracks
             const trackTopMargin =
@@ -384,7 +392,13 @@ const TracksInCategory = forwardRef<ExpandedHandle, Props>(
                           length={sequence.length}
                           margin-color="#fafafa"
                           margin-left={20}
-                          height={12}
+                          margin-top={addTopMargin ? 8 : 0}
+                          margin-bottom={addBottomMargin ? 3 : 0}
+                          height={
+                            12 +
+                            (addTopMargin ? 8 : 0) +
+                            (addBottomMargin ? 3 : 0)
+                          }
                           id={getTrackAccession(entry.accession)}
                           color={entry.color}
                           highlight-event="onmouseover"

--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -73,7 +73,7 @@ const MARGIN_CHANGE_TRACKS = [
   'coils',
 ];
 
-const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:'];
+const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:', 'TED:'];
 
 const b2sh = new Map([
   ['N_TERMINAL_DISC', 'discontinuosStart'], // TODO fix spelling in this and nightingale

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -213,11 +213,11 @@ export const ProteinViewer = ({
       }
     }
 
-    /* 
+    /*
       Logic to handle default display settings for families and domains.
       There's cases where representative families or representative domains are not available.
       Examples: representative families still not supported in InterPro Scan, or there's just no representative match found in the data.
-      This can create problems in the summary view, where the domains and families section are hidden by default and just the representative are shown. 
+      This can create problems in the summary view, where the domains and families section are hidden by default and just the representative are shown.
       If the representative track is not available, nothing would be shown. This prevents it, showing all the matches anyway.
     */
     const changeVisibilityFor: string[] = [];
@@ -282,7 +282,7 @@ export const ProteinViewer = ({
                 {children}
               </Options>
 
-              {/* Hide display mode switcher for alphafold viewer due to: 
+              {/* Hide display mode switcher for alphafold viewer due to:
               see comment in UseEffect above*/}
               {protein.accession && viewerType !== 'structures' && (
                 <ShowMoreTracks

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -320,23 +320,27 @@ export const ProteinViewer = ({
                     });
 
                     const LabelComponent = component?.component || 'span';
-                    let representativeEntries: ExtendedFeature[] | null = null;
-                    let nonRepresentativeEntries: ExtendedFeature[] | null =
-                      null;
+                    const reprEntries: ExtendedFeature[] = [];
+                    const tedEntries: ExtendedFeature[] = [];
+                    const otherEntries: ExtendedFeature[] = [];
 
                     if (type === 'domain' || type === 'family') {
-                      representativeEntries = entries.filter(
-                        (entry) => entry.representative === true,
+                      entries.forEach((entry: ExtendedFeature) => {
+                        if (entry.representative) reprEntries.push(entry);
+                        else if (entry.source_database === 'TED')
+                          tedEntries.push(entry);
+                        else otherEntries.push(entry);
+                      });
+                    } else if (type === 'ptm')
+                      standardizePTMData(entries, protein).forEach(
+                        (entry: ExtendedFeature) => {
+                          otherEntries.push(entry);
+                        },
                       );
-                      nonRepresentativeEntries = entries.filter(
-                        (entry) => entry.representative !== true,
-                      );
-                    }
-
-                    // Transform PTM data to track-like data
-                    if (type == 'ptm') {
-                      entries = standardizePTMData(entries, protein);
-                    }
+                    else
+                      entries.forEach((entry: ExtendedFeature) => {
+                        otherEntries.push(entry);
+                      });
 
                     // A few sections (like Alphafold camel case) need to be named differently than simply capitalizing words in the type.
                     // This dict is used to go from type to section name
@@ -390,52 +394,43 @@ export const ProteinViewer = ({
                             />
                           </div>
                         )}{' '}
-                        {representativeEntries ? (
-                          <>
-                            {representativeEntries.length > 0 ? (
-                              <RepresentativeTrack
-                                type={type}
-                                hideCategory={false}
-                                highlightColor={highlightColor}
-                                entries={representativeEntries}
-                                length={protein.sequence.length}
-                                openTooltip={openTooltip}
-                                closeTooltip={closeTooltip}
-                                isPrinting={isPrinting}
-                              />
-                            ) : (
-                              ' '
-                            )}
-                            <TracksInCategory
-                              entries={nonRepresentativeEntries || []}
-                              sequence={protein.sequence}
-                              hideCategory={hideCategory[type]}
-                              highlightColor={highlightColor}
-                              openTooltip={openTooltip}
-                              closeTooltip={closeTooltip}
-                              isPrinting={isPrinting}
-                              ref={(ref: ExpandedHandle) =>
-                                categoryRefs.current.push(ref)
-                              }
-                              databases={dataBase?.payload?.databases}
-                            />
-                          </>
-                        ) : (
-                          entries && (
-                            <TracksInCategory
-                              entries={entries}
-                              sequence={protein.sequence}
-                              hideCategory={hideCategory[type]}
-                              highlightColor={highlightColor}
-                              openTooltip={openTooltip}
-                              closeTooltip={closeTooltip}
-                              isPrinting={isPrinting}
-                              ref={(ref: ExpandedHandle) =>
-                                categoryRefs.current.push(ref)
-                              }
-                              databases={dataBase?.payload?.databases}
-                            />
-                          )
+                        {reprEntries.length > 0 && (
+                          <RepresentativeTrack
+                            type={type}
+                            hideCategory={false}
+                            highlightColor={highlightColor}
+                            entries={reprEntries}
+                            length={protein.sequence.length}
+                            openTooltip={openTooltip}
+                            closeTooltip={closeTooltip}
+                            isPrinting={isPrinting}
+                          />
+                        )}
+                        {tedEntries.length > 0 && (
+                          <TracksInCategory
+                            entries={tedEntries}
+                            sequence={protein.sequence}
+                            hideCategory={false}
+                            highlightColor={highlightColor}
+                            openTooltip={openTooltip}
+                            closeTooltip={closeTooltip}
+                            isPrinting={isPrinting}
+                          />
+                        )}
+                        {otherEntries.length > 0 && (
+                          <TracksInCategory
+                            entries={otherEntries}
+                            sequence={protein.sequence}
+                            hideCategory={hideCategory[type]}
+                            highlightColor={highlightColor}
+                            openTooltip={openTooltip}
+                            closeTooltip={closeTooltip}
+                            isPrinting={isPrinting}
+                            ref={(ref: ExpandedHandle) =>
+                              categoryRefs.current.push(ref)
+                            }
+                            databases={dataBase?.payload?.databases}
+                          />
                         )}
                       </div>
                     );

--- a/src/components/ProteinViewer/utils.ts
+++ b/src/components/ProteinViewer/utils.ts
@@ -27,6 +27,7 @@ export type ExtendedFeatureLocation = {
   confidence?: number;
   description?: string;
   seq_feature?: string;
+  color?: string;
 };
 
 export type ExtendedFeature = Feature & {

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -20,7 +20,7 @@ import {
   sortTracks,
   standardizeMobiDBFeatureStructure,
   standardizeResidueStructure,
-  moveExtraFeatures,
+  moveExternalFeatures,
 } from './utils';
 
 import { createSelector } from 'reselect';
@@ -264,7 +264,7 @@ const DomainsOnProteinLoaded = ({
   }
 
   if (processedDataMerged['external_sources']) {
-    moveExtraFeatures(processedDataMerged);
+    moveExternalFeatures(processedDataMerged);
   }
 
   // Reorganize sections and sort added matches

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -241,6 +241,7 @@ const DomainsOnProteinLoaded = ({
       'short_linear_motifs',
       'spurious_proteins',
       'active_site',
+      'external_sources',
     ];
     const tracksToProcess = allTracks.filter(
       (track) => !unaffectedTracks.includes(track),

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -20,6 +20,7 @@ import {
   sortTracks,
   standardizeMobiDBFeatureStructure,
   standardizeResidueStructure,
+  moveExtraFeatures,
 } from './utils';
 
 import { createSelector } from 'reselect';
@@ -260,6 +261,10 @@ const DomainsOnProteinLoaded = ({
         );
       });
     }
+  }
+
+  if (processedDataMerged['external_sources']) {
+    moveExtraFeatures(processedDataMerged);
   }
 
   // Reorganize sections and sort added matches

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/utils.ts
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/utils.ts
@@ -79,6 +79,8 @@ export function sortTracks(
   const [aAccession, aStart, aEnd] = getBoundaries(a);
   const [bAccession, bStart, bEnd] = getBoundaries(b);
 
+  if (aAccession && (aAccession as string).startsWith('TED:')) return -1;
+  if (bAccession && (bAccession as string).startsWith('TED:')) return 1;
   if (aStart > bStart) return 1;
   if (aStart < bStart) return -1;
   if (aStart === bStart) {
@@ -354,9 +356,9 @@ function processInterProN_Matches(
   );
   integratedInterProN_Matches = addSuffix(integratedInterProN_Matches);
 
-  /* 
+  /*
   Create map <integrated_accession: integrated_entryobj> to append integrated matches as children later
-   NOTE: see structure of returned InterPro-N objects 
+   NOTE: see structure of returned InterPro-N objects
   (it's a dict, where matches accessions are keys, values then contain the integrated entry as another dict)
   */
   let integratedInterProN_Map: Map<string, InterProN_Match> = new Map();
@@ -412,11 +414,11 @@ function processInterProN_Matches(
     type,
   );
 
-  /* 
+  /*
   Depending on which mode is selected, we need to return different objects
     - Only InterPro-N, "dl": simply return the merged unintegrated, integrated and representative data
     - Default mode, "best": return a record with the map of the integrated, the array of unintegrated and the list of best matches
-    - Stacked mode, "hmm_and_dl": return a record with the map of the integrated and the array of unintegrated 
+    - Stacked mode, "hmm_and_dl": return a record with the map of the integrated and the array of unintegrated
   */
   switch (mode) {
     case 'dl':
@@ -477,7 +479,7 @@ function combineMatches(
     ExtendedFeature | InterProN_Match
   > = new Map();
 
-  /* 
+  /*
     Build initial structure for unintegrated entries starting from InterPro-N ones.
     We're going to have a parentUnintegrated entry where all the unintegrated entries (HMMs and DLs)
     with the same accessionare going to fall.
@@ -523,7 +525,7 @@ function combineMatches(
     }
   });
 
-  /* 
+  /*
     Now we're going to to the same thing for integrated entries.
     Build initial structure for integrated entries starting from InterPro-N ones.
     We're going to have a parent InterPro entry where all the integrated entries (HMMs and DLs)
@@ -575,8 +577,8 @@ function combineMatches(
     }
   });
 
-  /* 
-    Logic to add representative data 
+  /*
+    Logic to add representative data
     Take representativa data from traditional matches first.
     If it's not available, then show the traditional data from InterPro-N
   */
@@ -709,8 +711,8 @@ function chooseBestMatch(
     });
   });
 
-  /* 
-  Logic to add representative data 
+  /*
+  Logic to add representative data
   Take representativa data from traditional matches first.
   If it's not available, then show the traditional data from InterPro-N
   */
@@ -792,3 +794,22 @@ export function mergeMatches(
       return [];
   }
 }
+
+export const moveExtraFeatures = (data: ProteinViewerDataObject) => {
+  data['external_sources'] = (
+    data['external_sources'] as MinimalFeature[]
+  ).filter((feature: MinimalFeature) => {
+    if (feature.source_database === 'DisProt') {
+      data['intrinsically_disordered_regions'].push(feature);
+      return false;
+    } else if (
+      feature.source_database === 'RepeatsDB' ||
+      feature.source_database === 'TED'
+    ) {
+      data['domain'].push(feature);
+      return false;
+    }
+
+    return true;
+  });
+};

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/utils.ts
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/utils.ts
@@ -795,7 +795,7 @@ export function mergeMatches(
   }
 }
 
-export const moveExtraFeatures = (data: ProteinViewerDataObject) => {
+export const moveExternalFeatures = (data: ProteinViewerDataObject) => {
   data['external_sources'] = (
     data['external_sources'] as MinimalFeature[]
   ).filter((feature: MinimalFeature) => {

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
@@ -15,26 +15,39 @@ export const formatDisProt = ({
 }: RequestedData<DisProtPayload>) => {
   const panelsData: MinimalFeature[] = [];
   if (!loading && status === HTTP_OK && payload) {
-    let i = 1;
+    const locationsByType = {} as { [key: string]: ProtVistaLocation[] };
+    Object.keys(TYPES).forEach((key) => {
+      locationsByType[key] = [];
+    });
     for (const region of payload.disprot_consensus.full) {
-      panelsData.push({
-        accession: `DISPROT:${i++}`,
-        protein: payload.acc,
-        source_database: 'DisProt',
-        type: TYPES[region.type] || '',
-        locations: [
-          {
-            fragments: [
-              {
-                start: region.start,
-                end: region.end,
-              },
-            ],
-          },
-        ],
-      } as MinimalFeature);
+      const key = region.type;
+      if (locationsByType[key]) {
+        locationsByType[key].push({
+          fragments: [
+            {
+              start: region.start,
+              end: region.end,
+            },
+          ],
+        } as ProtVistaLocation);
+      }
     }
+
+    Object.keys(locationsByType).forEach((key) => {
+      const locations = locationsByType[key];
+      if (locations.length > 0) {
+        panelsData.push({
+          accession: `DISPROT:${panelsData.length + 1}`,
+          protein: payload.acc,
+          source_database: 'DisProt',
+          type: TYPES[key],
+          locations: locations,
+          color: '#A7662B',
+        } as MinimalFeature);
+      }
+    });
   }
+
   return panelsData;
 };
 

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/DisProt/index.ts
@@ -1,11 +1,11 @@
 const HTTP_OK = 200;
 
-const TYPES: { [key: string]: string } = {
-  F: 'Function region',
-  S: 'Order state',
-  D: 'Disorder state',
-  T: 'Transition',
-  I: 'Transition with interaction',
+const TYPES: { [key: string]: [string, string] } = {
+  F: ['Function', '#b01e1c'],
+  S: ['Ordered', '#008de5'],
+  D: ['Disorder', '#a7662b'],
+  T: ['Transition', '#761e6f'],
+  I: ['Transition with interaction', '#761e6f'],
 };
 
 export const formatDisProt = ({
@@ -15,14 +15,13 @@ export const formatDisProt = ({
 }: RequestedData<DisProtPayload>) => {
   const panelsData: MinimalFeature[] = [];
   if (!loading && status === HTTP_OK && payload) {
-    const locationsByType = {} as { [key: string]: ProtVistaLocation[] };
-    Object.keys(TYPES).forEach((key) => {
-      locationsByType[key] = [];
-    });
+    const locations = [];
     for (const region of payload.disprot_consensus.full) {
-      const key = region.type;
-      if (locationsByType[key]) {
-        locationsByType[key].push({
+      if (TYPES[region.type]) {
+        const [description, color] = TYPES[region.type];
+        locations.push({
+          color: color,
+          description: description,
           fragments: [
             {
               start: region.start,
@@ -33,19 +32,14 @@ export const formatDisProt = ({
       }
     }
 
-    Object.keys(locationsByType).forEach((key) => {
-      const locations = locationsByType[key];
-      if (locations.length > 0) {
-        panelsData.push({
-          accession: `DISPROT:${panelsData.length + 1}`,
-          protein: payload.acc,
-          source_database: 'DisProt',
-          type: TYPES[key],
-          locations: locations,
-          color: '#A7662B',
-        } as MinimalFeature);
-      }
-    });
+    if (locations.length > 0) {
+      panelsData.push({
+        accession: `DISPROT:${panelsData.length + 1}`,
+        protein: payload.acc,
+        source_database: 'DisProt',
+        locations: locations,
+      } as MinimalFeature);
+    }
   }
 
   return panelsData;

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/RepeatsDB/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/RepeatsDB/index.ts
@@ -16,7 +16,8 @@ export const formatRepeatsDB = ({
             accession: `REPEAT:${proteinAcc}:${feature.start}-${feature.end}`,
             protein: proteinAcc,
             source_database: 'RepeatsDB',
-            type: 'Consensus',
+            type: 'Repeated region',
+            color: '#cc79a7',
             locations: [
               {
                 fragments: [

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/RepeatsDB/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/RepeatsDB/index.ts
@@ -10,25 +10,42 @@ export const formatRepeatsDB = ({
     const data = Object.values(payload.items);
     for (const item of data) {
       const proteinAcc = item.content.chain.structure;
-      for (const feature of item.content.loci) {
-        if (feature.type === 'region')
-          panelsData.push({
-            accession: `REPEAT:${proteinAcc}:${feature.start}-${feature.end}`,
-            protein: proteinAcc,
-            source_database: 'RepeatsDB',
-            type: 'Repeated region',
-            color: '#cc79a7',
-            locations: [
+      const locations = [];
+      let units = 0;
+      for (const loci of item.content.loci) {
+        if (loci.type === 'unit') {
+          locations.push({
+            color: units++ % 2 === 0 ? '#0072b2' : '#d55e00',
+            fragments: [
               {
-                fragments: [
-                  {
-                    start: feature.start,
-                    end: feature.end,
-                  },
-                ],
+                start: loci.start,
+                end: loci.end,
               },
             ],
-          } as MinimalFeature);
+            description: 'unit',
+          });
+        } else if (loci.type === 'insertion') {
+          locations.push({
+            color: '#f0e442',
+            fragments: [
+              {
+                start: loci.start,
+                end: loci.end,
+              },
+            ],
+            description: 'insertion',
+          });
+        }
+      }
+
+      if (locations.length > 0) {
+        panelsData.push({
+          accession: `REPEAT:${proteinAcc}:${panelsData.length}`,
+          protein: proteinAcc,
+          source_database: 'RepeatsDB',
+          type: 'Repeated region',
+          locations: locations,
+        } as MinimalFeature);
       }
     }
   }

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/TED/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/TED/index.ts
@@ -17,7 +17,14 @@ export const formatTED = ({
   status,
   payload,
 }: RequestedData<TEDPayload>) => {
-  if (loading || status !== HTTP_OK || !payload) return [] as MinimalFeature[];
+  if (
+    loading ||
+    status !== HTTP_OK ||
+    !payload ||
+    !payload.data ||
+    payload.data.length === 0
+  )
+    return [] as MinimalFeature[];
 
   return [
     {

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/TED/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/TED/index.ts
@@ -1,4 +1,16 @@
 const HTTP_OK = 200;
+const COLORS = [
+  '#4a79a7',
+  '#f28e2c',
+  '#e15759',
+  '#76b7b2',
+  '#59a14f',
+  '#edc949',
+  '#af7aa1',
+  '#ff9da7',
+  '#9c755f',
+  '#bab0ab',
+];
 
 export const formatTED = ({
   loading,
@@ -7,26 +19,22 @@ export const formatTED = ({
 }: RequestedData<TEDPayload>) => {
   if (loading || status !== HTTP_OK || !payload) return [] as MinimalFeature[];
 
-  return payload.data.map((domain: TEDDomain, index: number) => {
-    const tedId = (domain.ted_id.match(/TED\d+/) ?? ['TED'])[0];
-    return {
-      accession: `TED:${tedId}-${index}`,
-      protein: domain.uniprot_acc,
+  return [
+    {
+      accession: `TED:TED`,
       source_database: 'TED',
-      type: 'Domain',
-      locations: [
-        {
-          fragments: domain.chopping.split('_').map((segment) => {
-            const [start, end] = segment.split('-').map(Number);
-            return {
-              start: start,
-              end: end,
-            };
-          }),
-        },
-      ],
-    } as MinimalFeature;
-  });
+      locations: payload.data.map((domain: TEDDomain, index: number) => ({
+        color: COLORS[index % COLORS.length],
+        fragments: domain.chopping.split('_').map((segment) => {
+          const [start, end] = segment.split('-').map(Number);
+          return {
+            start: start,
+            end: end,
+          };
+        }),
+      })),
+    },
+  ] as MinimalFeature[];
 };
 
 export default formatTED;

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/TED/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/TED/index.ts
@@ -1,0 +1,32 @@
+const HTTP_OK = 200;
+
+export const formatTED = ({
+  loading,
+  status,
+  payload,
+}: RequestedData<TEDPayload>) => {
+  if (loading || status !== HTTP_OK || !payload) return [] as MinimalFeature[];
+
+  return payload.data.map((domain: TEDDomain, index: number) => {
+    const tedId = (domain.ted_id.match(/TED\d+/) ?? ['TED'])[0];
+    return {
+      accession: `TED:${tedId}-${index}`,
+      protein: domain.uniprot_acc,
+      source_database: 'TED',
+      type: 'Domain',
+      locations: [
+        {
+          fragments: domain.chopping.split('_').map((segment) => {
+            const [start, end] = segment.split('-').map(Number);
+            return {
+              start: start,
+              end: end,
+            };
+          }),
+        },
+      ],
+    } as MinimalFeature;
+  });
+};
+
+export default formatTED;

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
@@ -41,8 +41,6 @@ export function loadExternalSources<
     const disprotFormatted = dataDisProt ? formatDisProt(dataDisProt) : [];
     const tedFormatted = dataTED ? formatTED(dataTED) : [];
 
-    // TODO: Add Disprot
-
     // Fetch the props you want to inject. This could be done with context instead.
     const newProps = {
       externalSourcesData: [

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
@@ -116,25 +116,21 @@ const getDisProtURL = createSelector(
 );
 
 export const getTEDURL = createSelector(
-  (state: GlobalState) => state.settings.api,
+  (state: GlobalState) => state.settings.ted,
   (state: GlobalState) => state.customLocation.description.protein.accession,
   (
     { protocol, hostname, port, root }: ParsedURLServer,
     accession: string | null,
   ) => {
     if (!accession) return null;
-    const newDesc: InterProPartialDescription = {
-      main: { key: 'protein' },
-      protein: { db: 'uniprot', accession },
-    };
     return format({
       protocol,
       hostname,
       port,
-      pathname: root + descriptionToPath(newDesc),
-      query: {
-        ted: '',
-      },
+      pathname: `${root}/api/v1/uniprot/summary/${accession}`.replaceAll(
+        /\/{2,}/g,
+        '/',
+      ),
     });
   },
 );

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
@@ -6,7 +6,6 @@ import loadData from 'higherOrder/loadData/ts';
 import formatRepeatsDB from './RepeatsDB';
 import formatDisProt from './DisProt';
 import formatTED from './TED';
-import descriptionToPath from 'utils/processDescription/descriptionToPath';
 
 export type ExtenalSourcesProps = {
   loading: boolean;

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
@@ -115,7 +115,7 @@ const getDisProtURL = createSelector(
   },
 );
 
-const getTEDURL = createSelector(
+export const getTEDURL = createSelector(
   (state: GlobalState) => state.settings.api,
   (state: GlobalState) => state.customLocation.description.protein.accession,
   (

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
@@ -6,6 +6,7 @@ import loadData from 'higherOrder/loadData/ts';
 import formatRepeatsDB from './RepeatsDB';
 import formatDisProt from './DisProt';
 import formatTED from './TED';
+import descriptionToPath from 'utils/processDescription/descriptionToPath';
 
 export type ExtenalSourcesProps = {
   loading: boolean;
@@ -117,28 +118,26 @@ const getDisProtURL = createSelector(
 );
 
 const getTEDURL = createSelector(
-  (state: GlobalState) => state.settings.ted,
+  (state: GlobalState) => state.settings.api,
   (state: GlobalState) => state.customLocation.description.protein.accession,
   (
     { protocol, hostname, port, root }: ParsedURLServer,
     accession: string | null,
   ) => {
     if (!accession) return null;
+    const newDesc: InterProPartialDescription = {
+      main: { key: 'protein' },
+      protein: { db: 'uniprot', accession },
+    };
     return format({
       protocol,
       hostname,
       port,
-      pathname: root,
+      pathname: root + descriptionToPath(newDesc),
       query: {
-        acc: accession,
+        ted: '',
       },
     });
-    // return format({
-    //   protocol,
-    //   hostname,
-    //   port,
-    //   pathname: `${root}/api/v1/uniprot/summary/${accession}`.replaceAll(/\/{2,}/g, '/'),
-    // });
   },
 );
 

--- a/src/components/Related/DomainsOnProtein/utils.ts
+++ b/src/components/Related/DomainsOnProtein/utils.ts
@@ -195,8 +195,8 @@ export const proteinViewerReorganization = (
 
       if (!uniqueResidues[dictKey]) uniqueResidues[dictKey] = currentResidue;
     } else {
-      /* 
-        Results coming in from InterProScan 5 are splitted. We get a residue object for each "location" match. 
+      /*
+        Results coming in from InterProScan 5 are splitted. We get a residue object for each "location" match.
         Normally we'd have a single residue object with multiple locations matches in the "locations" attribute.
         The following logic is to group residues in a single object based on accession and the sites' description.
       */

--- a/src/reducers/settings/category/index.ts
+++ b/src/reducers/settings/category/index.ts
@@ -101,6 +101,14 @@ export const getDefaultSettingsFor = <T extends keyof SettingsState>(
         root: config.root.alphafold.pathname,
         query: config.root.alphafold.query,
       } as SettingsState[T];
+    case 'ted':
+      return {
+        protocol: config.root.ted.protocol,
+        hostname: config.root.ted.hostname,
+        port: config.root.ted.port || DEFAULT_HTTP_PORT,
+        root: config.root.ted.pathname,
+        query: config.root.ted.query,
+      } as SettingsState[T];
     default:
       return null;
   }

--- a/src/reducers/settings/index.ts
+++ b/src/reducers/settings/index.ts
@@ -15,4 +15,5 @@ export default combineReducers({
   wikipedia: category('wikipedia'),
   alphafold: category('alphafold'),
   proteinsAPI: category('proteinsAPI'),
+  ted: category('ted'),
 });

--- a/src/store/utils/get-initial-state/index.js
+++ b/src/store/utils/get-initial-state/index.js
@@ -71,6 +71,12 @@ export default (historyWrapper) => {
         port: config.root.proteinsAPI.port || DEFAULT_HTTP_PORT,
         root: config.root.proteinsAPI.pathname,
       };
+      settings.ted = {
+        protocol: config.root.ted.protocol,
+        hostname: config.root.ted.hostname,
+        port: config.root.ted.port || DEFAULT_HTTP_PORT,
+        root: config.root.ted.pathname,
+      };
     }
   }
   let description = { other: ['NotFound'] };

--- a/src/types/external-payloads.d.ts
+++ b/src/types/external-payloads.d.ts
@@ -241,3 +241,13 @@ type DisProtPayload = {
   regions: Array<DisprotRegion>;
   disprot_consensus: DisprotConsensus;
 };
+type TEDDomain = {
+  ted_id: string;
+  uniprot_acc: string;
+  consensus_level: string;
+  chopping: string;
+  cath_label: string;
+};
+type TEDPayload = {
+  data: Array<TEDDomain>;
+};

--- a/src/types/interpro-payloads.d.ts
+++ b/src/types/interpro-payloads.d.ts
@@ -345,6 +345,7 @@ type MinimalFeature = {
   locations?: Array<ProtVistaLocation>;
   children?: Array<{ accession: string; source_database: string }>;
   member_databases?: Record<string, unknown>;
+  representative?: boolean;
 };
 
 type Shapes =

--- a/src/types/state.d.ts
+++ b/src/types/state.d.ts
@@ -141,6 +141,7 @@ type SettingsState = {
   uniprot: ParsedURLServer;
   rfam: ParsedURLServer;
   proteinsAPI: ParsedURLServer;
+  ted: ParsedURLServer;
 };
 type ParsedURLServer = {
   protocol: string;
@@ -214,7 +215,8 @@ type Server =
   | 'alphafold'
   | 'repeatsDB'
   | 'disprot'
-  | 'proteinsAPI';
+  | 'proteinsAPI'
+  | 'ted';
 type ServerStatus = {
   status: boolean | null;
   lastCheck: number | null;

--- a/src/utils/entry-color/index.js
+++ b/src/utils/entry-color/index.js
@@ -32,6 +32,7 @@ export const getTrackColor = (
   entry /*: Entry */,
   colorMode /*: ColorMode */,
 ) => {
+  if (entry.color) return entry.color;
   let acc;
   // eslint-disable-next-line default-case
   switch (colorMode) {


### PR DESCRIPTION
This PR fetches TED domains from the TED API ~~_via_ the InterPro API (see ProteinsWebTeam/interpro7-api#178)~~. TED domains are shown under the representative domains section. They stay visible in summary/overview mode and are displayed on the protein overview page and the AlphaFold subpage.

> [!CAUTION]
> The EMBL-EBI domains have been whitelisted, so the TED API can be used on our frontend. However, a local instance running on `localhost` will still experience CORS issues. As a workaround, use `https://matthiasblum.fr/ted/` as a proxy instead of `https://ted.cathdb.info/`.

Other changes:
- RepeatsDB
  - Moved from the _External sources_ section to the _Domains_ section
  - Displaying individual units instead of the full consensus
- DisProt:
  - Moved from the _External sources_ section to the _Intrinsically disordered regions_ section
- Coloring:
  - Allow specifying the color of individual tracks or even locations so they are not all in the same color (dark grey) if the color of the source database isn't defined in `config.yml`.