### PR TITLE
Add InterProN matches and extra features to .tsv download on Protein pages

### DIFF
--- a/src/actions/creators/index.ts
+++ b/src/actions/creators/index.ts
@@ -6,6 +6,7 @@ import {
   AlphafoldModelCountAction,
   DataProgressAction,
   DownloadAction,
+  DownloadExtraData,
   FavouritesAction,
   IPScanAction,
   IPScanMetadataAction,
@@ -238,6 +239,7 @@ export const downloadURL = (
   subset: boolean,
   endpoint: string,
   originURL?: string,
+  extraData?: DownloadExtraData,
 ) =>
   ({
     type: types.DOWNLOAD_URL,
@@ -246,6 +248,7 @@ export const downloadURL = (
     subset,
     endpoint,
     originURL,
+    extraData,
   }) as DownloadAction;
 
 export const downloadError = (

--- a/src/actions/types/index.ts
+++ b/src/actions/types/index.ts
@@ -72,6 +72,12 @@ export const DOWNLOAD_SUCCESS = 'DOWNLOAD_SUCCESS';
 export const DOWNLOAD_DELETE = 'DOWNLOAD_DELETE';
 export const SET_INITIAL_DOWNLOADS = 'SET_INITIAL_DOWNLOADS';
 
+// Data already fetched (and cached) by the page, to be downloaded on file request
+export interface DownloadExtraData {
+  interpro_n?: InterProNMatches;
+  extra_features?: ExtraFeaturesPayload;
+}
+
 export interface DownloadAction
   extends Action<
     | typeof DOWNLOAD_URL
@@ -81,6 +87,7 @@ export interface DownloadAction
     | typeof DOWNLOAD_DELETE
   > {
   url: string;
+  extraData?: DownloadExtraData;
   key?: string;
   fileType: DownloadFileTypes;
   subset: boolean;

--- a/src/actions/types/index.ts
+++ b/src/actions/types/index.ts
@@ -76,6 +76,7 @@ export const SET_INITIAL_DOWNLOADS = 'SET_INITIAL_DOWNLOADS';
 export interface DownloadExtraData {
   interpro_n?: InterProNMatches;
   extra_features?: ExtraFeaturesPayload;
+  protein?: { accession: string; length: number };
 }
 
 export interface DownloadAction

--- a/src/components/File/index.tsx
+++ b/src/components/File/index.tsx
@@ -6,6 +6,7 @@ import { format } from 'url';
 import { askNotificationPermission } from 'utils/browser-notifications';
 import { downloadSelector } from 'reducers/download';
 import { downloadURL } from 'actions/creators';
+import { DownloadExtraData } from 'actions/types';
 
 import descriptionToPath from 'utils/processDescription/descriptionToPath';
 import blockEvent from 'utils/block-event';
@@ -40,6 +41,7 @@ type Props = {
   minWidth?: number | string;
   label?: string;
   showIcon?: boolean;
+  extraData?: DownloadExtraData;
 };
 
 type State = {
@@ -100,6 +102,7 @@ export class File extends PureComponent<Props, State> {
       !!this.props.subset,
       this.props.endpoint,
       window.location.href,
+      this.props.extraData,
     );
   });
 

--- a/src/components/Matches/FileExporter/index.tsx
+++ b/src/components/Matches/FileExporter/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import File from 'components/File';
 import { SupportedExtensions } from 'components/File/FileButton';
 import { getNeededCountersForSubpages } from 'higherOrder/loadData/defaults/relatedCounters';
+import { DownloadExtraData } from 'actions/types';
 
 const endpoint: Partial<
   Record<Endpoint, Partial<Record<Endpoint, string | undefined>>>
@@ -31,6 +32,7 @@ type Props = {
   label?: string;
   focused?: string | null;
   className?: string;
+  extraData?: DownloadExtraData;
 };
 const FileExporter = ({
   description,
@@ -43,6 +45,7 @@ const FileExporter = ({
   label,
   focused = null,
   minWidth,
+  extraData,
 }: Props) => {
   if (!description?.main) return null;
   const customLocationDescription = {
@@ -81,6 +84,7 @@ const FileExporter = ({
       endpoint={(endpoint?.[primary]?.[secondary] as string) || primary}
       minWidth={minWidth}
       label={label}
+      extraData={extraData}
     />
   );
 };

--- a/src/components/Protein/Sequence/DownloadButton/index.tsx
+++ b/src/components/Protein/Sequence/DownloadButton/index.tsx
@@ -28,11 +28,8 @@ const DownloadButton = ({ accession, sequence }: Props) => {
         }),
       )}
     >
-      <span
-        className={css('icon', 'icon-common', 'icon-download')}
-        data-icon="&#xf019;"
-      />
-      &nbsp;Download sequence (FASTA)
+      <span className={css('icon', 'icon-common', 'icon-download-alt')} />
+      &nbsp; Download sequence (FASTA)
     </a>
   );
 };

--- a/src/components/Protein/Summary/__snapshots__/test.js.snap
+++ b/src/components/Protein/Summary/__snapshots__/test.js.snap
@@ -209,12 +209,7 @@ exports[`<SummaryProtein /> should render 1`] = `
                 },
               }
             }
-            extraData={
-              {
-                "extra_features": undefined,
-                "interpro_n": undefined,
-              }
-            }
+            extraData={{}}
             fileType="tsv"
             label="Download matches (TSV)"
             minWidth="200px"
@@ -289,6 +284,7 @@ exports[`<SummaryProtein /> should render 1`] = `
           },
         }
       }
+      onExtraDataLoaded={[Function]}
       onFamiliesFound={[Function]}
       onMatchesLoaded={[Function]}
     />

--- a/src/components/Protein/Summary/__snapshots__/test.js.snap
+++ b/src/components/Protein/Summary/__snapshots__/test.js.snap
@@ -188,11 +188,12 @@ exports[`<SummaryProtein /> should render 1`] = `
         <label
           style={
             {
-              "marginBottom": "0.4rem",
+              "marginBottom": "0.3rem",
             }
           }
         >
           <FileExporter
+            className="vf-button vf-button--secondary"
             count={13}
             description={
               {
@@ -208,16 +209,16 @@ exports[`<SummaryProtein /> should render 1`] = `
                 },
               }
             }
+            extraData={
+              {
+                "extra_features": undefined,
+                "interpro_n": undefined,
+              }
+            }
             fileType="tsv"
             label="Download matches (TSV)"
             minWidth="200px"
             primary="entry"
-            search={
-              {
-                "extra_features": "",
-                "interpro_n": "",
-              }
-            }
             secondary="protein"
           />
         </label>

--- a/src/components/Protein/Summary/__snapshots__/test.js.snap
+++ b/src/components/Protein/Summary/__snapshots__/test.js.snap
@@ -212,6 +212,12 @@ exports[`<SummaryProtein /> should render 1`] = `
             label="Download matches (TSV)"
             minWidth="200px"
             primary="entry"
+            search={
+              {
+                "extra_features": "",
+                "interpro_n": "",
+              }
+            }
             secondary="protein"
           />
         </label>

--- a/src/components/Protein/Summary/index.tsx
+++ b/src/components/Protein/Summary/index.tsx
@@ -11,7 +11,10 @@ import Link from 'components/generic/Link';
 import ProteinEntryHierarchy from 'components/Protein/ProteinEntryHierarchy';
 
 import { UniProtLink } from 'components/ExtLink/patternLinkWrapper';
-import DomainsOnProtein from 'components/Related/DomainsOnProtein';
+import DomainsOnProtein, {
+  getExtraURL,
+  getInterProNMatches,
+} from 'components/Related/DomainsOnProtein';
 
 import loadable from 'higherOrder/loadable';
 import {
@@ -40,7 +43,9 @@ import local from './style.css';
 import summary from 'styles/summary.css';
 import BaseLink from 'components/ExtLink/BaseLink';
 
-const css = cssBinder(summary, fonts, ipro, local);
+import buttonCSS from 'components/SimpleCommonComponents/Button/style.css';
+
+const css = cssBinder(summary, fonts, ipro, local, buttonCSS);
 
 const SchemaOrgData = loadable({
   loader: () => import(/* webpackChunkName: "schemaOrg" */ 'schema_org'),
@@ -77,9 +82,17 @@ type Props = {
   loading: boolean;
 };
 
-interface LoadedProps extends Props {}
+interface LoadedProps
+  extends Props,
+    LoadDataProps<ExtraFeaturesPayload, 'Features'>,
+    LoadDataProps<InterProNMatches, 'InterProNMatches'> {}
 
-export const SummaryProtein = ({ data, loading }: LoadedProps) => {
+export const SummaryProtein = ({
+  data,
+  loading,
+  dataFeatures,
+  dataInterProNMatches,
+}: LoadedProps) => {
   const comparisonContainerRef = useRef<HTMLElement | null>(null);
   const [matchesLoaded, setMatchesLoaded] = useState(false);
   const [families, setFamilies] = useState<Array<
@@ -275,9 +288,9 @@ export const SummaryProtein = ({ data, loading }: LoadedProps) => {
               title="Search sequence with InterProScan"
               minWidth={MIN_WIDTH}
             />
-            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label style={{ marginBottom: '0.4rem' }}>
+            <label style={{ marginBottom: '0.3rem' }}>
               <FileExporter
+                className={css('vf-button', 'vf-button--secondary')}
                 description={{
                   main: { key: 'protein' },
                   protein: {
@@ -286,7 +299,10 @@ export const SummaryProtein = ({ data, loading }: LoadedProps) => {
                   },
                   entry: { integration: 'all' },
                 }}
-                search={{ interpro_n: '', extra_features: '' }}
+                extraData={{
+                  interpro_n: dataInterProNMatches?.payload || undefined,
+                  extra_features: dataFeatures?.payload || undefined,
+                }}
                 count={metadata.counters!.entries as number}
                 fileType="tsv"
                 primary="entry"
@@ -295,6 +311,7 @@ export const SummaryProtein = ({ data, loading }: LoadedProps) => {
                 label="Download matches (TSV)"
               />
             </label>
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
             <DownloadButton
               sequence={metadata.sequence}
               accession={metadata.accession}
@@ -317,4 +334,12 @@ export const SummaryProtein = ({ data, loading }: LoadedProps) => {
   );
 };
 
-export default SummaryProtein;
+export default loadData<ExtraFeaturesPayload, 'Features'>({
+  getUrl: getExtraURL('extra_features'),
+  propNamespace: 'Features',
+} as LoadDataParameters)(
+  loadData<InterProNMatches, 'InterProNMatches'>({
+    getUrl: getInterProNMatches,
+    propNamespace: 'InterProNMatches',
+  } as LoadDataParameters)(SummaryProtein),
+);

--- a/src/components/Protein/Summary/index.tsx
+++ b/src/components/Protein/Summary/index.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { useEffect, useRef } from 'react';
 import { isEqual } from 'lodash-es';
 import { format } from 'url';
-import loadData from 'higherOrder/loadData/ts';
 import config from 'config';
+import { DownloadExtraData } from 'actions/types';
 import GoTerms from 'components/GoTerms';
 import Length from 'components/Protein/Length';
 import Species from 'components/Protein/Species';
@@ -11,10 +11,7 @@ import Link from 'components/generic/Link';
 import ProteinEntryHierarchy from 'components/Protein/ProteinEntryHierarchy';
 
 import { UniProtLink } from 'components/ExtLink/patternLinkWrapper';
-import DomainsOnProtein, {
-  getExtraURL,
-  getInterProNMatches,
-} from 'components/Related/DomainsOnProtein';
+import DomainsOnProtein from 'components/Related/DomainsOnProtein';
 
 import loadable from 'higherOrder/loadable';
 import {
@@ -82,19 +79,10 @@ type Props = {
   loading: boolean;
 };
 
-interface LoadedProps
-  extends Props,
-    LoadDataProps<ExtraFeaturesPayload, 'Features'>,
-    LoadDataProps<InterProNMatches, 'InterProNMatches'> {}
-
-export const SummaryProtein = ({
-  data,
-  loading,
-  dataFeatures,
-  dataInterProNMatches,
-}: LoadedProps) => {
+export const SummaryProtein = ({ data, loading }: Props) => {
   const comparisonContainerRef = useRef<HTMLElement | null>(null);
   const [matchesLoaded, setMatchesLoaded] = useState(false);
+  const [extraData, setExtraData] = useState<DownloadExtraData>({});
   const [families, setFamilies] = useState<Array<
     Record<string, unknown>
   > | null>(null);
@@ -102,6 +90,12 @@ export const SummaryProtein = ({
 
   if (loading || !data || !data.metadata) return <Loading />;
   const metadata = data.metadata;
+
+  // Handle count and download for proteins with no matches, but with InterPro-N matches or extra features (only for TSV)
+  const downloadableCount =
+    (metadata.counters!.entries as number) +
+    Object.keys(extraData.interpro_n || {}).length +
+    Object.keys(extraData.extra_features || {}).length;
 
   const getSubfamiliesFromMatches = (
     results: EndpointWithMatchesPayload<EntryMetadata, MatchI>[],
@@ -288,6 +282,7 @@ export const SummaryProtein = ({
               title="Search sequence with InterProScan"
               minWidth={MIN_WIDTH}
             />
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
             <label style={{ marginBottom: '0.3rem' }}>
               <FileExporter
                 className={css('vf-button', 'vf-button--secondary')}
@@ -299,11 +294,8 @@ export const SummaryProtein = ({
                   },
                   entry: { integration: 'all' },
                 }}
-                extraData={{
-                  interpro_n: dataInterProNMatches?.payload || undefined,
-                  extra_features: dataFeatures?.payload || undefined,
-                }}
-                count={metadata.counters!.entries as number}
+                extraData={extraData}
+                count={downloadableCount}
                 fileType="tsv"
                 primary="entry"
                 secondary="protein"
@@ -311,7 +303,6 @@ export const SummaryProtein = ({
                 label="Download matches (TSV)"
               />
             </label>
-            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
             <DownloadButton
               sequence={metadata.sequence}
               accession={metadata.accession}
@@ -324,6 +315,7 @@ export const SummaryProtein = ({
           mainData={data}
           onMatchesLoaded={getSubfamiliesFromMatches}
           onFamiliesFound={handleInterProFamilies}
+          onExtraDataLoaded={setExtraData}
         />
       </section>
       {metadata.go_terms && (
@@ -334,12 +326,4 @@ export const SummaryProtein = ({
   );
 };
 
-export default loadData<ExtraFeaturesPayload, 'Features'>({
-  getUrl: getExtraURL('extra_features'),
-  propNamespace: 'Features',
-} as LoadDataParameters)(
-  loadData<InterProNMatches, 'InterProNMatches'>({
-    getUrl: getInterProNMatches,
-    propNamespace: 'InterProNMatches',
-  } as LoadDataParameters)(SummaryProtein),
-);
+export default SummaryProtein;

--- a/src/components/Protein/Summary/index.tsx
+++ b/src/components/Protein/Summary/index.tsx
@@ -286,6 +286,7 @@ export const SummaryProtein = ({ data, loading }: LoadedProps) => {
                   },
                   entry: { integration: 'all' },
                 }}
+                search={{ interpro_n: '', extra_features: '' }}
                 count={metadata.counters!.entries as number}
                 fileType="tsv"
                 primary="entry"

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -274,7 +274,7 @@ const getRelatedEntriesURL = createSelector(
   },
 );
 
-const getExtraURL = (query: string) =>
+export const getExtraURL = (query: string) =>
   createSelector(
     (state: GlobalState) => state.settings.api,
     (state: GlobalState) => state.customLocation.description,
@@ -325,7 +325,7 @@ const getPTMPayload = createSelector(
   },
 );
 
-const getInterProNMatches = createSelector(
+export const getInterProNMatches = createSelector(
   (state: GlobalState) => state.settings.api,
   (state: GlobalState) => state.customLocation.description.protein.accession,
   (

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -24,6 +24,7 @@ import { ProteinsAPIVariation } from '@nightingale-elements/nightingale-variatio
 import { proteinViewerReorganization } from './utils';
 import { connect } from 'react-redux';
 import { changeSettingsRaw } from 'actions/creators';
+import { DownloadExtraData } from 'actions/types';
 
 type Props = PropsWithChildren<{
   mainData: {
@@ -35,6 +36,7 @@ type Props = PropsWithChildren<{
     results: EndpointWithMatchesPayload<EntryMetadata, MatchI>[],
   ) => void;
   onFamiliesFound?: (families: Record<string, unknown>[]) => void;
+  onExtraDataLoaded?: (extraData: DownloadExtraData) => void;
   title?: string;
   matchTypeSettings: MatchTypeUISettings;
   colorDomainsBy: string;
@@ -74,6 +76,7 @@ const DomainOnProteinWithoutData = ({
   dataInterProNMatches,
   onMatchesLoaded,
   onFamiliesFound,
+  onExtraDataLoaded,
   children,
   externalSourcesData,
   title,
@@ -119,6 +122,18 @@ const DomainOnProteinWithoutData = ({
       }
     }
   }, [data, processData]);
+
+  useEffect(() => {
+    if (dataFeatures?.loading || dataInterProNMatches?.loading) return;
+    onExtraDataLoaded?.({
+      interpro_n: dataInterProNMatches?.payload || undefined,
+      extra_features: dataFeatures?.payload || undefined,
+      protein: {
+        accession: mainData.metadata.accession,
+        length: mainData.metadata.length,
+      },
+    });
+  }, [dataFeatures, dataInterProNMatches, mainData]);
 
   if (data?.loading && dataFeatures?.loading) return <Loading />;
   const payload = data?.payload as PayloadList<

--- a/src/components/Related/DomainsOnProtein/index.tsx
+++ b/src/components/Related/DomainsOnProtein/index.tsx
@@ -289,7 +289,7 @@ const getRelatedEntriesURL = createSelector(
   },
 );
 
-export const getExtraURL = (query: string) =>
+const getExtraURL = (query: string) =>
   createSelector(
     (state: GlobalState) => state.settings.api,
     (state: GlobalState) => state.customLocation.description,
@@ -340,7 +340,7 @@ const getPTMPayload = createSelector(
   },
 );
 
-export const getInterProNMatches = createSelector(
+const getInterProNMatches = createSelector(
   (state: GlobalState) => state.settings.api,
   (state: GlobalState) => state.customLocation.description.protein.accession,
   (

--- a/src/web-workers/download/index.worker.js
+++ b/src/web-workers/download/index.worker.js
@@ -203,7 +203,7 @@ const downloadContent =
 
       const key = [url, fileType, subset].filter(Boolean).join('|');
       // Counters for progress information
-      let totalCount;
+      let totalCount = 0;
       let i = 0;
       // Create a function to transform API response into processed file part
       const processResults = processResultsFor(fileType, subset, endpoint);

--- a/src/web-workers/download/index.worker.js
+++ b/src/web-workers/download/index.worker.js
@@ -31,6 +31,7 @@ const MAX_EBI_PAGE_SIZE = 100;
 // Time to wait before retrying to get results from API when we have a problem
 const DELAY_WHEN_SOME_KIND_OF_PROBLEM = 60000; // 1 minute
 const REQUEST_TIMEOUT = 408;
+const NO_CONTENT = 204;
 const MAX_ERROR_COUNT_FOR_ONE_REQUEST = 3;
 const THROTTLE_TIME = 500; // half a second
 
@@ -236,6 +237,14 @@ const downloadContent =
             // …wait a bit…
             await sleep(DELAY_WHEN_SOME_KIND_OF_PROBLEM);
             // …then restart the loop with at the same URL
+            continue;
+          }
+          // No content: this page has no results (e.g. a protein with no
+          // standard matches), so there's nothing to parse as JSON.
+          if (response.status === NO_CONTENT) {
+            next = null;
+            errorCount = 0;
+            totalCount = extraRows.length;
             continue;
           }
           const payload = await response.json();

--- a/src/web-workers/download/index.worker.js
+++ b/src/web-workers/download/index.worker.js
@@ -5,7 +5,12 @@ import { throttle } from 'lodash-es';
 import { sleep } from 'timing-functions';
 
 import getTableAccess, { DownloadJobs } from 'storage/idb';
-import { object2TSV, columns } from './object2TSV';
+import {
+  object2TSV,
+  columns,
+  interProNMatchesToRows,
+  extraFeaturesToRows,
+} from './object2TSV';
 
 // $FlowFixMe
 import { DOWNLOAD_URL, DOWNLOAD_DELETE } from 'actions/types';
@@ -207,6 +212,10 @@ const downloadContent =
       let next = format(firstPage);
       let errorCount = 0;
       let version = null;
+      // The interpro_n and extra_features extensions are returned on every page when requested,
+      // but they are the same for all pages, so we don't want to process them on every page
+      let interProNHandled = false;
+      let extraFeaturesHandled = false;
       while (next) {
         try {
           const response = await fetch(next);
@@ -228,6 +237,42 @@ const downloadContent =
             // use `totalCount + 1` to not finish at exactly 1 to account for the
             // time needed to create the blob
             onProgress({ part, progress: ++i / (totalCount + 1) });
+          }
+          // Append the InterPro-N matches and the extra features rows (only for the TSV), reusing the
+          // same columns as the standard matches and flagging them via the db
+          // column.
+          if (fileType === 'tsv' && !interProNHandled && payload.interpro_n) {
+            interProNHandled = true;
+            const firstProtein = payload.results?.[0]?.proteins?.[0];
+            const interProNRows = interProNMatchesToRows(
+              payload.interpro_n,
+              firstProtein?.accession,
+              firstProtein?.protein_length,
+            );
+            for (const part of processResults(interProNRows)) {
+              // eslint-disable-next-line
+              if (canceled.has(key)) return;
+              onProgress({ part, progress: ++i / (totalCount + 1) });
+            }
+          }
+
+          if (
+            fileType === 'tsv' &&
+            !extraFeaturesHandled &&
+            payload.extra_features
+          ) {
+            extraFeaturesHandled = true;
+            const firstProtein = payload.results?.[0]?.proteins?.[0];
+            const extraFeatureRows = extraFeaturesToRows(
+              payload.extra_features,
+              firstProtein?.accession,
+              firstProtein?.protein_length,
+            );
+            for (const part of processResults(extraFeatureRows)) {
+              // eslint-disable-next-line
+              if (canceled.has(key)) return;
+              onProgress({ part, progress: ++i / (totalCount + 1) });
+            }
           }
           // If it's the last page, it will be null, so we exit the loop
           next = payload.next;

--- a/src/web-workers/download/index.worker.js
+++ b/src/web-workers/download/index.worker.js
@@ -232,6 +232,11 @@ const downloadContent =
       while (next) {
         try {
           const response = await fetch(next);
+
+          // Avoid reassigning version if it was already set by a previous page/retry on timeout
+          if (version == null)
+            version = response.headers.get('InterPro-Version');
+
           // If the server sent a timeout response…
           if (response.status === REQUEST_TIMEOUT) {
             // …wait a bit…
@@ -248,7 +253,6 @@ const downloadContent =
             continue;
           }
           const payload = await response.json();
-          version = response.headers.get('InterPro-Version');
           mutatePayloadTo3rdPartyAPI(payload, endpoint, firstPage);
           totalCount = payload.count + extraRows.length;
           for (const part of processResults(payload.results)) {

--- a/src/web-workers/download/index.worker.js
+++ b/src/web-workers/download/index.worker.js
@@ -188,7 +188,7 @@ const mutatePayloadTo3rdPartyAPI = (payload, endpoint, page) => {
 };
 // the `_` is just to make flow happy
 const downloadContent =
-  (onProgress, onSuccess, onError) =>
+  (onProgress, onSuccess, onError, extraData = {}) =>
   // eslint-disable-next-line max-statements
   async (url, fileType, subset, endpoint, _) => {
     try {
@@ -212,10 +212,8 @@ const downloadContent =
       let next = format(firstPage);
       let errorCount = 0;
       let version = null;
-      // The interpro_n and extra_features extensions are returned on every page when requested,
-      // but they are the same for all pages, so we don't want to process them on every page
-      let interProNHandled = false;
-      let extraFeaturesHandled = false;
+      // The protein the extra rows are attached to, taken from the first page
+      let firstProtein = null;
       while (next) {
         try {
           const response = await fetch(next);
@@ -230,6 +228,7 @@ const downloadContent =
           version = response.headers.get('InterPro-Version');
           mutatePayloadTo3rdPartyAPI(payload, endpoint, firstPage);
           totalCount = payload.count;
+          if (!firstProtein) firstProtein = payload.results?.[0]?.proteins?.[0];
           for (const part of processResults(payload.results)) {
             // Check if it was canceled, if so, stop everything and return
             // eslint-disable-next-line
@@ -237,42 +236,6 @@ const downloadContent =
             // use `totalCount + 1` to not finish at exactly 1 to account for the
             // time needed to create the blob
             onProgress({ part, progress: ++i / (totalCount + 1) });
-          }
-          // Append the InterPro-N matches and the extra features rows (only for the TSV), reusing the
-          // same columns as the standard matches and flagging them via the db
-          // column.
-          if (fileType === 'tsv' && !interProNHandled && payload.interpro_n) {
-            interProNHandled = true;
-            const firstProtein = payload.results?.[0]?.proteins?.[0];
-            const interProNRows = interProNMatchesToRows(
-              payload.interpro_n,
-              firstProtein?.accession,
-              firstProtein?.protein_length,
-            );
-            for (const part of processResults(interProNRows)) {
-              // eslint-disable-next-line
-              if (canceled.has(key)) return;
-              onProgress({ part, progress: ++i / (totalCount + 1) });
-            }
-          }
-
-          if (
-            fileType === 'tsv' &&
-            !extraFeaturesHandled &&
-            payload.extra_features
-          ) {
-            extraFeaturesHandled = true;
-            const firstProtein = payload.results?.[0]?.proteins?.[0];
-            const extraFeatureRows = extraFeaturesToRows(
-              payload.extra_features,
-              firstProtein?.accession,
-              firstProtein?.protein_length,
-            );
-            for (const part of processResults(extraFeatureRows)) {
-              // eslint-disable-next-line
-              if (canceled.has(key)) return;
-              onProgress({ part, progress: ++i / (totalCount + 1) });
-            }
           }
           // If it's the last page, it will be null, so we exit the loop
           next = payload.next;
@@ -288,6 +251,27 @@ const downloadContent =
           }
         }
       }
+      // Append the InterPro-N matches and the extra features rows (only for the
+      // TSV), reusing the same columns as the standard matches and flagging them
+      // via the db column. They come from the responses already cached by the page.
+      if (fileType === 'tsv') {
+        const extraRows = [
+          ...interProNMatchesToRows(
+            extraData.interpro_n,
+            firstProtein?.accession,
+            firstProtein?.protein_length,
+          ),
+          ...extraFeaturesToRows(
+            extraData.extra_features,
+            firstProtein?.accession,
+            firstProtein?.protein_length,
+          ),
+        ];
+        for (const part of processResults(extraRows)) {
+          if (canceled.has(key)) return;
+          onProgress({ part, progress: ++i / (totalCount + 1) });
+        }
+      }
       onSuccess({ key, version: Number(version) });
     } catch (error) {
       onError(error);
@@ -300,7 +284,14 @@ const postProgress = throttle(
 );
 
 // Download manager, send messages from there
-const download = async (url, fileType, subset, endpoint, originURL) => {
+const download = async (
+  url,
+  fileType,
+  subset,
+  endpoint,
+  originURL,
+  extraData,
+) => {
   const action = createActionCallerFor(url, fileType, subset, endpoint);
   const onError = (error) => {
     postProgress(action(downloadProgress, 1));
@@ -338,6 +329,7 @@ const download = async (url, fileType, subset, endpoint, originURL) => {
           self.postMessage(action(downloadSuccess, newDownload));
         },
         onError,
+        extraData,
       ),
     );
   } catch (error) {
@@ -354,6 +346,7 @@ const main = ({ data }) => {
         data.subset,
         data.endpoint,
         data.originURL,
+        data.extraData,
       );
       break;
     case DOWNLOAD_DELETE:

--- a/src/web-workers/download/index.worker.js
+++ b/src/web-workers/download/index.worker.js
@@ -201,6 +201,22 @@ const downloadContent =
         });
       }
 
+      const extraRows =
+        fileType === 'tsv'
+          ? [
+              ...interProNMatchesToRows(
+                extraData.interpro_n,
+                extraData.protein?.accession,
+                extraData.protein?.length,
+              ),
+              ...extraFeaturesToRows(
+                extraData.extra_features,
+                extraData.protein?.accession,
+                extraData.protein?.length,
+              ),
+            ]
+          : [];
+
       const key = [url, fileType, subset].filter(Boolean).join('|');
       // Counters for progress information
       let totalCount = 0;
@@ -212,8 +228,6 @@ const downloadContent =
       let next = format(firstPage);
       let errorCount = 0;
       let version = null;
-      // The protein the extra rows are attached to, taken from the first page
-      let firstProtein = null;
       while (next) {
         try {
           const response = await fetch(next);
@@ -227,8 +241,7 @@ const downloadContent =
           const payload = await response.json();
           version = response.headers.get('InterPro-Version');
           mutatePayloadTo3rdPartyAPI(payload, endpoint, firstPage);
-          totalCount = payload.count;
-          if (!firstProtein) firstProtein = payload.results?.[0]?.proteins?.[0];
+          totalCount = payload.count + extraRows.length;
           for (const part of processResults(payload.results)) {
             // Check if it was canceled, if so, stop everything and return
             // eslint-disable-next-line
@@ -251,26 +264,9 @@ const downloadContent =
           }
         }
       }
-      // Append the InterPro-N matches and the extra features rows (only for the
-      // TSV), reusing the same columns as the standard matches and flagging them
-      // via the db column. They come from the responses already cached by the page.
-      if (fileType === 'tsv') {
-        const extraRows = [
-          ...interProNMatchesToRows(
-            extraData.interpro_n,
-            firstProtein?.accession,
-            firstProtein?.protein_length,
-          ),
-          ...extraFeaturesToRows(
-            extraData.extra_features,
-            firstProtein?.accession,
-            firstProtein?.protein_length,
-          ),
-        ];
-        for (const part of processResults(extraRows)) {
-          if (canceled.has(key)) return;
-          onProgress({ part, progress: ++i / (totalCount + 1) });
-        }
+      for (const part of processResults(extraRows)) {
+        if (canceled.has(key)) return;
+        onProgress({ part, progress: ++i / (totalCount + 1) });
       }
       onSuccess({ key, version: Number(version) });
     } catch (error) {

--- a/src/web-workers/download/object2TSV.js
+++ b/src/web-workers/download/object2TSV.js
@@ -296,6 +296,57 @@ columns.entryProtein = [
   },
 ];
 
+// Map interpro_n matches to rows in the entryProtein results' format
+export const interProNMatchesToRows = (
+  interproN /*: ?Object */,
+  proteinAccession /*: ?string */,
+  proteinLength /*: ?number */,
+) => {
+  if (!interproN) return [];
+  return Object.values(interproN).map((match /*: Object */) => ({
+    metadata: {
+      accession: match.accession,
+      name: match.name,
+      source_database: 'interpro-n',
+      type: match.type,
+      integrated:
+        match.integrated && typeof match.integrated === 'object'
+          ? match.integrated.accession
+          : match.integrated || null,
+    },
+    extra_fields: { short_name: match.short_name },
+    proteins: [
+      {
+        accession: proteinAccession,
+        protein_length: proteinLength,
+        entry_protein_locations: match.entry_protein_locations,
+      },
+    ],
+  }));
+};
+
+// Map extra features to rows in the entryProtein results' format
+export const extraFeaturesToRows = (
+  extraFeatures /*: ?Object */,
+  proteinAccession /*: ?string */,
+  proteinLength /*: ?number */,
+) => {
+  if (!extraFeatures) return [];
+  return Object.values(extraFeatures).map((feature /*: Object */) => ({
+    metadata: {
+      accession: feature.accession,
+      source_database: feature.source_database,
+    },
+    proteins: [
+      {
+        accession: proteinAccession,
+        protein_length: proteinLength,
+        entry_protein_locations: feature.locations,
+      },
+    ],
+  }));
+};
+
 export const object2TSV = (
   object /*: Object */,
   selectors /*: Array<{selector: string, serializer?: function}> */,


### PR DESCRIPTION
Addresses [IBU-12544](https://embl.atlassian.net/browse/IBU-12544).

- Upon requesting the generation of the .tsv, the already cached extra data (intepro_n and extra_features are requested on load) gets fetched;
- The fetched data gets processed by the already existing .tsv processing functions, using the same columns we had before (we use the db column to identity InterPro-N matches); 
- Sligthly improved UI style for the three (search, download fasta, download file) buttons.
 

