### PR TITLE
Improved options and unintegrated matches type for IPScan Jobs

### DIFF
--- a/src/components/IPScan/AdvancedOptions/index.tsx
+++ b/src/components/IPScan/AdvancedOptions/index.tsx
@@ -20,7 +20,7 @@ const mdb1Values = new Set([
   'CDD',
   'HAMAP',
   'Panther',
-  'PfamA',
+  'Pfam',
   'PIRSF',
   'PRINTS',
   'PrositeProfiles',
@@ -46,17 +46,29 @@ const labels = new Map([
   ['Gene3d', 'CATH-Gene3D'],
   ['PrositeProfiles', 'PROSITE profiles'],
   ['PrositePatterns', 'PROSITE patterns'],
+  ['FunFam', 'CATH-FunFam'],
 ]);
+
+const exclude = [
+  'SignalP_EUK',
+  'SignalP_GRAM_POSITIVE',
+  'SignalP_GRAM_NEGATIVE',
+];
+
+const sortOptions = (a: { value: string }, b: { value: string }) => {
+  return a.value < b.value ? -1 : 1;
+};
 
 const groupApplications = (
   applications: Array<IprscanParameterValue>,
   initialOptions?: InterProLocationSearch,
 ) => {
-  const mdb1 = [];
-  const mdb2 = [];
-  const other = [];
-  const noCategory = [];
-  const appOptions = initialOptions?.applications as Array<string>;
+  let mdb1 = [];
+  let mdb2 = [];
+  let other = [];
+  let noCategory = [];
+  let appOptions = initialOptions?.applications as Array<string>;
+
   for (const application of applications) {
     if (appOptions?.length) {
       application.defaultValue = appOptions.includes(application.value);
@@ -66,6 +78,13 @@ const groupApplications = (
     else if (otherValues.has(application.value)) other.push(application);
     else if (!ignoreList.has(application.value)) noCategory.push(application);
   }
+
+  mdb1 = mdb1.sort(sortOptions);
+  mdb2 = mdb2.sort(sortOptions);
+  other = other.sort(sortOptions);
+  noCategory = noCategory
+    .sort(sortOptions)
+    .filter((o) => !exclude.includes(o.value));
   return { mdb1, mdb2, other, noCategory };
 };
 

--- a/src/components/IPScan/AdvancedOptions/index.tsx
+++ b/src/components/IPScan/AdvancedOptions/index.tsx
@@ -20,7 +20,7 @@ const mdb1Values = new Set([
   'CDD',
   'HAMAP',
   'Panther',
-  'Pfam',
+  'PfamA',
   'PIRSF',
   'PRINTS',
   'PrositeProfiles',
@@ -49,11 +49,7 @@ const labels = new Map([
   ['FunFam', 'CATH-FunFam'],
 ]);
 
-const exclude = [
-  'SignalP_EUK',
-  'SignalP_GRAM_POSITIVE',
-  'SignalP_GRAM_NEGATIVE',
-];
+const excludeFromOptions = ['SignalP'];
 
 const sortOptions = (a: { value: string }, b: { value: string }) => {
   return a.value < b.value ? -1 : 1;
@@ -81,10 +77,10 @@ const groupApplications = (
 
   mdb1 = mdb1.sort(sortOptions);
   mdb2 = mdb2.sort(sortOptions);
-  other = other.sort(sortOptions);
-  noCategory = noCategory
+  other = other
     .sort(sortOptions)
-    .filter((o) => !exclude.includes(o.value));
+    .filter((o) => !excludeFromOptions.includes(o.value));
+  noCategory = noCategory.sort(sortOptions);
   return { mdb1, mdb2, other, noCategory };
 };
 
@@ -99,7 +95,8 @@ const applicationToCheckbox = ({
 }) => (
   <AdvancedOption
     name="appl"
-    value={value}
+    // Pfam edge case (the "PfamA" is defined by IPScan5)
+    value={value === 'PfamA' ? 'Pfam' : value}
     defaultChecked={defaultValue}
     title={properties && properties.properties[0].value}
     key={value}

--- a/src/components/IPScan/AdvancedOptions/index.tsx
+++ b/src/components/IPScan/AdvancedOptions/index.tsx
@@ -52,7 +52,7 @@ const labels = new Map([
 const excludeFromOptions = ['SignalP'];
 
 const sortOptions = (a: { value: string }, b: { value: string }) => {
-  return a.value < b.value ? -1 : 1;
+  return a.value[0].toLowerCase() < b.value[0].toLowerCase() ? -1 : 1;
 };
 
 const groupApplications = (
@@ -63,6 +63,7 @@ const groupApplications = (
   let mdb2 = [];
   let other = [];
   let noCategory = [];
+  let otherFeatures = [];
   let appOptions = initialOptions?.applications as Array<string>;
 
   for (const application of applications) {
@@ -77,11 +78,11 @@ const groupApplications = (
 
   mdb1 = mdb1.sort(sortOptions);
   mdb2 = mdb2.sort(sortOptions);
-  other = other
-    .sort(sortOptions)
-    .filter((o) => !excludeFromOptions.includes(o.value));
-  noCategory = noCategory.sort(sortOptions);
-  return { mdb1, mdb2, other, noCategory };
+  otherFeatures = other
+    .concat(noCategory)
+    .filter((o) => !excludeFromOptions.includes(o.value))
+    .sort(sortOptions);
+  return { mdb1, mdb2, otherFeatures };
 };
 
 const applicationToCheckbox = ({
@@ -95,8 +96,7 @@ const applicationToCheckbox = ({
 }) => (
   <AdvancedOption
     name="appl"
-    // Pfam edge case (the "PfamA" is defined by IPScan5)
-    value={value === 'PfamA' ? 'Pfam' : value}
+    value={value}
     defaultChecked={defaultValue}
     title={properties && properties.properties[0].value}
     key={value}
@@ -135,7 +135,7 @@ export const AdvancedOptions = ({
   const { loading, payload, ok } = data;
   if (loading) return 'Loading…';
   if (!ok || !payload) return 'Failed…';
-  const { mdb1, mdb2, other, noCategory } = groupApplications(
+  const { mdb1, mdb2, otherFeatures } = groupApplications(
     payload.values.values,
     initialOptions,
   );
@@ -216,8 +216,7 @@ export const AdvancedOptions = ({
           </fieldset>
           <fieldset className={css('new-fieldset')}>
             <legend>Other sequence features</legend>
-            {other.map(applicationToCheckbox)}
-            {noCategory.map(applicationToCheckbox)}
+            {otherFeatures.map(applicationToCheckbox)}
           </fieldset>
         </fieldset>
       </details>

--- a/src/components/IPScan/Summary/serializers.ts
+++ b/src/components/IPScan/Summary/serializers.ts
@@ -17,6 +17,7 @@ type IpScanMatch = {
   accession: string;
   name: string;
   short_name: string;
+  type?: string;
   source_database: string;
   protein_length: number;
   locations: Array<BaseLocation & Iprscan5Location>;
@@ -162,6 +163,7 @@ export const mergeData = (
       accession: match.signature.accession,
       name: match.signature.description || match.signature.name,
       short_name: match.signature.name,
+      type: match.signature.type,
       source_database: iproscan2urlDB(library),
       protein_length: sequenceLength || 0,
       locations: match.locations.map((loc) => ({

--- a/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
+++ b/src/components/Related/DomainsOnProtein/DomainsOnProteinLoaded/index.tsx
@@ -321,24 +321,26 @@ const DomainsOnProteinLoaded = ({
         const unintegratedEntry = {
           ...(processedDataMerged['unintegrated'][i] as ExtendedFeature),
         };
+
+        let dbSection: string = '';
         const sourcedb = unintegratedEntry.source_database;
         if (sourcedb && Object.keys(dbToSection).includes(sourcedb)) {
-          if (processedDataMerged[dbToSection[sourcedb]]) {
-            const previousSectionData = [
-              ...(processedDataMerged[
-                dbToSection[sourcedb]
-              ] as ExtendedFeature[]),
-            ];
-            previousSectionData.push(unintegratedEntry);
-            processedDataMerged[dbToSection[sourcedb]] = [
-              ...previousSectionData,
-            ];
-            accessionsToRemoveFromUnintegrated.push(
-              unintegratedEntry.accession,
-            );
-          }
+          dbSection = dbToSection[sourcedb];
+        }
+
+        let sectionKey: string =
+          unintegratedEntry.type?.toLowerCase() || dbSection;
+
+        if (processedDataMerged[sectionKey]) {
+          const previousSectionData = [
+            ...(processedDataMerged[sectionKey] as ExtendedFeature[]),
+          ];
+          previousSectionData.push(unintegratedEntry);
+          processedDataMerged[sectionKey] = [...previousSectionData];
+          accessionsToRemoveFromUnintegrated.push(unintegratedEntry.accession);
         }
       }
+
       const filteredUnintegrated = (
         processedDataMerged['unintegrated'] as ExtendedFeature[]
       ).filter(


### PR DESCRIPTION
This PR addresses the following:
- the unintegrated section of the IPScan Job results still contained some matches due to missing type in data coming in from IPScan. Now that the type is available, we can place them in the correct section.
- advanced options for job submission improvements, as outlined in: [IBU-11828](https://embl.atlassian.net/browse/IBU-11828)