### PR TITLE
Do not show no-entries callout while loading

### DIFF
--- a/src/components/Structure/ViewerAndEntries/EntrySelection/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/EntrySelection/index.tsx
@@ -13,6 +13,7 @@ type Props = {
   entryMap: Object;
   selectedEntry?: string;
   entriesNames: Record<string, string | NameObject>;
+  isReady: boolean;
 };
 
 const EntrySelection = ({
@@ -20,6 +21,7 @@ const EntrySelection = ({
   selectedEntry,
   entriesNames,
   updateStructure,
+  isReady,
 }: Props) => {
   const selectionGroups = [];
   selectionGroups.push(
@@ -57,19 +59,21 @@ const EntrySelection = ({
     // update structure viewer
     updateStructure(memberDB, entry);
   };
-  return selectionGroups.length > 1 ? (
-    <select
-      className={css('structure-viewer-select')}
-      onChange={onSelectionChange}
-      onBlur={onSelectionChange}
-      value={selectedEntry}
-      data-testid="structure-entry-select"
-    >
-      {selectionGroups}
-    </select>
-  ) : (
-    <Callout type="info">No entry matches this structure</Callout>
-  );
+  if (selectionGroups.length > 1) {
+    return (
+      <select
+        className={css('structure-viewer-select')}
+        onChange={onSelectionChange}
+        onBlur={onSelectionChange}
+        value={selectedEntry}
+        data-testid="structure-entry-select"
+      >
+        {selectionGroups}
+      </select>
+    );
+  } else if (isReady) {
+    return <Callout type="info">No entry matches this structure</Callout>;
+  }
 };
 
 export default EntrySelection;

--- a/src/components/Structure/ViewerAndEntries/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/index.tsx
@@ -414,6 +414,7 @@ class StructureView extends PureComponent<Props, State> {
                 entriesNames={this.getEntryNames()}
                 updateStructure={this.showEntryInStructure}
                 selectedEntry={selectedEntry}
+                isReady={this.state.isReady}
               />
             ) : null,
           }}


### PR DESCRIPTION
The message showing "No entry matches this structure" is showing while the page is loading, even if the structure _has_ entry matches, e.g. [2eho](https://www.ebi.ac.uk/interpro/structure/PDB/2eho/).

This PR propagates the `isReady` boolean down to the `EntrySelection` component so the message is only displayed if there are no matches _and_ the page is loaded (ready).