### PR TITLE
Improve Search Bar in Header

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -14,6 +14,7 @@ import { sideNavSelector } from 'reducers/ui/sideNav';
 import { toggleSideNav } from 'actions/creators';
 
 import ResizeObserverComponent from 'wrappers/ResizeObserverComponent';
+import getURLByAccession from 'utils/processDescription/getURLbyAccession';
 
 import Link from 'components/generic/Link';
 // $FlowFixMe
@@ -134,6 +135,12 @@ export class _SideIcons extends PureComponent {
 
   setSearchValue = (value) => {
     this.setState({ searchValue: value });
+    const directLinkDescription = getURLByAccession(value);
+    if (directLinkDescription) {
+      this.setState({ directLink: descriptionToPath(directLinkDescription) });
+    } else {
+      this.setState({ directLink: null });
+    }
   };
 
   render() {
@@ -152,21 +159,25 @@ export class _SideIcons extends PureComponent {
             <TextSearchBox
               name="search"
               delay={DEBOUNCE_RATE_SLOW}
-              shouldRedirect={true}
               forHeader={true}
               setSearchValue={this.setSearchValue}
             />
             <Link
-              to={{
-                description: {
-                  main: { key: 'search' },
-                  search: {
-                    ...search,
-                    type: 'text',
-                    value: searchValue,
-                  },
-                },
-              }}
+              to={
+                !this.state.directLink
+                  ? {
+                      description: {
+                        main: { key: 'search' },
+                        search: {
+                          ...search,
+                          type: 'text',
+                          value: searchValue,
+                        },
+                      },
+                    }
+                  : null
+              }
+              href={this.state.directLink}
             >
               <div role="button" aria-label="Search InterPro">
                 <svg

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -117,7 +117,7 @@ const HamburgerBtn = connect(mapStateToPropsHamburger, { toggleSideNav })(
   search: Object
 }; */
 
-export class _SideIcons extends PureComponent /*:: <SideIconsProps> */ {
+export class _SideIcons extends PureComponent {
   static propTypes = {
     movedAway: T.bool.isRequired,
     stuck: T.bool.isRequired,
@@ -125,8 +125,21 @@ export class _SideIcons extends PureComponent /*:: <SideIconsProps> */ {
     search: T.object.isRequired,
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      searchValue: '',
+    };
+  }
+
+  setSearchValue = (value) => {
+    this.setState({ searchValue: value });
+  };
+
   render() {
     const { movedAway, stuck, lowGraphics, search } = this.props;
+    const { searchValue } = this.state;
+
     return (
       <div
         className={styleBundle('columns', 'small-6', 'medium-4', {
@@ -141,6 +154,7 @@ export class _SideIcons extends PureComponent /*:: <SideIconsProps> */ {
               delay={DEBOUNCE_RATE_SLOW}
               shouldRedirect={true}
               forHeader={true}
+              setSearchValue={this.setSearchValue}
             />
             <Link
               to={{
@@ -149,6 +163,7 @@ export class _SideIcons extends PureComponent /*:: <SideIconsProps> */ {
                   search: {
                     ...search,
                     type: 'text',
+                    value: searchValue,
                   },
                 },
               }}
@@ -213,7 +228,6 @@ export class Header extends PureComponent /*:: <HeaderProps> */ {
   // TODO: check why position:sticky banner in the page works just on top - pbm with container
   render() {
     const { stickyMenuOffset: offset, stuck, isSignature } = this.props;
-    // console.log(this.state);
     const shouldStuck = stuck;
     return (
       <div

--- a/src/components/SearchByText/TextSearchBox/index.tsx
+++ b/src/components/SearchByText/TextSearchBox/index.tsx
@@ -83,8 +83,8 @@ class TextSearchBox extends PureComponent<Props, State> {
     /* 
       Used for search history but buggy -
       if you typed in something wrong 
-      and try to correct it, (e.g kinases, kinase),
-      it'll always go back to the first text typed
+      and tried to correct it, (e.g kinases, kinase),
+      it'd always go back to the text typed in the first place.
     */
     // let tmpSearchHistory = this.state.searchHistory;
     // if (value && !this.state.searchHistory.includes(value)) {
@@ -92,28 +92,24 @@ class TextSearchBox extends PureComponent<Props, State> {
     //   this.setState({ searchHistory: tmpSearchHistory });
     // }
     // searchStorage.setValue(tmpSearchHistory);
-
-    if (shouldRedirect) {
-      const directLinkDescription = getURLByAccession(value);
-      if (directLinkDescription) {
-        window.location.href = descriptionToPath(directLinkDescription);
-      }
-    }
-
-    // Finally just trigger a search
-    this.props.goToCustomLocation(
-      {
-        description: {
-          main: { key: 'search' },
-          search: {
-            type: 'text',
-            value,
+    const directLinkDescription = getURLByAccession(value);
+    if (directLinkDescription) {
+      window.location.href = descriptionToPath(directLinkDescription);
+    } else {
+      this.props.goToCustomLocation(
+        {
+          description: {
+            main: { key: 'search' },
+            search: {
+              type: 'text',
+              value,
+            },
           },
+          search: query,
         },
-        search: query,
-      },
-      replace,
-    );
+        replace,
+      );
+    }
   };
 
   private debouncedPush = debounce(

--- a/src/components/SearchByText/TextSearchBox/index.tsx
+++ b/src/components/SearchByText/TextSearchBox/index.tsx
@@ -29,7 +29,6 @@ type Props = {
   className?: string;
   goToCustomLocation: typeof goToCustomLocation;
   delay?: number;
-  shouldRedirect?: boolean;
   forHeader?: boolean;
   setSearchValue?: (s: string) => void;
 };
@@ -73,7 +72,7 @@ class TextSearchBox extends PureComponent<Props, State> {
     }
   }
   routerPush = (replace?: boolean) => {
-    const { pageSize, shouldRedirect } = this.props;
+    const { pageSize } = this.props;
     const query: { page: number; page_size?: number } = { page: 1 };
     if (pageSize) query.page_size = Number(pageSize);
     const value = this.state.localValue
@@ -92,6 +91,7 @@ class TextSearchBox extends PureComponent<Props, State> {
     //   this.setState({ searchHistory: tmpSearchHistory });
     // }
     // searchStorage.setValue(tmpSearchHistory);
+
     const directLinkDescription = getURLByAccession(value);
     if (directLinkDescription) {
       window.location.href = descriptionToPath(directLinkDescription);


### PR DESCRIPTION
This PR addresses the following:
- incomplete/incorrect data loading when redirection to a protein page happens after pressing enter in the search box in the header; 
- no automatic redirection/search initiation while the user is typing. The search action needs to be confermed by either pressing enter or by clicking on the search button;
- disabled usage of "search" history hints that caused the previously typed string to always reappear in the search box;