### PR TITLE
BFVD and Repeat fixes

### DIFF
--- a/src/components/ProteinViewer/TracksInCategory/index.tsx
+++ b/src/components/ProteinViewer/TracksInCategory/index.tsx
@@ -76,7 +76,7 @@ const MARGIN_CHANGE_TRACKS = [
 const EXCEPTIONAL_PREFIXES = ['G3D:', 'REPEAT:', 'DISPROT:', 'TED:'];
 const WITH_TOP_MARGIN = ['REPEAT:', 'TED:'];
 const WITH_BOTTOM_MARGIN = ['TED:'];
-const domainTypes = ['domain', 'homologous_superfamily', 'repeats'];
+const domainTypes = ['domain', 'homologous_superfamily', 'repeat'];
 
 const b2sh = new Map([
   ['N_TERMINAL_DISC', 'discontinuosStart'], // TODO fix spelling in this and nightingale

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -272,10 +272,8 @@ const DomainsOnProteinLoaded = ({
     moveExternalFeatures(processedDataMerged);
   }
 
-  console.log('hey', processedDataMerged);
   // Reorganize sections and sort added matches
   processedDataMerged = sectionsReorganization(processedDataMerged);
-  console.log(processedDataMerged);
 
   // Sort data by match position, but exclude residues and PIRSR
   Object.entries(

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -244,11 +244,16 @@ const DomainsOnProteinLoaded = ({
       'active_site',
       'external_sources',
     ];
-    const tracksToProcess = allTracks.filter(
-      (track) => !unaffectedTracks.includes(track),
-    );
 
     if (matchTypeSettings && colorDomainsBy) {
+      if (matchTypeSettings !== 'hmm') {
+        unaffectedTracks.push('repeat');
+      }
+
+      const tracksToProcess = allTracks.filter(
+        (track) => !unaffectedTracks.includes(track),
+      );
+
       tracksToProcess.forEach((track) => {
         const traditionalMatches = processedDataMerged[track];
 
@@ -267,8 +272,10 @@ const DomainsOnProteinLoaded = ({
     moveExternalFeatures(processedDataMerged);
   }
 
+  console.log('hey', processedDataMerged);
   // Reorganize sections and sort added matches
   processedDataMerged = sectionsReorganization(processedDataMerged);
+  console.log(processedDataMerged);
 
   // Sort data by match position, but exclude residues and PIRSR
   Object.entries(

--- a/src/components/Structure/ViewerAndEntries/ProteinViewerForPredictedStructure/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/ProteinViewerForPredictedStructure/index.tsx
@@ -236,7 +236,8 @@ const ProteinViewerForAlphafold = ({
   }, [processedData, dataConfidence, bfvd, protein]);
 
   useEffect(() => {
-    trackRef.current?.addEventListener('change', (rawEvent: Event) => {
+    const currentTrack = trackRef.current;
+    const handleChange = (rawEvent: Event) => {
       const event = rawEvent as CustomEvent;
       if (!event.detail) return;
       const { eventType, highlight } = event.detail;
@@ -278,7 +279,14 @@ const ProteinViewerForAlphafold = ({
           setFixedSelection(hoverSelectionRef.current);
         }
       }
-    });
+    };
+    // Add the listener
+    currentTrack?.addEventListener('change', handleChange);
+
+    // Clean up listener
+    return () => {
+      trackRef.current?.removeEventListener('change', handleChange);
+    };
   }, [trackRef.current, processedTracks]);
   if (
     !data ||


### PR DESCRIPTION
This PR addresses the following fixes:
- Repeats were .. repeated.. because of a mismatch domain != repeat between child and parent element. (`A0A084B9Z8`); 
- BFVD fixed highlighting on click now works;
- Some matches aren't displayed when opening the page. Didn't experience the problem again. Will have to check if that happens once published on `wwwdev`.