### PR TITLE
Structure model fixes, exporter for text search

### DIFF
--- a/src/components/SearchResults/__snapshots__/test.js.snap
+++ b/src/components/SearchResults/__snapshots__/test.js.snap
@@ -129,6 +129,20 @@ exports[`<SearchResults /> should render 1`] = `
     query={{}}
   >
     <Memo(Connect(HighlightToggler)) />
+    <Memo(Connect(Exporter))>
+      <div
+        className="menu-grid"
+      >
+        <Memo(Connect(FileExporter))
+          fileType="json"
+          name="SearchResultsIPR020422.json"
+        />
+        <Memo(Connect(FileExporter))
+          fileType="tsv"
+          name="SearchResultsIPR020422.tsv"
+        />
+      </div>
+    </Memo(Connect(Exporter))>
     <Column
       dataKey="id"
       renderer={[Function]}

--- a/src/components/SearchResults/index.tsx
+++ b/src/components/SearchResults/index.tsx
@@ -99,6 +99,20 @@ export const SearchResults = ({
         status={status}
       >
         <HighlightToggler />
+        <Exporter>
+          <div className={css('menu-grid')}>
+            <FileExporter
+              fileType="json"
+              name={`SearchResults${searchValue}.json`}
+              count={hitCount}
+            />
+            <FileExporter
+              fileType="tsv"
+              name={`SearchResults${searchValue}.tsv`}
+              count={hitCount}
+            />
+          </div>
+        </Exporter>
         <Column
           dataKey="id"
           renderer={(

--- a/src/components/Structure/ViewerAndEntries/ProteinViewerForPredictedStructure/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/ProteinViewerForPredictedStructure/index.tsx
@@ -253,17 +253,19 @@ const ProteinViewerForAlphafold = ({
             break;
 
           case 'mouseover': {
-            isHovering.current = true;
-            const color =
-              parseInt(event?.detail?.feature?.color?.substring(1), 16) || 0;
-            const selection =
-              highlight?.split(',').map((block: string) => {
-                const parts = block.split(':');
-                const start = Number(parts?.[0]) || 1;
-                const end = Number(parts?.[1]) || 1;
-                return { chain: 'A', start, end, color };
-              }) || [];
-            setHoverSelection(selection);
+            if (!fixedSelectionRef.current.length) {
+              isHovering.current = true;
+              const color =
+                parseInt(event?.detail?.feature?.color?.substring(1), 16) || 0;
+              const selection =
+                highlight?.split(',').map((block: string) => {
+                  const parts = block.split(':');
+                  const start = Number(parts?.[0]) || 1;
+                  const end = Number(parts?.[1]) || 1;
+                  return { chain: 'A', start, end, color };
+                }) || [];
+              setHoverSelection(selection);
+            }
             break;
           }
           default:

--- a/src/components/Structure3DModel/3DModel/index.tsx
+++ b/src/components/Structure3DModel/3DModel/index.tsx
@@ -109,10 +109,6 @@ const Structure3DModel = ({
     }
   }, [shouldResetViewer]);
 
-  useEffect(() => {
-    if (!selections) setShouldResetViewer(true);
-  }, [selections]);
-
   // Show warning if PDB is not available
   if (bfvd) {
     if (isPDBLoading) {


### PR DESCRIPTION
This PR addresses the following:
- Exporter menu is back on the text search page;
- If the model was rotated and a track was hovered over, moving the mouse out of the track caused the model to be reset to its initial position.
- If a track was clicked to keep a match highlighted on the structure, and the cursor was then moved to hover over another track, both matches were highlighted, using the color of the first selected match.