### PR TITLE
Check that parent.accession is not undefined

### DIFF
--- a/src/utils/entry-color/index.js
+++ b/src/utils/entry-color/index.js
@@ -58,7 +58,7 @@ export const getTrackColor = (
           return colorHash.hex('MobiDB-lite: Consensus Disorder Prediction');
         }
       }
-      if (entry.parent) {
+      if (entry.parent && entry.parent.accession) {
         acc = entry.parent.accession.split('').reverse().join('');
         return colorHash.hex(acc);
       }


### PR DESCRIPTION
When coloring by domain relationship, the error below is raised for tracks without a proper parent, e.g. unintegrated signatures, residue tracks, etc.

> TypeError: e.parent.accession is undefined

This PR adds a quick check to prevent this error.