### PR TITLE
Restore representative structure images

### DIFF
--- a/src/components/Entry/Summary/SidePanel/RepresentativeStructure/index.tsx
+++ b/src/components/Entry/Summary/SidePanel/RepresentativeStructure/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import LazyImage from 'components/LazyImage';
+import StructureImage from 'components/Structure/StructureImage';
 import Link from 'components/generic/Link';
 
 import cssBinder from 'styles/cssBinder';
@@ -8,8 +8,6 @@ import cssBinder from 'styles/cssBinder';
 import local from '../style.css';
 
 const css = cssBinder(local);
-
-const PDBE_IMAGES = 'https://www.ebi.ac.uk/pdbe/static/entry';
 
 const RepresentativeStructure = ({
   accession,
@@ -37,24 +35,24 @@ const RepresentativeStructure = ({
         >
           <div className={css('structure-images')}>
             {!hiddenImages.front && (
-              <LazyImage
-                src={`${PDBE_IMAGES}/${accession}_assembly_1_chain_front_image-200x200.png`}
-                alt={`structure with accession ${accession}, front view`}
+              <StructureImage
+                pdbId={accession}
+                view="front"
                 onError={hideImage('front')}
               />
             )}
             <div className={css('structure-images-side')}>
               {!hiddenImages.side && (
-                <LazyImage
-                  src={`${PDBE_IMAGES}/${accession}_assembly_1_chain_side_image-100x100.png`}
-                  alt={`structure with accession ${accession}, side view`}
+                <StructureImage
+                  pdbId={accession}
+                  view="side"
                   onError={hideImage('side')}
                 />
               )}
               {!hiddenImages.top && (
-                <LazyImage
-                  src={`${PDBE_IMAGES}/${accession}_assembly_1_chain_top_image-100x100.png`}
-                  alt={`structure with accession ${accession}, top view`}
+                <StructureImage
+                  pdbId={accession}
+                  view="top"
                   onError={hideImage('top')}
                 />
               )}

--- a/src/components/Entry/Summary/SidePanel/RepresentativeStructure/index.tsx
+++ b/src/components/Entry/Summary/SidePanel/RepresentativeStructure/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import LazyImage from 'components/LazyImage';
 import Link from 'components/generic/Link';
@@ -9,6 +9,8 @@ import local from '../style.css';
 
 const css = cssBinder(local);
 
+const PDBE_IMAGES = 'https://www.ebi.ac.uk/pdbe/static/entry';
+
 const RepresentativeStructure = ({
   accession,
   name,
@@ -16,6 +18,10 @@ const RepresentativeStructure = ({
   accession: string;
   name: string;
 }) => {
+  const [hiddenImages, setHiddenImages] = useState<Record<string, boolean>>({});
+  const hideImage = (view: string) => () =>
+    setHiddenImages((previous) => ({ ...previous, [view]: true }));
+
   return (
     <div className={css('side-panel')}>
       <div className={css('side-box')}>
@@ -29,17 +35,30 @@ const RepresentativeStructure = ({
             },
           }}
         >
-          <div
-            style={{
-              width: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-            }}
-          >
-            <LazyImage
-              src={`//www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/getimg.pl?source=pdbsum&pdb_code=${accession}&file=traces.jpg`}
-              alt={`structure with accession ${accession}`}
-            />
+          <div className={css('structure-images')}>
+            {!hiddenImages.front && (
+              <LazyImage
+                src={`${PDBE_IMAGES}/${accession}_assembly_1_chain_front_image-200x200.png`}
+                alt={`structure with accession ${accession}, front view`}
+                onError={hideImage('front')}
+              />
+            )}
+            <div className={css('structure-images-side')}>
+              {!hiddenImages.side && (
+                <LazyImage
+                  src={`${PDBE_IMAGES}/${accession}_assembly_1_chain_side_image-100x100.png`}
+                  alt={`structure with accession ${accession}, side view`}
+                  onError={hideImage('side')}
+                />
+              )}
+              {!hiddenImages.top && (
+                <LazyImage
+                  src={`${PDBE_IMAGES}/${accession}_assembly_1_chain_top_image-100x100.png`}
+                  alt={`structure with accession ${accession}, top view`}
+                  onError={hideImage('top')}
+                />
+              )}
+            </div>
           </div>
 
           <div>

--- a/src/components/Entry/Summary/SidePanel/style.css
+++ b/src/components/Entry/Summary/SidePanel/style.css
@@ -6,3 +6,16 @@ div.flex-space-evenly {
   display: flex;
   justify-content: space-evenly;
 }
+
+.structure-images {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+.structure-images-side {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/src/components/Matches/index.tsx
+++ b/src/components/Matches/index.tsx
@@ -539,7 +539,7 @@ const Matches = ({
             })}
           >
             <LazyImage
-              src={`//www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/getimg.pl?source=pdbsum&pdb_code=${accession}&file=traces.jpg`}
+              src={`https://www.ebi.ac.uk/pdbe/static/entry/${accession}_assembly_1_chain_front_image-200x200.png`}
               alt={`structure with accession ${accession}`}
             />
           </Link>

--- a/src/components/Matches/index.tsx
+++ b/src/components/Matches/index.tsx
@@ -22,7 +22,7 @@ import Table, {
 import HighlightedText from 'components/SimpleCommonComponents/HighlightedText';
 import NumberComponent from 'components/NumberComponent';
 import ExternalExportButton from 'components/Table/Exporter/ExternalExportButton';
-import LazyImage from 'components/LazyImage';
+import StructureImage from 'components/Structure/StructureImage';
 import Lazy from 'wrappers/Lazy';
 import loadWebComponent from 'utils/load-web-component';
 import { toPublicAPI } from 'utils/url';
@@ -538,8 +538,8 @@ const Matches = ({
               search: {},
             })}
           >
-            <LazyImage
-              src={`https://www.ebi.ac.uk/pdbe/static/entry/${accession}_assembly_1_chain_front_image-200x200.png`}
+            <StructureImage
+              pdbId={accession}
               alt={`structure with accession ${accession}`}
             />
           </Link>

--- a/src/components/Structure/Card/index.tsx
+++ b/src/components/Structure/Card/index.tsx
@@ -4,7 +4,7 @@ import Link from 'components/generic/Link';
 import Card from 'components/SimpleCommonComponents/Card';
 import HighlightedText from 'components/SimpleCommonComponents/HighlightedText';
 import Tooltip from 'components/SimpleCommonComponents/Tooltip';
-import LazyImage from 'components/LazyImage';
+import StructureImage from 'components/Structure/StructureImage';
 import SummaryCounterStructures from '../SummaryCounterStructures';
 import TaxnameStructures from './TaxnameStructures';
 import Lazy from 'wrappers/Lazy';
@@ -42,8 +42,8 @@ const StructureCard = ({ data, search, entryDB }: Props) => {
       }
       imageComponent={
         <Tooltip title={`3D visualisation of ${data.metadata.accession}`}>
-          <LazyImage
-            src={`https://www.ebi.ac.uk/pdbe/static/entry/${data.metadata.accession}_assembly_1_chain_front_image-200x200.png`}
+          <StructureImage
+            pdbId={data.metadata.accession}
             alt={`PDBe entry ${data.metadata.accession}`}
           />
         </Tooltip>

--- a/src/components/Structure/Card/index.tsx
+++ b/src/components/Structure/Card/index.tsx
@@ -43,7 +43,7 @@ const StructureCard = ({ data, search, entryDB }: Props) => {
       imageComponent={
         <Tooltip title={`3D visualisation of ${data.metadata.accession}`}>
           <LazyImage
-            src={`//www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/getimg.pl?source=pdbsum&pdb_code=${data.metadata.accession}&file=traces.jpg`}
+            src={`https://www.ebi.ac.uk/pdbe/static/entry/${data.metadata.accession}_assembly_1_chain_front_image-200x200.png`}
             alt={`PDBe entry ${data.metadata.accession}`}
           />
         </Tooltip>

--- a/src/components/Structure/StructureImage/index.tsx
+++ b/src/components/Structure/StructureImage/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import LazyImage from 'components/LazyImage';
+
+const PDBE_IMAGES = 'https://www.ebi.ac.uk/pdbe/static/entry';
+
+const SIZES = {
+  front: 200,
+  side: 100,
+  top: 100,
+} as const;
+
+export type StructureImageView = keyof typeof SIZES;
+
+type Props = {
+  pdbId: string;
+  view?: StructureImageView;
+  alt?: string;
+} & Omit<React.ComponentProps<'img'>, 'src' | 'alt' | 'ref'>;
+
+const StructureImage = ({ pdbId, view = 'front', alt, ...props }: Props) => {
+  const size = SIZES[view];
+  return (
+    <LazyImage
+      src={`${PDBE_IMAGES}/${pdbId}_assembly_1_chain_${view}_image-${size}x${size}.png`}
+      alt={alt ?? `structure with accession ${pdbId}, ${view} view`}
+      {...props}
+    />
+  );
+};
+
+export default StructureImage;

--- a/src/components/Structure/Summary/__snapshots__/test.js.snap
+++ b/src/components/Structure/Summary/__snapshots__/test.js.snap
@@ -124,16 +124,6 @@ exports[`<SummaryStructure /> should render 1`] = `
             <BaseLink
               className="ext"
               id="102m"
-              pattern="http://www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/GetPage.pl?pdbcode={id}"
-              target="_blank"
-            >
-              PDBsum
-            </BaseLink>
-          </li>
-          <li>
-            <BaseLink
-              className="ext"
-              id="102m"
               pattern="https://www.cathdb.info/pdb/{id}"
               target="_blank"
             >

--- a/src/components/Structure/Summary/index.tsx
+++ b/src/components/Structure/Summary/index.tsx
@@ -25,11 +25,6 @@ const css = cssBinder(summary, ipro);
 const EXTERNAL_LINKS = [
   { pattern: 'https://www.ebi.ac.uk/pdbe/entry/pdb/{id}', label: 'PDBe' },
   { pattern: 'https://www.rcsb.org/structure/{id}', label: 'RCSB PDB' },
-  {
-    pattern:
-      'http://www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/GetPage.pl?pdbcode={id}',
-    label: 'PDBsum',
-  },
   { pattern: 'https://www.cathdb.info/pdb/{id}', label: 'CATH' },
   {
     pattern: 'https://www.ebi.ac.uk/pdbe/scop/search?t=txt;q={id}',

--- a/src/components/Structure/ViewerOnDemand/__snapshots__/test.js.snap
+++ b/src/components/Structure/ViewerOnDemand/__snapshots__/test.js.snap
@@ -11,9 +11,9 @@ exports[`<ViewerOnDemand /> should render 1`] = `
     <div
       className="background"
     >
-      <LazyImage
+      <StructureImage
         alt="structure with accession 102m"
-        src="https://www.ebi.ac.uk/pdbe/static/entry/102m_assembly_1_chain_front_image-200x200.png"
+        pdbId="102m"
       />
     </div>
     <div

--- a/src/components/Structure/ViewerOnDemand/__snapshots__/test.js.snap
+++ b/src/components/Structure/ViewerOnDemand/__snapshots__/test.js.snap
@@ -13,7 +13,7 @@ exports[`<ViewerOnDemand /> should render 1`] = `
     >
       <LazyImage
         alt="structure with accession 102m"
-        src="//www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/getimg.pl?source=pdbsum&pdb_code=102m&file=traces.jpg"
+        src="https://www.ebi.ac.uk/pdbe/static/entry/102m_assembly_1_chain_front_image-200x200.png"
       />
     </div>
     <div

--- a/src/components/Structure/ViewerOnDemand/index.tsx
+++ b/src/components/Structure/ViewerOnDemand/index.tsx
@@ -56,7 +56,7 @@ export const ViewerOnDemand = (props: Props) => {
       <button className={styles['inner-wrapper']} onClick={handleClick}>
         <div className={styles.background}>
           <LazyImage
-            src={`//www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/getimg.pl?source=pdbsum&pdb_code=${id}&file=traces.jpg`}
+            src={`https://www.ebi.ac.uk/pdbe/static/entry/${id}_assembly_1_chain_front_image-200x200.png`}
             alt={`structure with accession ${id}`}
           />
         </div>
@@ -92,7 +92,7 @@ const mapStateToProps = createSelector(
   (state: GlobalState) => state.settings.ui.structureViewer,
   (userActivatedVisible) => ({
     userActivatedVisible: userActivatedVisible || false,
-  })
+  }),
 );
 
 export default connect(mapStateToProps, { changeSettingsRaw }, null, {

--- a/src/components/Structure/ViewerOnDemand/index.tsx
+++ b/src/components/Structure/ViewerOnDemand/index.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import Link from 'components/generic/Link';
-import LazyImage from 'components/LazyImage';
+import StructureImage from 'components/Structure/StructureImage';
 
 import loadable from 'higherOrder/loadable';
 
@@ -55,10 +55,7 @@ export const ViewerOnDemand = (props: Props) => {
     <div className={styles.wrapper}>
       <button className={styles['inner-wrapper']} onClick={handleClick}>
         <div className={styles.background}>
-          <LazyImage
-            src={`https://www.ebi.ac.uk/pdbe/static/entry/${id}_assembly_1_chain_front_image-200x200.png`}
-            alt={`structure with accession ${id}`}
-          />
+          <StructureImage pdbId={id} alt={`structure with accession ${id}`} />
         </div>
         <div className={styles.text}>
           <p>

--- a/src/pages/Structure/index.tsx
+++ b/src/pages/Structure/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Link from 'components/generic/Link';
 
 import MemberDBSelector from 'components/MemberDBSelector';
-import LazyImage from 'components/LazyImage';
+import StructureImage from 'components/Structure/StructureImage';
 
 import StructureListFilters from 'components/Structure/StructureListFilters';
 
@@ -350,8 +350,8 @@ const List = ({ data, customLocation, isStale, dataBase }: LoadedProps) => {
                   search: {},
                 })}
               >
-                <LazyImage
-                  src={`https://www.ebi.ac.uk/pdbe/static/entry/${accession}_assembly_1_chain_front_image-200x200.png`}
+                <StructureImage
+                  pdbId={accession as string}
                   alt={`structure with accession ${accession}`}
                   style={{ maxWidth: '33%' }}
                 />

--- a/src/pages/Structure/index.tsx
+++ b/src/pages/Structure/index.tsx
@@ -351,7 +351,7 @@ const List = ({ data, customLocation, isStale, dataBase }: LoadedProps) => {
                 })}
               >
                 <LazyImage
-                  src={`//www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/getimg.pl?source=pdbsum&pdb_code=${accession}&file=traces.jpg`}
+                  src={`https://www.ebi.ac.uk/pdbe/static/entry/${accession}_assembly_1_chain_front_image-200x200.png`}
                   alt={`structure with accession ${accession}`}
                   style={{ maxWidth: '33%' }}
                 />

--- a/stories/BasicUI/Card.stories.tsx
+++ b/stories/BasicUI/Card.stories.tsx
@@ -76,19 +76,6 @@ export const WithImageIconClass: CardStory = {
   },
 };
 
-export const WithImage: CardStory = {
-  args: {
-    title: 'The Card',
-    imageComponent: (
-      <LazyImage
-        src={`//www.ebi.ac.uk/thornton-srv/databases/cgi-bin/pdbsum/getimg.pl?source=pdbsum&pdb_code=1cuk&file=traces.jpg`}
-        alt={`structure with accession 1cuk`}
-      />
-    ),
-    children: 'A message to show',
-  },
-};
-
 export const WithSpeciesIcon: CardStory = {
   args: {
     title: 'The Card',


### PR DESCRIPTION
Addresses [IBU-12570](https://embl.atlassian.net/browse/IBU-12570).

- We now show the three structure pictures on the entry page in the "Representative structure" section;
- There were other pages (structure browse, structure matches) on InterPro that were using PDBSum. They're now fetching the structure from PDBe (single image) as well.
- Removed all the links and references to PDBSum;
