### PR TITLE
UniParc page for removed UniProtKB entries

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -9,13 +9,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24.4.0'
+          node-version: 20
           cache: 'npm'
 
       - name: 🔧 - Install
         run: |
           cp config.yml.example config.yml
-          npm i -g npm@11.4.2 --verbose
           npm ci
 
       - name: 🏗 - Build (dev)

--- a/README.md
+++ b/README.md
@@ -45,5 +45,3 @@ and run them as stand-alone commands
 -   `scripts` The scripts executed when various `npm run` options selected
 -   `src`  The source code for the website
 -   `tests` Functional tests for the website
-
-

--- a/src/components/Protein/UniParcProtein/index.tsx
+++ b/src/components/Protein/UniParcProtein/index.tsx
@@ -1,35 +1,32 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { createSelector } from 'reselect';
-
-import Length from 'components/Protein/Length';
+import config from 'config';
+import TitleTag from 'components/Title/TitleTag';
 import Species from 'components/Protein/Species';
 import Link from 'components/generic/Link';
 import DomainsOnProteinLoaded from 'components/Related/DomainsOnProtein/DomainsOnProteinLoaded';
 
-import { UniProtLink } from 'components/ExtLink/patternLinkWrapper';
-
-import Tooltip from 'components/SimpleCommonComponents/Tooltip';
-
 import { mergeData } from 'components/IPScan/Summary/serializers';
-import FileExporter from 'components/Matches/FileExporter';
 
 import DownloadButton from '../Sequence/DownloadButton';
-
-import { splitSequenceByChunks } from 'utils/sequence';
 
 import cssBinder from 'styles/cssBinder';
 
 import fonts from 'EBI-Icon-fonts/fonts.css';
 import ipro from 'styles/interpro-vf.css';
-import local from './style.css';
+import style from 'components/Title/style.css';
 import summary from 'styles/summary.css';
-import BaseLink from 'components/ExtLink/BaseLink';
 
-const css = cssBinder(summary, fonts, ipro, local);
+import AccessionTag from 'components/Title/AccessionTag';
+import Callout from 'components/SimpleCommonComponents/Callout';
+
+const css = cssBinder(summary, fonts, ipro, style);
 
 type Props = {
   data: {
-    metadata: ProteinMetadata & { name?: NameObject };
+    metadata: ProteinMetadata & { name?: NameObject } & {
+      taxonomies: { commonTaxon: string; commonTaxonId: string }[];
+    };
   };
   md5: string;
 };
@@ -43,9 +40,7 @@ export const UniParcProtein = ({ data, md5 }: Props) => {
 
     const fetchMatches = async () => {
       try {
-        const response = await fetch(
-          `https://www.ebi.ac.uk/interpro/matches/api/matches/${md5}`,
-        );
+        const response = await fetch(`${config.root.matches}/${md5}`);
         const data = await response.json();
         setMatches(data.matches || []);
       } catch (error) {
@@ -65,21 +60,29 @@ export const UniParcProtein = ({ data, md5 }: Props) => {
 
   return (
     <>
+      <Callout type="info">
+        {metadata.accession} is no longer available in UniProtKB. This page
+        shows information from its corresponding UniParc sequence entry.
+      </Callout>
+      <div className={css('title-name')}>
+        <div className={css('title-fav')}>
+          <AccessionTag
+            accession={metadata.accession}
+            db={metadata.source_database}
+            mainType={'protein'}
+            isIPScanResult={false}
+          />
+          <h3 className={css('margin-bottom-large')}>
+            UniParc Entry {metadata.id}
+          </h3>
+        </div>
+      </div>
+      <TitleTag mainType="protein" db="uniparc" dbLabel="uniparc" />
+      <br></br>
       <section className={css('vf-grid', 'summary-grid')}>
         <div className={css('vf-stack')}>
           <table className={css('vf-table', 'left-headers')}>
             <tbody>
-              <tr>
-                <td style={{ maxWidth: '50%' }}>UniProt ID</td>
-                <td>
-                  <i
-                    className={css('shortname')}
-                    data-testid="protein-shortname"
-                  >
-                    {metadata.accession}
-                  </i>
-                </td>
-              </tr>
               <tr>
                 <td>Length</td>
                 <td data-testid="protein-length">
@@ -87,54 +90,21 @@ export const UniParcProtein = ({ data, md5 }: Props) => {
                 </td>
               </tr>
               <tr>
-                <td>Taxonomy</td>
+                <td>Taxonomies</td>
                 <td data-testid="protein-species">
-                  <Species
-                    fullName={metadata.source_organism.fullName}
-                    taxID={metadata.source_organism.taxId}
-                  />
+                  {metadata.taxonomies?.map((taxonomy, idx) => {
+                    return (
+                      <>
+                        <Species
+                          fullName={taxonomy.commonTaxon}
+                          taxID={taxonomy.commonTaxonId}
+                        />
+                        {idx !== metadata.taxonomies?.length - 1 ? ', ' : ''}
+                      </>
+                    );
+                  })}
                 </td>
               </tr>
-              {metadata.proteome && metadata.proteome.length > 0 && (
-                <tr>
-                  <td>Proteome</td>
-                  <td data-testid="protein-proteome">
-                    <Link
-                      to={{
-                        description: {
-                          main: { key: 'proteome' },
-                          proteome: {
-                            db: 'uniprot',
-                            accession: metadata.proteome,
-                          },
-                        },
-                      }}
-                    >
-                      {metadata.proteome}
-                    </Link>
-                  </td>
-                </tr>
-              )}
-              {metadata.gene && (
-                <tr>
-                  <td>Gene</td>
-                  <td>{metadata.gene}</td>
-                </tr>
-              )}
-              {metadata.description && metadata.description.length ? (
-                <tr>
-                  <td data-testid="protein-function">
-                    Function{' '}
-                    <Tooltip title="Provided By UniProt">
-                      <span
-                        className={css('small', 'icon', 'icon-common')}
-                        data-icon="&#xf129;"
-                        aria-label="Provided By UniProt"
-                      />
-                    </Tooltip>
-                  </td>
-                </tr>
-              ) : null}
             </tbody>
           </table>
         </div>
@@ -144,75 +114,16 @@ export const UniParcProtein = ({ data, md5 }: Props) => {
               <h5>External Links</h5>
               <ul className={css('no-bullet')}>
                 <li>
-                  <UniProtLink id={metadata.accession} className={css('ext')}>
+                  <Link
+                    href={`https://www.uniprot.org/uniparc/${metadata.id}/entry/${metadata.accession}`}
+                    className={css('ext')}
+                  >
                     UniProt
-                  </UniProtLink>
+                  </Link>
                 </li>
-                {metadata.in_bfvd ? (
-                  <>
-                    <li>
-                      <BaseLink
-                        id={metadata.accession}
-                        target={'_blank'}
-                        pattern="https://bfvd.foldseek.com/cluster/{id}"
-                        className={css('ext')}
-                      >
-                        BFVD
-                      </BaseLink>
-                    </li>
-                    <li>
-                      <BaseLink
-                        id={metadata.accession}
-                        target={'_blank'}
-                        pattern="https://search.foldseek.com/search?accession={id}&source=BFVD"
-                        className={css('ext')}
-                      >
-                        Foldseek
-                      </BaseLink>
-                    </li>
-                  </>
-                ) : null}
-                {metadata.in_alphafold ? (
-                  <>
-                    <li>
-                      <BaseLink
-                        id={metadata.accession}
-                        target={'_blank'}
-                        pattern="https://alphafold.ebi.ac.uk/entry/{id}"
-                        className={css('ext')}
-                      >
-                        AlphaFold
-                      </BaseLink>
-                    </li>
-                    <li>
-                      <BaseLink
-                        id={metadata.accession}
-                        target={'_blank'}
-                        pattern="https://search.foldseek.com/search?accession={id}&source=AlphaFoldDB"
-                        className={css('ext')}
-                      >
-                        Foldseek
-                      </BaseLink>
-                    </li>
-                  </>
-                ) : null}
               </ul>
             </section>
             <hr style={{ margin: '0.8em' }} />
-            {/* {/* <HmmerButton
-              sequence={metadata.sequence}
-              accession={metadata.accession}
-              title="Search protein with HMMER"
-              minWidth={minWidth}
-            /> 
-                // <IPScanButton
-                //     sequence={splitSequenceByChunks(
-                //         metadata.sequence,
-                //         metadata.id || '',
-                //     )}
-                //     title="Search sequence with InterProScan"
-                //     minWidth={"20"}
-                // /> */}
             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
             <DownloadButton
               sequence={metadata.sequence}

--- a/src/components/Protein/UniParcProtein/index.tsx
+++ b/src/components/Protein/UniParcProtein/index.tsx
@@ -1,0 +1,254 @@
+import React, { useRef, useEffect, useState } from 'react';
+import { createSelector } from 'reselect';
+
+import Length from 'components/Protein/Length';
+import Species from 'components/Protein/Species';
+import Link from 'components/generic/Link';
+import DomainsOnProteinLoaded from 'components/Related/DomainsOnProtein/DomainsOnProteinLoaded';
+
+import { UniProtLink } from 'components/ExtLink/patternLinkWrapper';
+
+import Tooltip from 'components/SimpleCommonComponents/Tooltip';
+
+import { mergeData } from 'components/IPScan/Summary/serializers';
+import FileExporter from 'components/Matches/FileExporter';
+
+import DownloadButton from '../Sequence/DownloadButton';
+
+import { splitSequenceByChunks } from 'utils/sequence';
+
+import cssBinder from 'styles/cssBinder';
+
+import fonts from 'EBI-Icon-fonts/fonts.css';
+import ipro from 'styles/interpro-vf.css';
+import local from './style.css';
+import summary from 'styles/summary.css';
+import BaseLink from 'components/ExtLink/BaseLink';
+
+const css = cssBinder(summary, fonts, ipro, local);
+
+type Props = {
+  data: {
+    metadata: ProteinMetadata & { name?: NameObject };
+  };
+  md5: string;
+};
+
+export const UniParcProtein = ({ data, md5 }: Props) => {
+  const metadata = data.metadata;
+  const [matches, setMatches] = useState([]);
+
+  useEffect(() => {
+    if (!metadata || !metadata.accession || !md5) return;
+
+    const fetchMatches = async () => {
+      try {
+        const response = await fetch(
+          `https://www.ebi.ac.uk/interpro/matches/api/matches/${md5}`,
+        );
+        const data = await response.json();
+        setMatches(data.matches || []);
+      } catch (error) {
+        console.error('Failed to fetch matches:', error);
+        setMatches([]);
+      }
+    };
+
+    fetchMatches();
+  }, [metadata, md5]);
+
+  let organisedData = {};
+
+  if (matches && matches.length > 0) {
+    organisedData = mergeData(matches, metadata.length);
+  }
+
+  console.log(organisedData);
+  return (
+    <>
+      <section className={css('vf-grid', 'summary-grid')}>
+        <div className={css('vf-stack')}>
+          <table className={css('vf-table', 'left-headers')}>
+            <tbody>
+              <tr>
+                <td style={{ maxWidth: '50%' }}>Short name</td>
+                <td>
+                  <i
+                    className={css('shortname')}
+                    data-testid="protein-shortname"
+                  >
+                    {metadata.id}
+                  </i>
+                </td>
+              </tr>
+              <tr>
+                <td>Length</td>
+                <td data-testid="protein-length">
+                  <Length metadata={metadata} />
+                </td>
+                x
+              </tr>
+              <tr>
+                <td>Species</td>
+                <td data-testid="protein-species">
+                  <Species
+                    fullName={metadata.source_organism.fullName}
+                    taxID={metadata.source_organism.taxId}
+                  />
+                </td>
+              </tr>
+              {metadata.proteome && metadata.proteome.length > 0 && (
+                <tr>
+                  <td>Proteome</td>
+                  <td data-testid="protein-proteome">
+                    <Link
+                      to={{
+                        description: {
+                          main: { key: 'proteome' },
+                          proteome: {
+                            db: 'uniprot',
+                            accession: metadata.proteome,
+                          },
+                        },
+                      }}
+                    >
+                      {metadata.proteome}
+                    </Link>
+                  </td>
+                </tr>
+              )}
+              {metadata.gene && (
+                <tr>
+                  <td>Gene</td>
+                  <td>{metadata.gene}</td>
+                </tr>
+              )}
+              {metadata.description && metadata.description.length ? (
+                <tr>
+                  <td data-testid="protein-function">
+                    Function{' '}
+                    <Tooltip title="Provided By UniProt">
+                      <span
+                        className={css('small', 'icon', 'icon-common')}
+                        data-icon="&#xf129;"
+                        aria-label="Provided By UniProt"
+                      />
+                    </Tooltip>
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+        <div className={css('vf-stack')}>
+          <section>
+            <section>
+              <h5>External Links</h5>
+              <ul className={css('no-bullet')}>
+                <li>
+                  <UniProtLink id={metadata.accession} className={css('ext')}>
+                    UniProt
+                  </UniProtLink>
+                </li>
+                {metadata.in_bfvd ? (
+                  <>
+                    <li>
+                      <BaseLink
+                        id={metadata.accession}
+                        target={'_blank'}
+                        pattern="https://bfvd.foldseek.com/cluster/{id}"
+                        className={css('ext')}
+                      >
+                        BFVD
+                      </BaseLink>
+                    </li>
+                    <li>
+                      <BaseLink
+                        id={metadata.accession}
+                        target={'_blank'}
+                        pattern="https://search.foldseek.com/search?accession={id}&source=BFVD"
+                        className={css('ext')}
+                      >
+                        Foldseek
+                      </BaseLink>
+                    </li>
+                  </>
+                ) : null}
+                {metadata.in_alphafold ? (
+                  <>
+                    <li>
+                      <BaseLink
+                        id={metadata.accession}
+                        target={'_blank'}
+                        pattern="https://alphafold.ebi.ac.uk/entry/{id}"
+                        className={css('ext')}
+                      >
+                        AlphaFold
+                      </BaseLink>
+                    </li>
+                    <li>
+                      <BaseLink
+                        id={metadata.accession}
+                        target={'_blank'}
+                        pattern="https://search.foldseek.com/search?accession={id}&source=AlphaFoldDB"
+                        className={css('ext')}
+                      >
+                        Foldseek
+                      </BaseLink>
+                    </li>
+                  </>
+                ) : null}
+              </ul>
+            </section>
+            <hr style={{ margin: '0.8em' }} />
+            {/* {/* <HmmerButton
+              sequence={metadata.sequence}
+              accession={metadata.accession}
+              title="Search protein with HMMER"
+              minWidth={minWidth}
+            /> 
+                // <IPScanButton
+                //     sequence={splitSequenceByChunks(
+                //         metadata.sequence,
+                //         metadata.id || '',
+                //     )}
+                //     title="Search sequence with InterProScan"
+                //     minWidth={"20"}
+                // /> */}
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label style={{ marginBottom: '0.4rem' }}>
+              <FileExporter
+                description={{
+                  main: { key: 'protein' },
+                  protein: {
+                    db: metadata.source_database,
+                    accession: metadata.accession,
+                  },
+                  entry: { integration: 'all' },
+                }}
+                count={metadata.counters!.entries as number}
+                fileType="tsv"
+                primary="entry"
+                secondary="protein"
+                minWidth={20}
+                label="Download matches (TSV)"
+              />
+            </label>
+            <DownloadButton
+              sequence={metadata.sequence}
+              accession={metadata.accession}
+            />
+          </section>
+        </div>
+      </section>
+      <br></br>
+      {matches && matches.length > 0 && (
+        <DomainsOnProteinLoaded
+          mainData={{ metadata }}
+          dataMerged={organisedData}
+          loading={false}
+        ></DomainsOnProteinLoaded>
+      )}
+    </>
+  );
+};

--- a/src/components/Protein/UniParcProtein/index.tsx
+++ b/src/components/Protein/UniParcProtein/index.tsx
@@ -63,7 +63,6 @@ export const UniParcProtein = ({ data, md5 }: Props) => {
     organisedData = mergeData(matches, metadata.length);
   }
 
-  console.log(organisedData);
   return (
     <>
       <section className={css('vf-grid', 'summary-grid')}>
@@ -71,25 +70,24 @@ export const UniParcProtein = ({ data, md5 }: Props) => {
           <table className={css('vf-table', 'left-headers')}>
             <tbody>
               <tr>
-                <td style={{ maxWidth: '50%' }}>Short name</td>
+                <td style={{ maxWidth: '50%' }}>UniProt ID</td>
                 <td>
                   <i
                     className={css('shortname')}
                     data-testid="protein-shortname"
                   >
-                    {metadata.id}
+                    {metadata.accession}
                   </i>
                 </td>
               </tr>
               <tr>
                 <td>Length</td>
                 <td data-testid="protein-length">
-                  <Length metadata={metadata} />
+                  {metadata.length} amino acids
                 </td>
-                x
               </tr>
               <tr>
-                <td>Species</td>
+                <td>Taxonomy</td>
                 <td data-testid="protein-species">
                   <Species
                     fullName={metadata.source_organism.fullName}
@@ -216,24 +214,6 @@ export const UniParcProtein = ({ data, md5 }: Props) => {
                 //     minWidth={"20"}
                 // /> */}
             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label style={{ marginBottom: '0.4rem' }}>
-              <FileExporter
-                description={{
-                  main: { key: 'protein' },
-                  protein: {
-                    db: metadata.source_database,
-                    accession: metadata.accession,
-                  },
-                  entry: { integration: 'all' },
-                }}
-                count={metadata.counters!.entries as number}
-                fileType="tsv"
-                primary="entry"
-                secondary="protein"
-                minWidth={20}
-                label="Download matches (TSV)"
-              />
-            </label>
             <DownloadButton
               sequence={metadata.sequence}
               accession={metadata.accession}

--- a/src/pages/endpoint-page.js
+++ b/src/pages/endpoint-page.js
@@ -147,21 +147,20 @@ class Summary extends PureComponent {
     }
 
     /* UniParc edge case */
-    if (
-      status == 204 &&
-      payloadUniParc.results &&
-      payloadUniParc.results.length > 0
-    ) {
-      const uniParcResult = payloadUniParc.results[0];
-      const taxonInfo =
-        uniParcResult.commonTaxons[uniParcResult.commonTaxons.length - 1];
+    if (status == 204 && payloadUniParc.results.length > 0) {
       const uniprotAccession =
         customLocation.description[customLocation.description.main.key]
           .accession;
-      console.log(uniParcResult);
+      const uniParcResult = payloadUniParc.results.filter((res) =>
+        res.uniProtKBAccessions.some((acc) => acc.includes(uniprotAccession)),
+      )[0];
+
+      const taxonInfo =
+        uniParcResult.commonTaxons[uniParcResult.commonTaxons.length - 1];
+
       const standardizedData = {
         metadata: {
-          name: 'test',
+          name: '',
           counters: {},
           accession: uniprotAccession,
           id: uniParcResult.uniParcId,
@@ -179,11 +178,7 @@ class Summary extends PureComponent {
           <div className={f('row')}>
             <div className={f('medium-12', 'large-12', 'columns')}>
               <UnconnectedErrorBoundary customLocation={customLocation}>
-                <h3>
-                  {' '}
-                  UniParc Entry {standardizedData.metadata.id} (
-                  {uniprotAccession}){' '}
-                </h3>
+                <h3> UniParc Entry {standardizedData.metadata.id}</h3>
               </UnconnectedErrorBoundary>
             </div>
           </div>

--- a/src/pages/endpoint-page.js
+++ b/src/pages/endpoint-page.js
@@ -22,6 +22,7 @@ import RemovedEntrySummary from 'components/Entry/RemovedEntrySummary';
 import Title from 'components/Title';
 import EdgeCase from 'components/EdgeCase';
 import { getMessageIfLocationRemoved } from 'utils/removed-pages';
+import { UniParcProtein } from '/src/components/Protein/UniParcProtein';
 
 import {
   // schemaProcessDataRecord,
@@ -50,6 +51,7 @@ const propTypes = {
   }).isRequired,
   match: T.string,
   dataBase: dataPropType.isRequired,
+  dataUniParc: dataPropType.isRequired,
   subPagesForEndpoint: T.oneOfType([T.func, T.object]),
 };
 
@@ -57,6 +59,7 @@ class SummaryComponent extends PureComponent {
   static propTypes = {
     data: dataPropType.isRequired,
     dataBase: dataPropType.isRequired,
+    dataUniParc: dataPropType.isRequired,
     customLocation: T.object.isRequired,
     SummaryAsync: T.oneOfType([T.func, T.object]),
   };
@@ -65,6 +68,7 @@ class SummaryComponent extends PureComponent {
     const {
       data: { payload, loading },
       dataBase: { payload: payloadDB, loading: loadingDB },
+      dataUniParc: { payload: payloadUniParc, loading: loadingUniParc },
       customLocation,
       SummaryAsync,
     } = this.props;
@@ -103,9 +107,11 @@ class Summary extends PureComponent {
     const {
       data: { status, loading, payload },
       dataBase: { payload: payloadDB, loading: loadingDB },
+      dataUniParc: { payload: payloadUniParc, loading: loadingUniParc },
       customLocation,
       subPagesForEndpoint,
     } = this.props;
+
     const {
       description: {
         main: { key: endpoint },
@@ -137,6 +143,70 @@ class Summary extends PureComponent {
           status={410}
           shouldRedirect={false}
         />
+      );
+    }
+
+    /* UniParc edge case */
+    if (
+      status == 204 &&
+      payloadUniParc.results &&
+      payloadUniParc.results.length > 0
+    ) {
+      const uniParcResult = payloadUniParc.results[0];
+      const taxonInfo =
+        uniParcResult.commonTaxons[uniParcResult.commonTaxons.length - 1];
+      const uniprotAccession =
+        customLocation.description[customLocation.description.main.key]
+          .accession;
+      console.log(uniParcResult);
+      const standardizedData = {
+        metadata: {
+          name: 'test',
+          counters: {},
+          accession: uniprotAccession,
+          id: uniParcResult.uniParcId,
+          source_organism: {
+            fullName: taxonInfo.commonTaxon,
+            taxId: taxonInfo.commonTaxonId,
+          },
+          length: uniParcResult.sequence.length,
+          sequence: uniParcResult.sequence.value,
+        },
+      };
+
+      return (
+        <>
+          <div className={f('row')}>
+            <div className={f('medium-12', 'large-12', 'columns')}>
+              <UnconnectedErrorBoundary customLocation={customLocation}>
+                <h3>
+                  {' '}
+                  UniParc Entry {standardizedData.metadata.id} (
+                  {uniprotAccession}){' '}
+                </h3>
+              </UnconnectedErrorBoundary>
+            </div>
+          </div>
+          <div className={f('row')}>
+            <div className={f('medium-12', 'large-12', 'columns')}>
+              <section className={f('menu-and-content')}>
+                <nav>
+                  <UnconnectedErrorBoundary customLocation={customLocation}>
+                    {/*<EntryMenu metadata={payload.metadata} />*/}
+                  </UnconnectedErrorBoundary>
+                </nav>
+                <section>
+                  <UnconnectedErrorBoundary customLocation={customLocation}>
+                    <UniParcProtein
+                      data={standardizedData}
+                      md5={uniParcResult.sequence.md5}
+                    />
+                  </UnconnectedErrorBoundary>
+                </section>
+              </section>
+            </div>
+          </div>
+        </>
       );
     }
 
@@ -337,8 +407,23 @@ const mapStateToProps = createSelector(
   }),
 );
 
+const getUniParc = createSelector(
+  (state) =>
+    state.customLocation.description[state.customLocation.description.main.key]
+      .accession,
+  (accession) => {
+    if (!accession) return null;
+    return `https://rest.uniprot.org/uniparc/search?query=${accession}`;
+  },
+);
+
 export default loadData({
   getUrl: getUrlForMeta,
   propNamespace: 'Base',
   mapStateToProps,
-})(loadData(getUrlForApi)(EndPointPage));
+})(
+  loadData({
+    getUrl: getUniParc,
+    propNamespace: 'UniParc',
+  })(loadData(getUrlForApi)(EndPointPage)),
+);

--- a/src/pages/endpoint-page.js
+++ b/src/pages/endpoint-page.js
@@ -147,7 +147,7 @@ class Summary extends PureComponent {
     }
 
     /* UniParc edge case */
-    if (status == 204 && payloadUniParc.results.length > 0) {
+    if (status === 204 && payloadUniParc.results.length > 0) {
       const uniprotAccession =
         customLocation.description[customLocation.description.main.key]
           .accession;
@@ -155,19 +155,14 @@ class Summary extends PureComponent {
         res.uniProtKBAccessions.some((acc) => acc.includes(uniprotAccession)),
       )[0];
 
-      const taxonInfo =
-        uniParcResult.commonTaxons[uniParcResult.commonTaxons.length - 1];
-
       const standardizedData = {
         metadata: {
           name: '',
           counters: {},
           accession: uniprotAccession,
           id: uniParcResult.uniParcId,
-          source_organism: {
-            fullName: taxonInfo.commonTaxon,
-            taxId: taxonInfo.commonTaxonId,
-          },
+          source_organism: '',
+          taxonomies: uniParcResult.commonTaxons,
           length: uniParcResult.sequence.length,
           sequence: uniParcResult.sequence.value,
         },
@@ -177,19 +172,7 @@ class Summary extends PureComponent {
         <>
           <div className={f('row')}>
             <div className={f('medium-12', 'large-12', 'columns')}>
-              <UnconnectedErrorBoundary customLocation={customLocation}>
-                <h3> UniParc Entry {standardizedData.metadata.id}</h3>
-              </UnconnectedErrorBoundary>
-            </div>
-          </div>
-          <div className={f('row')}>
-            <div className={f('medium-12', 'large-12', 'columns')}>
               <section className={f('menu-and-content')}>
-                <nav>
-                  <UnconnectedErrorBoundary customLocation={customLocation}>
-                    {/*<EntryMenu metadata={payload.metadata} />*/}
-                  </UnconnectedErrorBoundary>
-                </nav>
                 <section>
                   <UnconnectedErrorBoundary customLocation={customLocation}>
                     <UniParcProtein


### PR DESCRIPTION
This PR addresses [IBU-12265](https://embl.atlassian.net/browse/IBU-12265).
A new and different component gets rendered if our API returns 404 on a UniProt accession and if UniParc has entries for it.
The new page resembles the protein one, with some changes that accommodate differences in the available data.
I think this is a good starting point. Do let me know if you want me to add/remove anything.
