### PR TITLE
Include short_name column in TSV download

### DIFF
--- a/src/web-workers/download/object2TSV.js
+++ b/src/web-workers/download/object2TSV.js
@@ -79,6 +79,7 @@ export const columns /*: {
   entry: [
     { name: 'Accession', selector: 'metadata.accession' },
     { name: 'Name', selector: 'metadata.name' },
+    { name: 'Short Name', selector: 'metadata.short_name' },
     { name: 'Source Database', selector: 'metadata.source_database' },
     { name: 'Type', selector: 'metadata.type' },
     { name: 'Integrated Into', selector: 'metadata.integrated' },


### PR DESCRIPTION
This PR addresses [IBU-11884](https://embl.atlassian.net/browse/IBU-11884).

Given the separate strategies that are used to get data for the table and the TSV generator, a little change on the backend is needed for this to work. [Here] the link to the backend PR](https://github.com/ProteinsWebTeam/interpro7-api/pull/183)

Also, this makes things more consistent and easier to understand: for the table, the dataKey for the short_name is counters.extra_fields.short_name, which is semantically weird.