### PR TITLE
BFVD extra

### DIFF
--- a/config/master_config.yml
+++ b/config/master_config.yml
@@ -48,6 +48,7 @@ pages:
       - structure
       - logo
       - alphafold
+      - bfvd
       - entry_alignments
       - interactions
       - pathways
@@ -60,6 +61,7 @@ pages:
       - entry
       - structure
       - alphafold
+      - bfvd
       - sequence
       - similar_proteins
   structure:

--- a/config/staging_config.yml
+++ b/config/staging_config.yml
@@ -49,6 +49,7 @@ pages:
       - model
       - logo
       - alphafold
+      - bfvd
       - entry_alignments
       - interactions
       - pathways
@@ -60,6 +61,7 @@ pages:
       - entry
       - structure
       - alphafold
+      - bfvd
       - sequence
       - similar_proteins
   structure:

--- a/src/components/Matches/index.tsx
+++ b/src/components/Matches/index.tsx
@@ -552,7 +552,10 @@ const Matches = ({
       <Column
         dataKey="in_alphafold"
         displayIf={primary === 'protein'}
-        renderer={(inAlphafold: boolean, { accession }: ProteinMetadata) =>
+        renderer={(
+          inAlphafold: boolean,
+          { accession, in_bfvd }: ProteinMetadata,
+        ) =>
           inAlphafold ? (
             <Link
               to={{
@@ -563,6 +566,21 @@ const Matches = ({
               }}
             >
               AlphaFold
+            </Link>
+          ) : in_bfvd ? (
+            <Link
+              to={{
+                description: {
+                  main: { key: 'protein' },
+                  protein: {
+                    db: 'uniprot',
+                    accession,
+                    detail: 'bfvd',
+                  },
+                },
+              }}
+            >
+              BFVD
             </Link>
           ) : null
         }

--- a/src/pages/Protein/index.tsx
+++ b/src/pages/Protein/index.tsx
@@ -335,7 +335,7 @@ const List = ({ data, customLocation, isStale, dataBase }: LoadedProps) => {
           </Column>
           <Column
             dataKey="in_alphafold"
-            renderer={(inAlphafold, { accession }) =>
+            renderer={(inAlphafold, { accession, in_bfvd }: ProteinMetadata) =>
               inAlphafold ? (
                 <Link
                   to={{
@@ -350,6 +350,21 @@ const List = ({ data, customLocation, isStale, dataBase }: LoadedProps) => {
                   }}
                 >
                   AlphaFold
+                </Link>
+              ) : in_bfvd ? (
+                <Link
+                  to={{
+                    description: {
+                      main: { key: 'protein' },
+                      protein: {
+                        db: 'uniprot',
+                        accession,
+                        detail: 'bfvd',
+                      },
+                    },
+                  }}
+                >
+                  BFVD
                 </Link>
               ) : null
             }

--- a/src/subPages/SimilarProteins/Table/index.tsx
+++ b/src/subPages/SimilarProteins/Table/index.tsx
@@ -217,7 +217,10 @@ const SimilarProteinTable = ({
         <Column dataKey="gene">Gene</Column>
         <Column
           dataKey="in_alphafold"
-          renderer={(inAlphafold: boolean, { accession }: ProteinMetadata) =>
+          renderer={(
+            inAlphafold: boolean,
+            { accession, in_bfvd }: ProteinMetadata,
+          ) =>
             inAlphafold ? (
               <Link
                 to={{
@@ -228,6 +231,21 @@ const SimilarProteinTable = ({
                 }}
               >
                 AlphaFold
+              </Link>
+            ) : in_bfvd ? (
+              <Link
+                to={{
+                  description: {
+                    main: { key: 'protein' },
+                    protein: {
+                      db: 'uniprot',
+                      accession,
+                      detail: 'bfvd',
+                    },
+                  },
+                }}
+              >
+                BFVD
               </Link>
             ) : null
           }


### PR DESCRIPTION
This PR adds to following:

- fix for the two config files that are missing the `bfvd` subpages
- links from the protein tables to the BFVD subpage (at the moment, the "Predicted Structure" column shows a link to the AlphaFold subpage, but if the protein has a BFVD prediction, it shows nothing)