### PR TITLE
Minor change to domain viewer margins

### DIFF
--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -240,7 +240,13 @@ export const ProteinViewer = ({
   }, [showMoreSettings]);
 
   return (
-    <div ref={mainRef} className={css('fullscreenable', 'margin-bottom-large')}>
+    <div
+      ref={mainRef}
+      className={css(
+        'fullscreenable',
+        viewerType !== 'structures' ? 'margin-bottom-large' : '',
+      )}
+    >
       {/* Tooltip */}
       <div
         ref={refs.setFloating}

--- a/src/components/ProteinViewer/style.css
+++ b/src/components/ProteinViewer/style.css
@@ -152,6 +152,8 @@ g:global(.child-location-group.clg-5) path {
 }
 .fullscreenable {
   overflow: scroll;
+}
+.margin-bottom-large {
   min-height: 600px; /*To fit option menu*/
 }
 table.matches-in-table {

--- a/src/components/Related/DomainEntriesOnStructure/index.tsx
+++ b/src/components/Related/DomainEntriesOnStructure/index.tsx
@@ -6,6 +6,7 @@ import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 import ProteinViewerForStructure from './ProteinViewerLoaded';
 
 import cssBinder from 'styles/cssBinder';
+import ipro from 'styles/interpro-vf.css';
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import { orderByAccession } from 'components/Related/DomainsOnProtein/utils';
 import { flattenTracksObject } from 'components/Related/DomainsOnProtein/DomainsOnProteinLoaded';
@@ -14,7 +15,7 @@ import { DataForProteinChain, mergeChimericProteins } from './utils';
 
 import { ExtendedFeature } from 'components/ProteinViewer/utils';
 
-const css = cssBinder(fonts);
+const css = cssBinder(ipro, fonts);
 
 function getBoundaries(item: ExtendedFeature | ExtendedFeature[]) {
   let fragment = undefined;
@@ -318,9 +319,9 @@ const EntriesOnStructure = ({
 
           let accessionList: string[] = [];
 
-          /* 
-            - Take protein object for each "viewer" data 
-            - take the accession 
+          /*
+            - Take protein object for each "viewer" data
+            - take the accession
             - split the accession if it's composed of multiple uniprot accessions
           */
 

--- a/src/styles/interpro-vf.css
+++ b/src/styles/interpro-vf.css
@@ -146,3 +146,7 @@ details.read-more {
     cursor: pointer;
   }
 }
+
+.vf-stack > h4 + * {
+  margin-top: 0;
+}


### PR DESCRIPTION
This PR changes how bottom margins are used for the domain viewer, i.e. only use larger margins, required to show the Options menu with the InterPro-N options, when we have non-structure proteins.

It also slightly reduces the domain viewer and its title.