### PR TITLE
Curation subpage to overview redirect

### DIFF
--- a/src/utils/removed-pages/index.tsx
+++ b/src/utils/removed-pages/index.tsx
@@ -59,7 +59,7 @@ export const removedPages: Array<{
                 main: { key: 'entry' },
                 entry: {
                   ...location.entry,
-                  detail: 'overview',
+                  detail: '',
                 },
               },
             }}


### PR DESCRIPTION
This PR fixes the redirection from the curation subpage to the main/overview page of Pfam entries.

We moved the curation details from the curation subpage to the overview page, but the link in the warning message adds an `/overview` at the end of the URL.

Example: https://www.ebi.ac.uk/interpro/entry/pfam/PF03106/curation/