### PR TITLE
TED using AlphaFold API

### DIFF
--- a/config/dev_config.yml
+++ b/config/dev_config.yml
@@ -16,7 +16,6 @@ root:
   Rfam: https://www.ebi.ac.uk/ebisearch/ws/rest/rfam
   UniProt: https://rest.uniprot.org/
   proteinsAPI: https://www.ebi.ac.uk/proteins/api/
-  ted: https://ted.cathdb.info/
 
 title: InterPro
 

--- a/config/master_config.yml
+++ b/config/master_config.yml
@@ -16,7 +16,6 @@ root:
   Rfam: https://www.ebi.ac.uk/ebisearch/ws/rest/rfam
   UniProt: https://rest.uniprot.org/
   proteinsAPI: https://www.ebi.ac.uk/proteins/api/
-  ted: https://ted.cathdb.info/
 
 github:
   InterProClient:

--- a/config/staging_config.yml
+++ b/config/staging_config.yml
@@ -16,7 +16,6 @@ root:
   Rfam: https://www.ebi.ac.uk/ebisearch/ws/rest/rfam
   UniProt: https://rest.uniprot.org/
   proteinsAPI: https://www.ebi.ac.uk/proteins/api/
-  ted: https://ted.cathdb.info/
 
 github:
   InterProClient:

--- a/src/components/ProteinViewer/Popup/TED/index.tsx
+++ b/src/components/ProteinViewer/Popup/TED/index.tsx
@@ -18,11 +18,17 @@ const TEDPopup = ({ detail }: Props) => {
   return (
     <section>
       <h6>TED consensus domain</h6>
-      {locations.map(({ fragments }, i) => (
-        <div key={i}>
-          <Positions fragments={fragments} protein={protein} key={i} />
-        </div>
-      ))}
+      <strong>Boundaries:</strong>{' '}
+      {locations
+        .map(({ fragments }) =>
+          fragments
+            .map((fragment) => `${fragment.start}-${fragment.end}`)
+            .join(', '),
+        )
+        .join('; ')}
+      <br />
+      <strong>QScore:</strong>{' '}
+      {locations.length > 0 ? (locations[0].score as string) : 'N/A'}
     </section>
   );
 };

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/TED/index.ts
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/TED/index.ts
@@ -21,8 +21,8 @@ export const formatTED = ({
     loading ||
     status !== HTTP_OK ||
     !payload ||
-    !payload.data ||
-    payload.data.length === 0
+    !payload.annotations ||
+    payload.annotations.length === 0
   )
     return [] as MinimalFeature[];
 
@@ -30,16 +30,18 @@ export const formatTED = ({
     {
       accession: `TED:TED`,
       source_database: 'TED',
-      locations: payload.data.map((domain: TEDDomain, index: number) => ({
-        color: COLORS[index % COLORS.length],
-        fragments: domain.chopping.split('_').map((segment) => {
-          const [start, end] = segment.split('-').map(Number);
-          return {
-            start: start,
-            end: end,
-          };
+      locations: payload.annotations.map(
+        (domain: TEDDomain, index: number) => ({
+          color: COLORS[index % COLORS.length],
+          fragments: domain.segments.map((segment) => {
+            return {
+              start: segment.af_start,
+              end: segment.af_end,
+            };
+          }),
+          score: domain.qscore,
         }),
-      })),
+      ),
     },
   ] as MinimalFeature[];
 };

--- a/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
+++ b/src/components/Related/DomainsOnProtein/ExternalSourcesHOC/index.tsx
@@ -115,7 +115,7 @@ const getDisProtURL = createSelector(
 );
 
 export const getTEDURL = createSelector(
-  (state: GlobalState) => state.settings.ted,
+  (state: GlobalState) => state.settings.alphafold,
   (state: GlobalState) => state.customLocation.description.protein.accession,
   (
     { protocol, hostname, port, root }: ParsedURLServer,
@@ -126,10 +126,7 @@ export const getTEDURL = createSelector(
       protocol,
       hostname,
       port,
-      pathname: `${root}/api/v1/uniprot/summary/${accession}`.replaceAll(
-        /\/{2,}/g,
-        '/',
-      ),
+      pathname: `${root}/api/domains/${accession}`.replaceAll(/\/{2,}/g, '/'),
     });
   },
 );

--- a/src/reducers/settings/category/index.ts
+++ b/src/reducers/settings/category/index.ts
@@ -109,14 +109,6 @@ export const getDefaultSettingsFor = <T extends keyof SettingsState>(
         root: config.root.bfvd.pathname,
         query: config.root.bfvd.query,
       } as SettingsState[T];
-    case 'ted':
-      return {
-        protocol: config.root.ted.protocol,
-        hostname: config.root.ted.hostname,
-        port: config.root.ted.port || DEFAULT_HTTP_PORT,
-        root: config.root.ted.pathname,
-        query: config.root.ted.query,
-      } as SettingsState[T];
     default:
       return null;
   }

--- a/src/reducers/settings/index.ts
+++ b/src/reducers/settings/index.ts
@@ -16,5 +16,4 @@ export default combineReducers({
   alphafold: category('alphafold'),
   bfvd: category('bfvd'),
   proteinsAPI: category('proteinsAPI'),
-  ted: category('ted'),
 });

--- a/src/store/utils/get-initial-state/index.js
+++ b/src/store/utils/get-initial-state/index.js
@@ -71,12 +71,6 @@ export default (historyWrapper) => {
         port: config.root.proteinsAPI.port || DEFAULT_HTTP_PORT,
         root: config.root.proteinsAPI.pathname,
       };
-      settings.ted = {
-        protocol: config.root.ted.protocol,
-        hostname: config.root.ted.hostname,
-        port: config.root.ted.port || DEFAULT_HTTP_PORT,
-        root: config.root.ted.pathname,
-      };
     }
   }
   let description = { other: ['NotFound'] };

--- a/src/types/external-payloads.d.ts
+++ b/src/types/external-payloads.d.ts
@@ -243,13 +243,20 @@ type DisProtPayload = {
   regions: Array<DisprotRegion>;
   disprot_consensus: DisprotConsensus;
 };
+type TEDSegment = {
+  af_start: number;
+  af_end: number;
+  segment_id: number;
+};
 type TEDDomain = {
-  ted_id: string;
-  uniprot_acc: string;
-  consensus_level: string;
-  chopping: string;
+  ted_domain_no: number;
   cath_label: string;
+  cath_assignment_level: string;
+  nres_domain: number;
+  plddt: number;
+  qscore: number;
+  segments: Array<TEDSegment>;
 };
 type TEDPayload = {
-  data: Array<TEDDomain>;
+  annotations: Array<TEDDomain>;
 };

--- a/src/types/state.d.ts
+++ b/src/types/state.d.ts
@@ -217,8 +217,7 @@ type Server =
   | 'bfvd'
   | 'repeatsDB'
   | 'disprot'
-  | 'proteinsAPI'
-  | 'ted';
+  | 'proteinsAPI';
 type ServerStatus = {
   status: boolean | null;
   lastCheck: number | null;


### PR DESCRIPTION
Switches to using the AlphaFold API instead of the TED API to retrieve TED domains, mainly so we can display the Q-score.