### PR TITLE
Status in IPScan Jobs when data is not ready yet

### DIFF
--- a/src/components/IPScan/Actions/index.tsx
+++ b/src/components/IPScan/Actions/index.tsx
@@ -92,7 +92,7 @@ export const Actions = ({
           {!forStatus && <span>Delete Results</span>}
         </Button>
       </Tooltip>
-      {status === 'finished' && (
+      {status === 'finished_with_results' && (
         <Tooltip
           title={
             <div>

--- a/src/components/IPScan/Status/SequenceList/index.tsx
+++ b/src/components/IPScan/Status/SequenceList/index.tsx
@@ -171,7 +171,9 @@ export const IPScanStatus = ({
 
   return (
     <section>
-      <IPScanVersionCheck ipScanVersion={jobIProVersion} />
+      {job?.status === 'finished_with_results' && (
+        <IPScanVersionCheck ipScanVersion={jobIProVersion} />
+      )}
 
       <h3 className={css('light')}>
         Your InterProScan Search Results (Sequences){' '}
@@ -236,7 +238,7 @@ export const IPScanStatus = ({
           <StatusTooltip status={job?.status} />
         </section>
       </section>
-      {job?.status === 'finished' && expiryDate >= new Date() && (
+      {job?.status === 'finished_with_results' && expiryDate >= new Date() && (
         <section className={css('summary-row')}>
           <header>
             Expires{' '}
@@ -255,93 +257,96 @@ export const IPScanStatus = ({
           <section>{expiryDate.toDateString()}</section>
         </section>
       )}
-      <section className={css('summary-row')}>
-        <header>Actions</header>
-        <section>
-          <Actions
-            localID={job?.localID || ''}
-            status={job?.status || ''}
-            MoreActions={
-              <>
-                <ReRun jobsData={jobsData} />
-                <DropDownButton label="Download" icon="icon-download">
-                  <DownloadAll job={job} jobsData={jobsData} />
-                </DropDownButton>
-              </>
-            }
-          />
+      {job.status === 'finished_with_results' && (
+        <section className={css('summary-row')}>
+          <header>Actions</header>
+          <section>
+            <Actions
+              localID={job?.localID || ''}
+              status={job?.status || ''}
+              MoreActions={
+                <>
+                  <ReRun jobsData={jobsData} />
+                  <DropDownButton label="Download" icon="icon-download">
+                    <DownloadAll job={job} jobsData={jobsData} />
+                  </DropDownButton>
+                </>
+              }
+            />
+          </section>
         </section>
-      </section>
-      <Table
-        dataTable={paginatedJobs}
-        rowKey="localID"
-        contentType="result"
-        actualSize={job?.entries || 1}
-        query={search}
-        showTableIcon={false}
-        // groupActions={GroupActions}
-      >
-        <Column
-          dataKey="localTitle"
-          isSearchable={true}
-          isSortable={true}
-          renderer={(localTitle: string, row: IprscanDataIDB) => (
-            <>
-              <span style={{ marginRight: '1em' }}>
-                <Link
-                  to={{
-                    description: {
-                      main: { key: 'result' },
-                      result: {
-                        type: 'InterProScan',
-                        job: job?.remoteID,
-                        accession: row.localID,
+      )}
+      {job.status === 'finished_with_results' && (
+        <Table
+          dataTable={paginatedJobs}
+          rowKey="localID"
+          contentType="result"
+          actualSize={job?.entries || 1}
+          query={search}
+          showTableIcon={false}
+          // groupActions={GroupActions}
+        >
+          <Column
+            dataKey="localTitle"
+            isSearchable={true}
+            isSortable={true}
+            renderer={(localTitle: string, row: IprscanDataIDB) => (
+              <>
+                <span style={{ marginRight: '1em' }}>
+                  <Link
+                    to={{
+                      description: {
+                        main: { key: 'result' },
+                        result: {
+                          type: 'InterProScan',
+                          job: job?.remoteID,
+                          accession: row.localID,
+                        },
                       },
-                    },
-                  }}
-                >
-                  {(row.results[0]?.crossReferences ||
-                    row.results[0]?.xref)?.[0]?.id ||
-                    (localTitle === '∅' ? null : localTitle) ||
-                    row.localID}
-                </Link>
-              </span>
-              {/* {row.remoteID && !row.remoteID.startsWith('imported') && (
+                    }}
+                  >
+                    {(row.results[0]?.crossReferences ||
+                      row.results[0]?.xref)?.[0]?.id ||
+                      (localTitle === '∅' ? null : localTitle) ||
+                      row.localID}
+                  </Link>
+                </span>
+                {/* {row.remoteID && !row.remoteID.startsWith('imported') && (
                 <CopyToClipboard
                   textToCopy={getIProScanURL(row.remoteID)}
                   tooltipText="Copy URL"
                 />
               )} */}
-            </>
-          )}
-        >
-          Sequence
-        </Column>
-        <Column
-          defaultKey="matches"
-          dataKey="results"
-          // isSearchable={true}
-          // isSortable={true}
-          displayIf={job.seqtype !== 'n'}
-          renderer={(results: Array<Iprscan5Result>) =>
-            results[0].matches.length
-          }
-        >
-          Matches
-        </Column>
-        <Column
-          defaultKey="length"
-          dataKey="results"
-          // isSearchable={true}
-          // isSortable={true}
-          renderer={(results: Array<Iprscan5Result>) =>
-            results[0].sequence.length
-          }
-        >
-          Sequence length
-        </Column>
+              </>
+            )}
+          >
+            Sequence
+          </Column>
+          <Column
+            defaultKey="matches"
+            dataKey="results"
+            // isSearchable={true}
+            // isSortable={true}
+            displayIf={job.seqtype !== 'n'}
+            renderer={(results: Array<Iprscan5Result>) =>
+              results[0].matches.length
+            }
+          >
+            Matches
+          </Column>
+          <Column
+            defaultKey="length"
+            dataKey="results"
+            // isSearchable={true}
+            // isSortable={true}
+            renderer={(results: Array<Iprscan5Result>) =>
+              results[0].sequence.length
+            }
+          >
+            Sequence length
+          </Column>
 
-        {/* <Column
+          {/* <Column
           dataKey="localID"
           defaultKey="actions"
           headerClassName={css('table-header-center')}
@@ -352,7 +357,8 @@ export const IPScanStatus = ({
         >
           Action
         </Column> */}
-      </Table>
+        </Table>
+      )}
     </section>
   );
 };

--- a/src/components/IPScan/Status/index.tsx
+++ b/src/components/IPScan/Status/index.tsx
@@ -138,7 +138,7 @@ export class IPScanStatus extends PureComponent<Props, State> {
 
     const statusColumnName: Record<string, string> = {
       'imported file': 'Imported',
-      'finished': 'Completed',
+      finished_with_results: 'Completed',
       'saved in browser': 'Saved',
     };
 
@@ -281,7 +281,8 @@ export class IPScanStatus extends PureComponent<Props, State> {
                 {(status === 'running' ||
                   status === 'created' ||
                   status === 'queued' ||
-                  status === 'submitted') && (
+                  status === 'submitted' ||
+                  status === 'finished') && (
                   <div>
                     <SpinningCircle />
                     <div>Searching</div>
@@ -299,9 +300,11 @@ export class IPScanStatus extends PureComponent<Props, State> {
                     aria-label="Job failed or not found"
                   />
                 ) : null}
-                {['finished', 'imported file', 'saved in browser'].includes(
-                  status,
-                ) &&
+                {[
+                  'finished_with_results',
+                  'imported file',
+                  'saved in browser',
+                ].includes(status) &&
                   (statusColumnName[status] ||
                     status[0].toUpperCase() + status.slice(1))}
               </Tooltip>

--- a/src/components/IPScan/Summary/StatusTooltip/index.tsx
+++ b/src/components/IPScan/Summary/StatusTooltip/index.tsx
@@ -16,7 +16,8 @@ const _StatusTooltip = ({ status }: Props) => (
       status === 'queued' ||
       status === 'created' ||
       status === 'importing' ||
-      status === 'submitted') && (
+      status === 'submitted' ||
+      status === 'finished') && (
       <>
         <SpinningCircle />
         <div className={css('status')}>Searching</div>
@@ -33,7 +34,7 @@ const _StatusTooltip = ({ status }: Props) => (
         {status}
       </>
     ) : null}
-    {['finished', 'imported file', 'saved in browser'].includes(
+    {['finished_with_results', 'imported file', 'saved in browser'].includes(
       status || '',
     ) && (
       <>
@@ -42,7 +43,7 @@ const _StatusTooltip = ({ status }: Props) => (
           data-icon="&#xf00c;"
           aria-label="Job finished"
         />{' '}
-        {status}
+        {status?.replace('finished_with_results', 'Finished')}
       </>
     )}
   </Tooltip>

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -28,6 +28,7 @@ type JobStatus =
   | 'saved in browser'
   | 'running'
   | 'finished'
+  | 'finished_with_results'
   | 'queued'
   | 'error';
 


### PR DESCRIPTION
This PR addresses: [IBU-12120](https://embl.atlassian.net/browse/IBU-12120)

The problem is that the "Finished" status is assigned to a job even if data hasn't been retrieved yet.

We now have a new state "finished_with_results" that gets assigned ONLY once the data is retrieved.

Consequently, but not optimally from a semantic POV, the "finished" state will now be processed like the "running" one, and the "Searching" spinner will be displayed.
