### PR TITLE
Fix the InterProScan about page

### DIFF
--- a/src/components/About/InterProScan/index.tsx
+++ b/src/components/About/InterProScan/index.tsx
@@ -31,16 +31,18 @@ const parseBody = (text: string) =>
     );
 
 interface LoadedProps
-  extends LoadDataProps<{
-    tag_name: string;
-    body: string;
-  }> {}
+  extends LoadDataProps<
+    Array<{
+      tag_name: string;
+      body: string;
+    }>
+  > {}
 
 export const InterProScan = ({ data }: LoadedProps) => {
   if (!data) return null;
   const { loading, payload } = data;
-  if (loading || !payload) return <Loading />;
-  const { tag_name: version, body } = payload;
+  if (loading || !payload || payload.length === 0) return <Loading />;
+  const { tag_name: version, body } = payload[0];
   const metadata = parseBody(body);
   return (
     <section>


### PR DESCRIPTION
InterProScan has an About page on the website (https://www.ebi.ac.uk/interpro/about/interproscan/). We don't have links to allow users to navigate to it anymore, but I guess some users have it in their bookmarks. There is an error on this page, which this PR fixes.