### PR TITLE
Display '∅' for any null value in table rows

### DIFF
--- a/src/components/Table/Row/index.tsx
+++ b/src/components/Table/Row/index.tsx
@@ -74,10 +74,10 @@ class Row<
                 {group && i === 0 ? (
                   <div style={{ display: 'flex' }}>
                     <span>&emsp;</span>
-                    {renderer(lodashGet(row, dataKey, '∅'), row, extra)}
+                    {renderer(lodashGet(row, dataKey, '∅') || '∅', row, extra)}
                   </div>
                 ) : (
-                  renderer(lodashGet(row, dataKey, '∅'), row, extra)
+                  renderer(lodashGet(row, dataKey, '∅') || '∅', row, extra)
                 )}
               </td>
             ),


### PR DESCRIPTION
This PR addresses [IBU-12114](https://embl.atlassian.net/browse/IBU-12114).