### PR TITLE
Predicted structure coloring

### DIFF
--- a/src/components/ProteinViewer/Options/style.css
+++ b/src/components/ProteinViewer/Options/style.css
@@ -18,15 +18,18 @@
   .view-options-title {
     font-size: 1rem;
     font-weight: 500;
-    flex-shrink: 0;
   }
 }
 
 .view-options {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  font-size: 90%;
+  display: grid;
+  grid-auto-flow: column;
+  margin-left: auto;
+}
+
+:global(.split-view) .view-options {
+  display: grid;
+  grid-auto-flow: row;
   margin-left: auto;
 }
 

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -63,7 +63,6 @@ const RepresentativeTrack = ({
 
   // Update data with track color based on the selected color mode
   useEffect(() => {
-    console.log(entries);
     setData(
       entries.map((entry) => ({
         ...entry,

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -75,7 +75,7 @@ const RepresentativeTrack = ({
                   : null,
               }
             : colorDomainsBy === EntryColorMode.ACCESSION
-              ? { parent: entry }
+              ? { accession: entry.accession }
               : entry,
           colorDomainsBy,
         ),

--- a/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
+++ b/src/components/ProteinViewer/RepresentativeDomainsTrack/index.tsx
@@ -63,6 +63,7 @@ const RepresentativeTrack = ({
 
   // Update data with track color based on the selected color mode
   useEffect(() => {
+    console.log(entries);
     setData(
       entries.map((entry) => ({
         ...entry,
@@ -73,7 +74,9 @@ const RepresentativeTrack = ({
                   ? { accession: entry.integrated }
                   : null,
               }
-            : entry,
+            : colorDomainsBy === EntryColorMode.ACCESSION
+              ? { parent: entry }
+              : entry,
           colorDomainsBy,
         ),
       })),

--- a/src/components/ProteinViewer/index.tsx
+++ b/src/components/ProteinViewer/index.tsx
@@ -69,6 +69,21 @@ type Props = PropsWithChildren<{
   showConservationButton?: boolean;
   /** `DISABLED` - conservation data is currently disabled */
   handleConservationLoad?: () => void;
+
+  setHasRepresentativeData?: (s: {
+    family: boolean | null;
+    domain: boolean | null;
+  }) => void;
+  hasRepresentativeData?: { family: boolean | null; domain: boolean | null };
+  setRepresentativeDataForStructure?: (s: {
+    family: ExtendedFeature[];
+    domain: ExtendedFeature[];
+  }) => void;
+  representativeDataForStructure?: {
+    family: ExtendedFeature[];
+    domain: ExtendedFeature[];
+  };
+
   /** `DISABLED` - conservation data is currently disabled */
   conservationError?: string;
   /** TO include loading animation in the header */
@@ -119,6 +134,10 @@ export const ProteinViewer = ({
   changeSettingsRaw,
   showMoreSettings,
   handleConservationLoad,
+  setHasRepresentativeData,
+  hasRepresentativeData,
+  setRepresentativeDataForStructure,
+  representativeDataForStructure,
   conservationError,
   dataBase,
   loading = false,
@@ -239,6 +258,15 @@ export const ProteinViewer = ({
     setHideCategory(newHideCategory);
   }, [showMoreSettings]);
 
+  useEffect(() => {
+    if (setHasRepresentativeData) {
+      setHasRepresentativeData({ family: null, domain: null });
+    }
+    if (setRepresentativeDataForStructure) {
+      setRepresentativeDataForStructure({ family: [], domain: [] });
+    }
+  }, [matchTypeSettings]);
+
   return (
     <div
       ref={mainRef}
@@ -357,6 +385,22 @@ export const ProteinViewer = ({
                     let hideDiv: string = '';
                     if (!showMore && !mainTracks.includes(type)) {
                       hideDiv = 'none';
+                    }
+
+                    if (type === 'domain' || type === 'family') {
+                      if (setHasRepresentativeData && hasRepresentativeData) {
+                        hasRepresentativeData[type] = reprEntries.length > 0;
+                        setHasRepresentativeData(hasRepresentativeData);
+                      }
+                      if (
+                        setRepresentativeDataForStructure &&
+                        representativeDataForStructure
+                      ) {
+                        representativeDataForStructure[type] = reprEntries;
+                        setRepresentativeDataForStructure(
+                          representativeDataForStructure,
+                        );
+                      }
                     }
 
                     return (

--- a/src/components/SimpleCommonComponents/Tooltip/index.tsx
+++ b/src/components/SimpleCommonComponents/Tooltip/index.tsx
@@ -41,6 +41,7 @@ const Tooltip = ({
   children,
   distance = 0,
   interactive = false,
+  isFullScreen = false,
   classNames = [],
   ...rest
 }: Props) => {
@@ -85,22 +86,29 @@ const Tooltip = ({
         }
       }, TOOLTIP_DELAY);
   };
+
+  const tooltipElement = (
+    <div
+      ref={refs.setFloating}
+      style={floatingStyles}
+      className={css(['popper', ...classNames].join(' '))}
+      onMouseEnter={() => setOverTooltip(true)}
+      onMouseLeave={() => setOverTooltip(false)}
+    >
+      <FloatingArrow ref={arrowRef} context={context} />
+      {content}
+    </div>
+  );
+
   return (
     <>
-      {hide ? null : (
-        <FloatingPortal>
-          <div
-            ref={refs.setFloating}
-            style={floatingStyles}
-            className={css('popper', ...classNames)}
-            onMouseEnter={() => setOverTooltip(true)}
-            onMouseLeave={() => setOverTooltip(false)}
-          >
-            <FloatingArrow ref={arrowRef} context={context} />
-            {content}
-          </div>
-        </FloatingPortal>
-      )}
+      {!hide &&
+        (isFullScreen ? (
+          tooltipElement
+        ) : (
+          <FloatingPortal>{tooltipElement}</FloatingPortal>
+        ))}
+
       <div
         {...rest}
         ref={refs.setReference}

--- a/src/components/Structure/Viewer/style.css
+++ b/src/components/Structure/Viewer/style.css
@@ -1,5 +1,5 @@
 .viewer-resizer {
-  height: calc(100% - 2 * var(--height-bar));
+  height: 95%;
 
   & .structure-and-label {
     height: 100%;
@@ -8,8 +8,7 @@
     & .structure-viewer-ref {
       align-items: center;
       justify-content: center;
-      height: 88%;
-      max-width: 80vw;
+      height: 90%;
     }
 
     & .structure-label {

--- a/src/components/Structure/ViewerAndEntries/ProteinViewerForPredictedStructure/index.tsx
+++ b/src/components/Structure/ViewerAndEntries/ProteinViewerForPredictedStructure/index.tsx
@@ -153,6 +153,11 @@ type Props = {
   colorBy?: string;
   setColorMap?: (s: Record<number, number>) => void;
   setHasTED: (s: boolean) => void;
+  setHasRepresentativeData?: (s: {
+    family: boolean | null;
+    domain: boolean | null;
+  }) => void;
+  hasRepresentativeData?: { family: boolean | null; domain: boolean | null };
   isSplitScreen: boolean;
   bfvd?: string;
   dataInterProNMatches?: Record<string, InterProN_Match>;
@@ -179,6 +184,8 @@ const ProteinViewerForAlphafold = ({
   onChangeSelection,
   setColorMap,
   setHasTED,
+  setHasRepresentativeData,
+  hasRepresentativeData,
   colorBy,
   dataTED,
   isSplitScreen = false,
@@ -189,6 +196,12 @@ const ProteinViewerForAlphafold = ({
   const [fixedSelection, _setFixedSelection] = useState<Selection[]>([]);
   const [hoverSelection, _setHoverSelection] = useState<Selection[]>([]);
   const [colorGroup, setColorGroup] = useState({});
+
+  const [representativeDataForStructure, setRepresentativeDataForStructure] =
+    useState<{ family: ExtendedFeature[]; domain: ExtendedFeature[] }>({
+      family: [],
+      domain: [],
+    });
 
   const [processedTracks, setProcessedTracks] =
     useState<ProteinViewerDataObject>({});
@@ -303,13 +316,6 @@ const ProteinViewerForAlphafold = ({
 
   // Color 3D model based on selection
   useEffect(() => {
-    const {
-      interpro,
-      unintegrated,
-      representativeDomains,
-      representativeFamilies,
-    } = processedData;
-
     const tedData = dataTED ? formatTED(dataTED) : [];
     const tedFeatures: Feature[] = [];
     if (tedData.length > 0)
@@ -329,8 +335,8 @@ const ProteinViewerForAlphafold = ({
     const colorToObj: Record<string, Feature[]> = {
       af: [] as Feature[],
       bfvd: [] as Feature[],
-      repr_families: representativeFamilies as Feature[],
-      repr_domains: representativeDomains as Feature[],
+      repr_families: representativeDataForStructure['family'],
+      repr_domains: representativeDataForStructure['domain'] as Feature[],
       ted: tedFeatures as Feature[],
     };
 
@@ -349,7 +355,7 @@ const ProteinViewerForAlphafold = ({
       }
       if (setColorMap) setColorMap(colorMap);
     }
-  }, [colorBy, dataTED, colorDomainsBy]);
+  }, [colorBy, dataTED, colorDomainsBy, representativeDataForStructure]);
 
   if (
     !data ||
@@ -468,6 +474,10 @@ const ProteinViewerForAlphafold = ({
           title="Protein domains"
           showOptions={!isSplitScreen}
           matchesAvailable={matchesAvailable}
+          setHasRepresentativeData={setHasRepresentativeData}
+          hasRepresentativeData={hasRepresentativeData}
+          setRepresentativeDataForStructure={setRepresentativeDataForStructure}
+          representativeDataForStructure={representativeDataForStructure}
         />
       </div>
     );

--- a/src/components/Structure3DModel/3DModel/index.tsx
+++ b/src/components/Structure3DModel/3DModel/index.tsx
@@ -111,46 +111,24 @@ const Structure3DModel = ({
     }
   }, [colorBy, hasRepresentativeData]);
 
-  const renderLegend = () => {
-    if (colorBy === 'af' || colorBy === 'bfvd') {
-      return (
-        <>
-          <ul className={css('legend')}>
-            <li>
-              {' '}
-              <b> Model Confidence </b>{' '}
-            </li>
-            {confidenceColors.map((item) => (
-              <li key={item.category}>
-                <span style={{ backgroundColor: item.color }}>&nbsp;</span>{' '}
-                {item.category} ({item.range})
-              </li>
-            ))}
-          </ul>
-        </>
-      );
-    } else if (colorBy === 'ted') {
-      return (
-        <ul className={css('legend')}>
-          <li>
-            {' '}
-            <b> Ted </b>{' '}
-          </li>
-          <li> Highlight all TED domains </li>
-        </ul>
-      );
-    } else if (colorBy?.includes('repr')) {
-      return (
-        <ul className={css('legend')}>
-          <li>
-            {' '}
-            <b> Representative data </b>{' '}
-          </li>
-          <li> Highlight {colorBy.replace('repr_', 'representative ')} </li>
-        </ul>
-      );
-    }
-    return '';
+  const renderLegend = (display: string = '') => {
+    return (
+      <div className={css('legend-container')}>
+        {(colorBy === 'af' || colorBy === 'bfvd') && (
+          <>
+            <b> Model Confidence </b>
+            <ul className={css('legend', display)}>
+              {confidenceColors.map((item) => (
+                <li key={item.category}>
+                  <span style={{ backgroundColor: item.color }}>&nbsp;</span>{' '}
+                  {item.category} ({item.range})
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+    );
   };
 
   // Effect to check PDB availability (moved from BFVDModelSubPage)
@@ -315,24 +293,8 @@ const Structure3DModel = ({
                   ''
                 )}
               </li>
+              <li> {renderLegend()} </li>
             </ul>
-            {/*models.length > 1 ? (
-                <li>
-                  <span className={css('header')}>Prediction</span>
-                  <select
-                    value={modelId || ''}
-                    className={css('protein-list')}
-                    onChange={(event) => onModelChange(event.target.value)}
-                    onBlur={(event) => onModelChange(event.target.value)}
-                  >
-                    {models.map((model) => (
-                      <option key={model.modelEntityId}>{model.modelEntityId}</option>
-                    ))}
-                  </select>
-                </li>
-              ) : (
-                ''
-              )*/}
           </div>
         )}
 
@@ -399,15 +361,7 @@ const Structure3DModel = ({
           >
             {!hasMultipleProteins && (
               <>
-                <div className={css('color-theme-title')}>
-                  <b>Colouring theme</b>
-                  <Tooltip html={renderLegend()} isFullScreen={true}>
-                    <span
-                      className={css('icon', 'icon-common')}
-                      data-icon="&#xf059;"
-                    />
-                  </Tooltip>
-                </div>
+                <b>Colour by</b>
                 <select
                   className={css('color-theme-select')}
                   value={colorBy}
@@ -442,6 +396,7 @@ const Structure3DModel = ({
                 setReady(true);
               }}
             />
+            {isSplitScreen && renderLegend('inline-legend')}
           </PictureInPicturePanel>
         </div>
       </div>

--- a/src/components/Structure3DModel/3DModel/index.tsx
+++ b/src/components/Structure3DModel/3DModel/index.tsx
@@ -256,7 +256,8 @@ const Structure3DModel = ({
                   ''
                 )}
               </li>
-              {/*models.length > 1 ? (
+            </ul>
+            {/*models.length > 1 ? (
                 <li>
                   <span className={css('header')}>Prediction</span>
                   <select
@@ -273,44 +274,9 @@ const Structure3DModel = ({
               ) : (
                 ''
               )*/}
-              {!hasMultipleProteins && (
-                <li>
-                  <span className={css('header')}>Colour by</span>
-                  <select
-                    value={colorBy}
-                    className={css('protein-list')}
-                    onChange={(event) =>
-                      onColorChange && onColorChange(event.target.value)
-                    }
-                  >
-                    <option value={bfvd ? 'bfvd' : 'af'}>
-                      Model confidence
-                    </option>
-                    {hasTED && <option value="ted">TED domains</option>}
-                    {/* <option value="repr_families">Representative families</option>
-                    <option value="repr_domains">Representative domains</option> */}
-                  </select>
-                </li>
-              )}
-            </ul>
-
-            {(colorBy === 'af' || colorBy === 'bfvd') && (
-              <>
-                <h5>Model confidence</h5>
-                <ul className={css('legend')}>
-                  {confidenceColors.map((item) => (
-                    <li key={item.category}>
-                      <span style={{ backgroundColor: item.color }}>
-                        &nbsp;
-                      </span>{' '}
-                      {item.category} ({item.range})
-                    </li>
-                  ))}
-                </ul>
-              </>
-            )}
           </div>
         )}
+
         <div className={css('panel-component')}>
           <PictureInPicturePanel
             className={css({ 'structure-viewer-split': isSplitScreen })}
@@ -372,6 +338,40 @@ const Structure3DModel = ({
               </div>
             }
           >
+            {!hasMultipleProteins && (
+              <>
+                <b>Colouring theme</b>
+                <select
+                  value={colorBy}
+                  onChange={(event) =>
+                    onColorChange && onColorChange(event.target.value)
+                  }
+                >
+                  <option value={bfvd ? 'bfvd' : 'af'}>Model confidence</option>
+                  {hasTED && <option value="ted">TED domains</option>}
+                  {/* <option value="repr_families">Representative families</option>
+                    <option value="repr_domains">Representative domains</option> */}
+                </select>
+              </>
+            )}
+
+            {/* {(colorBy === 'af' || colorBy === 'bfvd') && (
+            <>
+              <h5>Model confidence</h5>
+              <ul className={css('legend')}>
+                {confidenceColors.map((item) => (
+                  <li key={item.category}>
+                    <span style={{ backgroundColor: item.color }}>
+                      &nbsp;
+                    </span>{' '}
+                    {item.category} ({item.range})
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          */}
+
             <StructureViewer
               id={'fullSequence'}
               url={!bfvd && modelInfo ? modelInfo.cifUrl : bfvdURL}

--- a/src/components/Structure3DModel/3DModel/index.tsx
+++ b/src/components/Structure3DModel/3DModel/index.tsx
@@ -113,7 +113,7 @@ const Structure3DModel = ({
 
   const renderLegend = (display: string = '') => {
     return (
-      <div className={css('legend-container')}>
+      <div className={css(display ? 'inline-legend-container' : '')}>
         {(colorBy === 'af' || colorBy === 'bfvd') && (
           <>
             <b> Model Confidence </b>

--- a/src/components/Structure3DModel/3DModel/index.tsx
+++ b/src/components/Structure3DModel/3DModel/index.tsx
@@ -129,7 +129,7 @@ const Structure3DModel = ({
           </ul>
         </>
       );
-    } else if (colorBy == 'ted') {
+    } else if (colorBy === 'ted') {
       return (
         <ul className={css('legend')}>
           <li>

--- a/src/components/Structure3DModel/3DModel/index.tsx
+++ b/src/components/Structure3DModel/3DModel/index.tsx
@@ -3,17 +3,14 @@ import React, { useEffect, useState } from 'react';
 import { createSelector } from 'reselect';
 import { format } from 'url';
 import loadData from 'higherOrder/loadData/ts';
-import config from 'config';
 
 import Link from 'components/generic/Link';
-import { UniProtLink } from 'components/ExtLink/patternLinkWrapper';
 import FullScreenButton from 'components/SimpleCommonComponents/FullScreenButton';
 import PictureInPicturePanel from 'components/SimpleCommonComponents/PictureInPicturePanel';
 import PIPToggleButton from 'components/SimpleCommonComponents/PictureInPicturePanel/ToggleButton';
 import Loading from 'components/SimpleCommonComponents/Loading';
 import Callout from 'components/SimpleCommonComponents/Callout';
 import Button from 'components/SimpleCommonComponents/Button';
-import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 
 import StructureViewer from 'components/Structure/ViewerOnDemand';
 import { Selection } from 'components/Structure/ViewerAndEntries';

--- a/src/components/Structure3DModel/3DModel/index.tsx
+++ b/src/components/Structure3DModel/3DModel/index.tsx
@@ -59,6 +59,7 @@ type Props = {
   colorBy?: string;
   colorMap?: Record<number, number>;
   hasTED: boolean;
+  hasRepresentativeData?: { family: boolean | null; domain: boolean | null };
   modelId: string | null;
   modelUrl?: string;
   bfvd?: string;
@@ -77,6 +78,7 @@ const Structure3DModel = ({
   colorBy,
   colorMap,
   hasTED,
+  hasRepresentativeData,
   modelId,
   modelUrl,
   bfvd,
@@ -93,6 +95,21 @@ const Structure3DModel = ({
   const [isPDBLoading, setIsPDBLoading] = useState(false);
   const [isPDBAvailable, setIsPDBAvailable] = useState(false);
   const [bfvdURL, setBfvdURL] = useState(bfvd || '');
+
+  useEffect(() => {
+    const selectedValueToKey: Record<string, 'family' | 'domain'> = {
+      repr_families: 'family',
+      repr_domains: 'domain',
+    };
+    if (
+      colorBy &&
+      hasRepresentativeData &&
+      hasRepresentativeData[selectedValueToKey[colorBy]] === null &&
+      onColorChange
+    ) {
+      onColorChange(bfvd ? 'bfvd' : 'af');
+    }
+  }, [colorBy, hasRepresentativeData]);
 
   const renderLegend = () => {
     if (colorBy === 'af' || colorBy === 'bfvd') {
@@ -112,6 +129,26 @@ const Structure3DModel = ({
           </ul>
         </>
       );
+    } else if (colorBy == 'ted') {
+      return (
+        <ul className={css('legend')}>
+          <li>
+            {' '}
+            <b> Ted </b>{' '}
+          </li>
+          <li> Highlight all TED domains </li>
+        </ul>
+      );
+    } else if (colorBy?.includes('repr')) {
+      return (
+        <ul className={css('legend')}>
+          <li>
+            {' '}
+            <b> Representative data </b>{' '}
+          </li>
+          <li> Highlight {colorBy.replace('repr_', 'representative ')} </li>
+        </ul>
+      );
     }
     return '';
   };
@@ -124,7 +161,6 @@ const Structure3DModel = ({
       fetch(bfvd, { method: 'GET' })
         .then((res) => {
           if (res.ok) {
-            console.log(res);
             setIsPDBAvailable(true);
           }
           setIsPDBLoading(false);
@@ -365,11 +401,7 @@ const Structure3DModel = ({
               <>
                 <div className={css('color-theme-title')}>
                   <b>Colouring theme</b>
-                  <Tooltip
-                    title={renderLegend()}
-                    interactive={true}
-                    isFullScreen={true}
-                  >
+                  <Tooltip html={renderLegend()} isFullScreen={true}>
                     <span
                       className={css('icon', 'icon-common')}
                       data-icon="&#xf059;"
@@ -379,14 +411,20 @@ const Structure3DModel = ({
                 <select
                   className={css('color-theme-select')}
                   value={colorBy}
-                  onChange={(event) =>
-                    onColorChange && onColorChange(event.target.value)
-                  }
+                  onChange={(event) => {
+                    if (onColorChange) onColorChange(event.target.value);
+                  }}
                 >
                   <option value={bfvd ? 'bfvd' : 'af'}>Model confidence</option>
                   {hasTED && <option value="ted">TED domains</option>}
-                  {/* <option value="repr_families">Representative families</option>
-                    <option value="repr_domains">Representative domains</option> */}
+                  {hasRepresentativeData && hasRepresentativeData['family'] && (
+                    <option value="repr_families">
+                      Representative families
+                    </option>
+                  )}
+                  {hasRepresentativeData && hasRepresentativeData['domain'] && (
+                    <option value="repr_domains">Representative domains</option>
+                  )}
                 </select>
               </>
             )}

--- a/src/components/Structure3DModel/3DModel/index.tsx
+++ b/src/components/Structure3DModel/3DModel/index.tsx
@@ -13,6 +13,7 @@ import PIPToggleButton from 'components/SimpleCommonComponents/PictureInPictureP
 import Loading from 'components/SimpleCommonComponents/Loading';
 import Callout from 'components/SimpleCommonComponents/Callout';
 import Button from 'components/SimpleCommonComponents/Button';
+import Tooltip from 'components/SimpleCommonComponents/Tooltip';
 
 import StructureViewer from 'components/Structure/ViewerOnDemand';
 import { Selection } from 'components/Structure/ViewerAndEntries';
@@ -92,6 +93,28 @@ const Structure3DModel = ({
   const [isPDBLoading, setIsPDBLoading] = useState(false);
   const [isPDBAvailable, setIsPDBAvailable] = useState(false);
   const [bfvdURL, setBfvdURL] = useState(bfvd || '');
+
+  const renderLegend = () => {
+    if (colorBy === 'af' || colorBy === 'bfvd') {
+      return (
+        <>
+          <ul className={css('legend')}>
+            <li>
+              {' '}
+              <b> Model Confidence </b>{' '}
+            </li>
+            {confidenceColors.map((item) => (
+              <li key={item.category}>
+                <span style={{ backgroundColor: item.color }}>&nbsp;</span>{' '}
+                {item.category} ({item.range})
+              </li>
+            ))}
+          </ul>
+        </>
+      );
+    }
+    return '';
+  };
 
   // Effect to check PDB availability (moved from BFVDModelSubPage)
   useEffect(() => {
@@ -340,8 +363,21 @@ const Structure3DModel = ({
           >
             {!hasMultipleProteins && (
               <>
-                <b>Colouring theme</b>
+                <div className={css('color-theme-title')}>
+                  <b>Colouring theme</b>
+                  <Tooltip
+                    title={renderLegend()}
+                    interactive={true}
+                    isFullScreen={true}
+                  >
+                    <span
+                      className={css('icon', 'icon-common')}
+                      data-icon="&#xf059;"
+                    />
+                  </Tooltip>
+                </div>
                 <select
+                  className={css('color-theme-select')}
                   value={colorBy}
                   onChange={(event) =>
                     onColorChange && onColorChange(event.target.value)
@@ -354,23 +390,6 @@ const Structure3DModel = ({
                 </select>
               </>
             )}
-
-            {/* {(colorBy === 'af' || colorBy === 'bfvd') && (
-            <>
-              <h5>Model confidence</h5>
-              <ul className={css('legend')}>
-                {confidenceColors.map((item) => (
-                  <li key={item.category}>
-                    <span style={{ backgroundColor: item.color }}>
-                      &nbsp;
-                    </span>{' '}
-                    {item.category} ({item.range})
-                  </li>
-                ))}
-              </ul>
-            </>
-          )}
-          */}
 
             <StructureViewer
               id={'fullSequence'}

--- a/src/components/Structure3DModel/3DModel/style.css
+++ b/src/components/Structure3DModel/3DModel/style.css
@@ -65,6 +65,10 @@ select {
   max-width: 100% !important;
 }
 
+:global(.split-view) .structure-viewer-split {
+  padding: 10px;
+}
+
 div.alphafold-model .structure-viewer-split {
   height: 90vh;
 }

--- a/src/components/Structure3DModel/3DModel/style.css
+++ b/src/components/Structure3DModel/3DModel/style.css
@@ -33,7 +33,18 @@ ul.legend {
 ul.legend {
   display: flex;
   flex-direction: column;
+  font-size: 1em;
+}
+
+ul.inline-legend {
+  display: flex;
+  flex-direction: row;
   font-size: 0.9em;
+  gap: 5px;
+}
+
+.legend-container {
+  height: 4em;
 }
 
 ul.information > li:nth-child(n + 2) {
@@ -83,7 +94,7 @@ div.alphafold-model .structure-viewer-split {
 }
 
 .color-theme-select {
-  height: 50px;
+  min-height: 40px;
 }
 
 .color-theme-title {

--- a/src/components/Structure3DModel/3DModel/style.css
+++ b/src/components/Structure3DModel/3DModel/style.css
@@ -43,7 +43,8 @@ ul.inline-legend {
   gap: 5px;
 }
 
-.legend-container {
+.inline-legend-container {
+  margin-top: -6em;
   height: 4em;
 }
 

--- a/src/components/Structure3DModel/3DModel/style.css
+++ b/src/components/Structure3DModel/3DModel/style.css
@@ -1,6 +1,8 @@
 .af-container {
   display: flex;
   flex-wrap: no-wrap;
+  height: 100%;
+  margin-bottom: 2em;
 
   & .panel-component {
     flex-grow: 2;
@@ -11,6 +13,7 @@
     padding-right: 1rem;
   }
 }
+
 @media screen and (max-width: 44em) {
   .af-container {
     flex-wrap: wrap;
@@ -25,6 +28,12 @@ ul.information,
 ul.legend {
   margin: 0;
   padding: 0;
+}
+
+ul.legend {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9em;
 }
 
 ul.information > li:nth-child(n + 2) {
@@ -71,4 +80,14 @@ select {
 
 div.alphafold-model .structure-viewer-split {
   height: 90vh;
+}
+
+.color-theme-select {
+  height: 50px;
+}
+
+.color-theme-title {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
 }

--- a/src/subPages/AlphaFoldModelSubPage/index.tsx
+++ b/src/subPages/AlphaFoldModelSubPage/index.tsx
@@ -52,6 +52,13 @@ const AlphaFoldModelSubPage = ({
   const [colorBy, setColorBy] = useState('af');
   const [colorMap, setColorMap] = useState<Record<number, number>>({});
   const [hasTED, setHasTED] = useState(false);
+  const [hasRepresentativeData, setHasRepresentativeData] = useState<{
+    family: boolean | null;
+    domain: boolean | null;
+  }>({
+    family: null,
+    domain: null,
+  });
 
   const handleProteinChange = (value: string) => {
     setProteinAcc(value);
@@ -85,11 +92,12 @@ const AlphaFoldModelSubPage = ({
       })}
       ref={container}
     >
-      {proteinAcc && (
+      {proteinAcc && hasRepresentativeData !== null && (
         <AlphaFoldModel
           colorMap={colorMap}
           proteinAcc={proteinAcc}
           hasTED={hasTED}
+          hasRepresentativeData={hasRepresentativeData}
           hasMultipleProteins={hasMultipleProteins}
           onModelChange={handleModelChange}
           onColorChange={onColorChange}
@@ -120,6 +128,8 @@ const AlphaFoldModelSubPage = ({
               setSelectionsInModel(selection);
             }}
             isSplitScreen={isSplitScreen}
+            setHasRepresentativeData={setHasRepresentativeData}
+            hasRepresentativeData={hasRepresentativeData}
           />
         </div>
       )}

--- a/src/subPages/BFVDModelSubPage/index.tsx
+++ b/src/subPages/BFVDModelSubPage/index.tsx
@@ -48,6 +48,13 @@ const BFVDModelSubPage = ({
   const [colorBy, setColorBy] = useState('bfvd');
   const [colorMap, setColorMap] = useState<Record<number, number>>({});
   const [hasTED, setHasTED] = useState(false);
+  const [hasRepresentativeData, setHasRepresentativeData] = useState<{
+    family: boolean | null;
+    domain: boolean | null;
+  }>({
+    family: null,
+    domain: null,
+  });
 
   const [modelId, setModelId] = useState<string | null>(null);
   const [isSplitScreen, setSplitScreen] = useState(false);
@@ -89,10 +96,11 @@ const BFVDModelSubPage = ({
       })}
       ref={container}
     >
-      {proteinAcc && (
+      {proteinAcc && hasRepresentativeData !== null && (
         <BFVDModel
           colorMap={colorMap}
           hasTED={hasTED}
+          hasRepresentativeData={hasRepresentativeData}
           proteinAcc={proteinAcc}
           hasMultipleProteins={hasMultipleProteins}
           onModelChange={handleModelChange}
@@ -126,6 +134,8 @@ const BFVDModelSubPage = ({
               setSelectionsInModel(selection);
             }}
             isSplitScreen={isSplitScreen}
+            setHasRepresentativeData={setHasRepresentativeData}
+            hasRepresentativeData={hasRepresentativeData}
           />
         </div>
       )}

--- a/src/utils/entry-color/index.js
+++ b/src/utils/entry-color/index.js
@@ -36,6 +36,9 @@ export const getTrackColor = (
   // eslint-disable-next-line default-case
   switch (colorMode) {
     case EntryColorMode.ACCESSION:
+      if (entry.parent) {
+        entry = entry.parent;
+      }
       acc = entry.accession.startsWith('residue:')
         ? entry.accession
             .split('residue:')[1]

--- a/src/utils/entry-color/index.js
+++ b/src/utils/entry-color/index.js
@@ -36,9 +36,6 @@ export const getTrackColor = (
   // eslint-disable-next-line default-case
   switch (colorMode) {
     case EntryColorMode.ACCESSION:
-      if (entry.parent) {
-        entry = entry.parent;
-      }
       acc = entry.accession.startsWith('residue:')
         ? entry.accession
             .split('residue:')[1]


### PR DESCRIPTION
This PR addresses: [IBU-12138](https://embl.atlassian.net/browse/IBU-12138) and [IBU-12139](https://embl.atlassian.net/browse/IBU-12139)

The "Colouring theme" selector now includes representative families and domains depending on availability and it's now correctly updated when the match type (InterPro vs InterPro-N) is changed.

Changing color scheme on the protein viewer updates the color of representative data as well and that's why I find the name "theme" maybe a bit confusing. It might be worth looking for a better name (although model confidence and TED do stay the same).

The selector is now available in split screen on top of the structure.

Information about the model confidence has been moved to a tooltip next to the selector label. 
We can make descriptions for TED and representative data better.

